### PR TITLE
feat: gate live readiness on usable collateral

### DIFF
--- a/packages/runtime/src/carryme_runtime/readiness.py
+++ b/packages/runtime/src/carryme_runtime/readiness.py
@@ -5,6 +5,7 @@ from carryme_models import (
     PaperTradeAccountPreflight,
     PaperTradeExecutionPreflight,
     PreviewConfirmationEntry,
+    VenueAccountPreflight,
 )
 
 from carryme_runtime.confirmation import require_confirmed_preview
@@ -76,6 +77,11 @@ def _build_zero_collateral_blockers(
             continue
         usable_collateral = _usable_collateral(venue_status)
         if usable_collateral is None:
+            if venue_status.ready or venue_status.authenticated:
+                blockers.append(
+                    f"Venue {venue_status.venue} is missing collateral data for the "
+                    f"confirmed {preview_leg.target_notional:.2f} notional preview"
+                )
             continue
         if usable_collateral > 0:
             continue
@@ -86,16 +92,16 @@ def _build_zero_collateral_blockers(
     return blockers
 
 
-def _usable_collateral(venue_status: object) -> float | None:
-    available_to_trade = getattr(venue_status, "available_to_trade", None)
+def _usable_collateral(venue_status: VenueAccountPreflight) -> float | None:
+    available_to_trade = venue_status.available_to_trade
     if isinstance(available_to_trade, int | float):
         return float(available_to_trade)
 
-    free_collateral = getattr(venue_status, "free_collateral", None)
+    free_collateral = venue_status.free_collateral
     if isinstance(free_collateral, int | float):
         return float(free_collateral)
 
-    total_collateral = getattr(venue_status, "total_collateral", None)
+    total_collateral = venue_status.total_collateral
     if isinstance(total_collateral, int | float):
         return float(total_collateral)
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -3125,6 +3125,14 @@ def test_live_submission_readiness_endpoint_blocks_zero_hyperliquid_collateral(
                         total_collateral=0.0,
                         available_to_trade=0.0,
                         free_collateral=0.0,
+                    ),
+                    VenueAccountPreflight(
+                        venue="extended",
+                        enabled=True,
+                        authenticated=True,
+                        ready=True,
+                        credential_mode="api_key",
+                        free_collateral=25.0,
                     )
                 ],
                 blocking_reasons=[],
@@ -3143,6 +3151,9 @@ def test_live_submission_readiness_endpoint_blocks_zero_hyperliquid_collateral(
         lambda: StubAccountPreflightService()
     )
     app.dependency_overrides[get_api_settings] = lambda: ApiSettings(
+        extended_live_enabled=True,
+        extended_api_key="extended-key",
+        extended_stark_private_key="extended-stark",
         hyperliquid_live_enabled=True,
         hyperliquid_account_address="0xhyper",
         hyperliquid_api_wallet_private_key="0xwallet",
@@ -3156,11 +3167,11 @@ def test_live_submission_readiness_endpoint_blocks_zero_hyperliquid_collateral(
 
     assert response.status_code == 200
     payload = response.json()
+    assert payload["confirmed_preview"] is True
     assert payload["ready"] is False
-    assert (
+    assert payload["blocking_reasons"] == [
         "Venue hyperliquid has no usable collateral for the confirmed 11.00 notional preview"
-        in payload["blocking_reasons"]
-    )
+    ]
 
 
 def test_paradex_live_execution_endpoint_submits_confirmed_preview(tmp_path: Path) -> None:
@@ -3272,6 +3283,7 @@ def test_paradex_live_execution_endpoint_submits_confirmed_preview(tmp_path: Pat
                         authenticated=True,
                         ready=True,
                         credential_mode="api_key",
+                        free_collateral=25.0,
                     ),
                     VenueAccountPreflight(
                         venue="paradex",
@@ -3279,6 +3291,7 @@ def test_paradex_live_execution_endpoint_submits_confirmed_preview(tmp_path: Pat
                         authenticated=True,
                         ready=True,
                         credential_mode="subkey_jwt",
+                        available_to_trade=25.0,
                     ),
                 ],
                 blocking_reasons=[],
@@ -3470,6 +3483,7 @@ def test_extended_live_execution_endpoint_submits_confirmed_preview(tmp_path: Pa
                         authenticated=True,
                         ready=True,
                         credential_mode="api_key",
+                        free_collateral=25.0,
                     )
                 ],
                 blocking_reasons=[],
@@ -3654,6 +3668,7 @@ def test_hyperliquid_live_execution_endpoint_submits_confirmed_preview(tmp_path:
                         authenticated=True,
                         ready=True,
                         credential_mode="api_wallet",
+                        available_to_trade=25.0,
                     ),
                     VenueAccountPreflight(
                         venue="extended",
@@ -3661,6 +3676,7 @@ def test_hyperliquid_live_execution_endpoint_submits_confirmed_preview(tmp_path:
                         authenticated=True,
                         ready=True,
                         credential_mode="api_key",
+                        free_collateral=25.0,
                     ),
                 ],
                 blocking_reasons=[],
@@ -3859,6 +3875,7 @@ def test_paired_live_execution_endpoint_submits_both_legs(tmp_path: Path) -> Non
                         authenticated=True,
                         ready=True,
                         credential_mode="api_key",
+                        free_collateral=25.0,
                     ),
                     VenueAccountPreflight(
                         venue="paradex",
@@ -3866,6 +3883,7 @@ def test_paired_live_execution_endpoint_submits_both_legs(tmp_path: Path) -> Non
                         authenticated=True,
                         ready=True,
                         credential_mode="subkey_jwt",
+                        available_to_trade=25.0,
                     ),
                 ],
                 blocking_reasons=[],
@@ -4079,6 +4097,7 @@ def test_guarded_paired_live_execution_endpoint_auto_cleans_open_leg(tmp_path: P
                         authenticated=True,
                         ready=True,
                         credential_mode="api_key",
+                        free_collateral=25.0,
                         position_symbols=positions["extended"],
                     ),
                     VenueAccountPreflight(
@@ -4087,6 +4106,7 @@ def test_guarded_paired_live_execution_endpoint_auto_cleans_open_leg(tmp_path: P
                         authenticated=True,
                         ready=True,
                         credential_mode="subkey_jwt",
+                        available_to_trade=25.0,
                         position_symbols=positions["paradex"],
                     ),
                 ],
@@ -4101,6 +4121,7 @@ def test_guarded_paired_live_execution_endpoint_auto_cleans_open_leg(tmp_path: P
                     authenticated=True,
                     ready=True,
                     credential_mode="api_key",
+                    free_collateral=25.0,
                 ),
                 VenueAccountPreflight(
                     venue="paradex",
@@ -4108,6 +4129,7 @@ def test_guarded_paired_live_execution_endpoint_auto_cleans_open_leg(tmp_path: P
                     authenticated=True,
                     ready=True,
                     credential_mode="subkey_jwt",
+                    available_to_trade=25.0,
                 ),
             ]
 
@@ -4487,6 +4509,7 @@ def test_guarded_paired_live_execution_endpoint_reuses_existing_cleanup_confirma
                         authenticated=True,
                         ready=True,
                         credential_mode="api_key",
+                        free_collateral=25.0,
                         position_symbols=positions["extended"],
                     ),
                     VenueAccountPreflight(
@@ -4495,6 +4518,7 @@ def test_guarded_paired_live_execution_endpoint_reuses_existing_cleanup_confirma
                         authenticated=True,
                         ready=True,
                         credential_mode="subkey_jwt",
+                        available_to_trade=25.0,
                         position_symbols=positions["paradex"],
                     ),
                 ],
@@ -4509,6 +4533,7 @@ def test_guarded_paired_live_execution_endpoint_reuses_existing_cleanup_confirma
                     authenticated=True,
                     ready=True,
                     credential_mode="api_key",
+                    free_collateral=25.0,
                 ),
                 VenueAccountPreflight(
                     venue="paradex",
@@ -4516,6 +4541,7 @@ def test_guarded_paired_live_execution_endpoint_reuses_existing_cleanup_confirma
                     authenticated=True,
                     ready=True,
                     credential_mode="subkey_jwt",
+                    available_to_trade=25.0,
                 ),
             ]
 
@@ -4877,6 +4903,7 @@ def test_guarded_paired_live_execution_endpoint_returns_existing_cleanup_executi
                         authenticated=True,
                         ready=True,
                         credential_mode="api_key",
+                        free_collateral=25.0,
                         position_symbols=["ARB-USD"],
                     ),
                     VenueAccountPreflight(
@@ -4885,6 +4912,7 @@ def test_guarded_paired_live_execution_endpoint_returns_existing_cleanup_executi
                         authenticated=True,
                         ready=True,
                         credential_mode="subkey_jwt",
+                        available_to_trade=25.0,
                         position_symbols=[],
                     ),
                 ],
@@ -4899,6 +4927,7 @@ def test_guarded_paired_live_execution_endpoint_returns_existing_cleanup_executi
                     authenticated=True,
                     ready=True,
                     credential_mode="api_key",
+                    free_collateral=25.0,
                 ),
                 VenueAccountPreflight(
                     venue="paradex",
@@ -4906,6 +4935,7 @@ def test_guarded_paired_live_execution_endpoint_returns_existing_cleanup_executi
                     authenticated=True,
                     ready=True,
                     credential_mode="subkey_jwt",
+                    available_to_trade=25.0,
                 ),
             ]
 
@@ -5184,6 +5214,7 @@ def test_guarded_paired_live_execution_endpoint_rejects_duplicate_retry(
                         authenticated=True,
                         ready=True,
                         credential_mode="api_key",
+                        free_collateral=25.0,
                     ),
                     VenueAccountPreflight(
                         venue="paradex",
@@ -5191,6 +5222,7 @@ def test_guarded_paired_live_execution_endpoint_rejects_duplicate_retry(
                         authenticated=True,
                         ready=True,
                         credential_mode="subkey_jwt",
+                        available_to_trade=25.0,
                     ),
                 ],
                 blocking_reasons=[],

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -294,6 +294,271 @@ def test_build_live_submission_readiness_blocks_zero_usable_collateral() -> None
     )
 
 
+def test_build_live_submission_readiness_blocks_when_collateral_data_missing() -> None:
+    confirmation = PreviewConfirmationEntry(
+        entry_id=9,
+        confirmed_at=datetime(2026, 3, 29, 13, 10, tzinfo=UTC),
+        paper_trade_id=6,
+        label="arb_extended_hyperliquid",
+        preview_hash="preview-hash",
+        preview=PaperTradeOrderPreview(
+            paper_trade_id=6,
+            label="arb_extended_hyperliquid",
+            generated_at=datetime(2026, 3, 29, 13, 5, tzinfo=UTC),
+            slippage_tolerance_bps=12,
+            preview_hash="preview-hash",
+            legs=[
+                VenueOrderPreview(
+                    venue="hyperliquid",
+                    symbol="ARB",
+                    fee_profile="tier0",
+                    side="buy",
+                    target_notional=11.0,
+                    quantity=119.3,
+                    quantity_text="119.3",
+                    reference_price=0.0922,
+                    reference_price_source="best_ask",
+                    worst_acceptable_price=0.09229,
+                    worst_price_text="0.09229",
+                    order_type="limit",
+                    time_in_force="ioc",
+                    http_method="POST",
+                    endpoint_path_hint="/exchange",
+                    required_auth_env_vars=[
+                        "CARRYME_API_HYPERLIQUID_ACCOUNT_ADDRESS",
+                        "CARRYME_API_HYPERLIQUID_API_WALLET_PRIVATE_KEY",
+                    ],
+                    auth_scheme="account address + API wallet private key",
+                    payload={"coin": "ARB"},
+                    notes=[],
+                )
+            ],
+        ),
+    )
+
+    readiness = build_live_submission_readiness(
+        paper_trade_id=6,
+        label="arb_extended_hyperliquid",
+        preview_hash="preview-hash",
+        confirmations=[confirmation],
+        execution_preflight=PaperTradeExecutionPreflight(
+            paper_trade_id=6,
+            label="arb_extended_hyperliquid",
+            ready=True,
+            venues=[],
+            blocking_reasons=[],
+        ),
+        account_preflight=PaperTradeAccountPreflight(
+            paper_trade_id=6,
+            label="arb_extended_hyperliquid",
+            ready=True,
+            venues=[
+                VenueAccountPreflight(
+                    venue="hyperliquid",
+                    enabled=True,
+                    authenticated=True,
+                    ready=True,
+                    credential_mode="api_wallet",
+                )
+            ],
+            blocking_reasons=[],
+        ),
+    )
+
+    assert readiness.ready is False
+    assert readiness.blocking_reasons == [
+        "Venue hyperliquid is missing collateral data for the confirmed 11.00 notional preview"
+    ]
+
+
+def test_build_live_submission_readiness_allows_positive_collateral() -> None:
+    confirmation = PreviewConfirmationEntry(
+        entry_id=9,
+        confirmed_at=datetime(2026, 3, 29, 13, 10, tzinfo=UTC),
+        paper_trade_id=6,
+        label="arb_extended_hyperliquid",
+        preview_hash="preview-hash",
+        preview=PaperTradeOrderPreview(
+            paper_trade_id=6,
+            label="arb_extended_hyperliquid",
+            generated_at=datetime(2026, 3, 29, 13, 5, tzinfo=UTC),
+            slippage_tolerance_bps=12,
+            preview_hash="preview-hash",
+            legs=[
+                VenueOrderPreview(
+                    venue="hyperliquid",
+                    symbol="ARB",
+                    fee_profile="tier0",
+                    side="buy",
+                    target_notional=11.0,
+                    quantity=119.3,
+                    quantity_text="119.3",
+                    reference_price=0.0922,
+                    reference_price_source="best_ask",
+                    worst_acceptable_price=0.09229,
+                    worst_price_text="0.09229",
+                    order_type="limit",
+                    time_in_force="ioc",
+                    http_method="POST",
+                    endpoint_path_hint="/exchange",
+                    required_auth_env_vars=[
+                        "CARRYME_API_HYPERLIQUID_ACCOUNT_ADDRESS",
+                        "CARRYME_API_HYPERLIQUID_API_WALLET_PRIVATE_KEY",
+                    ],
+                    auth_scheme="account address + API wallet private key",
+                    payload={"coin": "ARB"},
+                    notes=[],
+                )
+            ],
+        ),
+    )
+
+    readiness = build_live_submission_readiness(
+        paper_trade_id=6,
+        label="arb_extended_hyperliquid",
+        preview_hash="preview-hash",
+        confirmations=[confirmation],
+        execution_preflight=PaperTradeExecutionPreflight(
+            paper_trade_id=6,
+            label="arb_extended_hyperliquid",
+            ready=True,
+            venues=[],
+            blocking_reasons=[],
+        ),
+        account_preflight=PaperTradeAccountPreflight(
+            paper_trade_id=6,
+            label="arb_extended_hyperliquid",
+            ready=True,
+            venues=[
+                VenueAccountPreflight(
+                    venue="hyperliquid",
+                    enabled=True,
+                    authenticated=True,
+                    ready=True,
+                    credential_mode="api_wallet",
+                    available_to_trade=25.0,
+                )
+            ],
+            blocking_reasons=[],
+        ),
+    )
+
+    assert readiness.ready is True
+    assert readiness.blocking_reasons == []
+
+
+def test_build_live_submission_readiness_blocks_only_zero_collateral_venues() -> None:
+    confirmation = PreviewConfirmationEntry(
+        entry_id=9,
+        confirmed_at=datetime(2026, 3, 29, 13, 10, tzinfo=UTC),
+        paper_trade_id=6,
+        label="arb_extended_hyperliquid",
+        preview_hash="preview-hash",
+        preview=PaperTradeOrderPreview(
+            paper_trade_id=6,
+            label="arb_extended_hyperliquid",
+            generated_at=datetime(2026, 3, 29, 13, 5, tzinfo=UTC),
+            slippage_tolerance_bps=12,
+            preview_hash="preview-hash",
+            legs=[
+                VenueOrderPreview(
+                    venue="hyperliquid",
+                    symbol="ARB",
+                    fee_profile="tier0",
+                    side="buy",
+                    target_notional=11.0,
+                    quantity=119.3,
+                    quantity_text="119.3",
+                    reference_price=0.0922,
+                    reference_price_source="best_ask",
+                    worst_acceptable_price=0.09229,
+                    worst_price_text="0.09229",
+                    order_type="limit",
+                    time_in_force="ioc",
+                    http_method="POST",
+                    endpoint_path_hint="/exchange",
+                    required_auth_env_vars=[
+                        "CARRYME_API_HYPERLIQUID_ACCOUNT_ADDRESS",
+                        "CARRYME_API_HYPERLIQUID_API_WALLET_PRIVATE_KEY",
+                    ],
+                    auth_scheme="account address + API wallet private key",
+                    payload={"coin": "ARB"},
+                    notes=[],
+                ),
+                VenueOrderPreview(
+                    venue="extended",
+                    symbol="ARB-USD",
+                    fee_profile="default",
+                    side="sell",
+                    target_notional=11.0,
+                    quantity=119.3,
+                    quantity_text="119.3",
+                    reference_price=0.0922,
+                    reference_price_source="best_bid",
+                    worst_acceptable_price=0.0921,
+                    worst_price_text="0.0921",
+                    order_type="limit",
+                    time_in_force="ioc",
+                    http_method="POST",
+                    endpoint_path_hint="/api/v1/user/order",
+                    required_auth_env_vars=[
+                        "CARRYME_API_EXTENDED_API_KEY",
+                        "CARRYME_API_EXTENDED_STARK_PRIVATE_KEY",
+                    ],
+                    auth_scheme="api key + Stark signing key",
+                    payload={"symbol": "ARB-USD"},
+                    notes=[],
+                ),
+            ],
+        ),
+    )
+
+    readiness = build_live_submission_readiness(
+        paper_trade_id=6,
+        label="arb_extended_hyperliquid",
+        preview_hash="preview-hash",
+        confirmations=[confirmation],
+        execution_preflight=PaperTradeExecutionPreflight(
+            paper_trade_id=6,
+            label="arb_extended_hyperliquid",
+            ready=True,
+            venues=[],
+            blocking_reasons=[],
+        ),
+        account_preflight=PaperTradeAccountPreflight(
+            paper_trade_id=6,
+            label="arb_extended_hyperliquid",
+            ready=True,
+            venues=[
+                VenueAccountPreflight(
+                    venue="hyperliquid",
+                    enabled=True,
+                    authenticated=True,
+                    ready=True,
+                    credential_mode="api_wallet",
+                    available_to_trade=0.0,
+                    free_collateral=0.0,
+                    total_collateral=0.0,
+                ),
+                VenueAccountPreflight(
+                    venue="extended",
+                    enabled=True,
+                    authenticated=True,
+                    ready=True,
+                    credential_mode="api_key",
+                    free_collateral=22.0,
+                ),
+            ],
+            blocking_reasons=[],
+        ),
+    )
+
+    assert readiness.ready is False
+    assert readiness.blocking_reasons == [
+        "Venue hyperliquid has no usable collateral for the confirmed 11.00 notional preview"
+    ]
+
+
 def test_build_trade_intent_sizes_by_capacity_fraction_and_cap() -> None:
     intent = build_trade_intent(
         OpportunityRecord(


### PR DESCRIPTION
## Summary
- add a readiness-time collateral gate that blocks confirmed live previews when a venue reports zero usable collateral
- cover the new gate in runtime and API tests
- verify the real Hyperliquid account path now blocks live readiness instead of appearing tradable at zero collateral

## Testing
- uv run pytest tests/test_runtime.py -q
- uv run pytest tests/test_api.py -q
- uv run ruff check .
- uv run mypy $(find src apps packages tests -name "*.py" -type f)
- uv run pytest


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Submission readiness now validates venue-specific account collateral and blocks submissions when collateral is missing or unusable for the confirmed preview.
  * Readiness responses include precise blocking reasons for "missing collateral data" or "no usable collateral".

* **Tests**
  * Added endpoint and unit tests covering collateral-related blocking scenarios and allowed submissions when usable collateral exists.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->