### PR TITLE
feat: enable hyperliquid paired execution

### DIFF
--- a/apps/api/src/carryme_api/app.py
+++ b/apps/api/src/carryme_api/app.py
@@ -374,6 +374,10 @@ def get_paired_live_execution_coordinator(
         ExtendedLiveExecutionService,
         Depends(get_extended_live_execution_service),
     ],
+    hyperliquid_service: Annotated[
+        HyperliquidLiveExecutionService,
+        Depends(get_hyperliquid_live_execution_service),
+    ],
     paradex_service: Annotated[
         ParadexLiveExecutionService,
         Depends(get_paradex_live_execution_service),
@@ -384,6 +388,7 @@ def get_paired_live_execution_coordinator(
     return PairedLiveExecutionCoordinator(
         services={
             "extended": extended_service,
+            "hyperliquid": hyperliquid_service,
             "paradex": paradex_service,
         }
     )

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -76,6 +76,27 @@ def test_fee_profiles_endpoint() -> None:
     assert {item["profile"] for item in payload} == {"retail", "pro", "pro_fastfills"}
 
 
+def test_paired_live_execution_coordinator_provider_includes_hyperliquid() -> None:
+    from carryme_api.app import get_paired_live_execution_coordinator
+    from carryme_runtime import (
+        ExtendedLiveExecutionService,
+        HyperliquidLiveExecutionService,
+        ParadexLiveExecutionService,
+    )
+
+    class StubService:
+        async def submit_confirmed_preview(self, **kwargs: object) -> None:
+            return None
+
+    coordinator = get_paired_live_execution_coordinator(
+        extended_service=cast(ExtendedLiveExecutionService, StubService()),
+        hyperliquid_service=cast(HyperliquidLiveExecutionService, StubService()),
+        paradex_service=cast(ParadexLiveExecutionService, StubService()),
+    )
+
+    assert set(coordinator.services) == {"extended", "hyperliquid", "paradex"}
+
+
 def test_funding_pair_endpoint_uses_service_dependency() -> None:
     class StubOpportunityService:
         async def score_pair(self, **_: str) -> FundingArbOpportunity:

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -2,7 +2,7 @@ import asyncio
 import json
 import time
 from datetime import UTC, datetime
-from typing import Any, cast
+from typing import Any, Literal, cast
 
 import httpx
 import pytest
@@ -3484,6 +3484,149 @@ def test_paired_live_execution_coordinator_marks_partial_when_second_leg_fails()
         assert entry.status == "partial"
         assert [leg.status for leg in entry.legs] == ["submitted", "rejected"]
         assert entry.legs[1].response_payload == {"error": "paradex reject", "venue": "paradex"}
+
+    asyncio.run(run())
+
+
+def test_paired_live_execution_coordinator_supports_hyperliquid_leg() -> None:
+    paper_trade = PaperTradeEntry(
+        entry_id=13,
+        created_at=datetime(2026, 3, 29, 13, 0, tzinfo=UTC),
+        note="candidate accepted",
+        intent=FundingPairTradeIntent(
+            label="arb_extended_hyperliquid",
+            canonical_symbol="ARB-USD-PERP",
+            source_recorded_at=datetime(2026, 3, 29, 12, 55, tzinfo=UTC),
+            one_day_net_edge_after_entry=0.00042,
+            break_even_days_entry=0.63,
+            capacity_limit_notional=126.83,
+            target_notional=11.0,
+            capacity_fraction=0.25,
+            max_target_notional=11.0,
+            long_leg=TradeLegIntent(
+                venue="hyperliquid",
+                symbol="ARB",
+                fee_profile="tier0",
+                side="buy",
+                target_notional=11.0,
+            ),
+            short_leg=TradeLegIntent(
+                venue="extended",
+                symbol="ARB-USD",
+                fee_profile="default",
+                side="sell",
+                target_notional=11.0,
+            ),
+        ),
+    )
+    confirmation = PreviewConfirmationEntry(
+        entry_id=10,
+        confirmed_at=datetime(2026, 3, 29, 13, 10, tzinfo=UTC),
+        paper_trade_id=13,
+        label="arb_extended_hyperliquid",
+        preview_hash="preview-hash",
+        preview=PaperTradeOrderPreview(
+            paper_trade_id=13,
+            label="arb_extended_hyperliquid",
+            generated_at=datetime(2026, 3, 29, 13, 5, tzinfo=UTC),
+            slippage_tolerance_bps=10,
+            preview_hash="preview-hash",
+            legs=[
+                VenueOrderPreview(
+                    venue="extended",
+                    symbol="ARB-USD",
+                    fee_profile="default",
+                    side="sell",
+                    target_notional=11.0,
+                    quantity=123.0,
+                    quantity_text="123",
+                    reference_price=0.0890,
+                    reference_price_source="best_bid",
+                    worst_acceptable_price=0.0889,
+                    worst_price_text="0.0889",
+                    endpoint_path_hint="/api/v1/user/order",
+                    auth_scheme="api key + Stark signing key",
+                    payload={"symbol": "ARB-USD"},
+                    notes=[],
+                ),
+                VenueOrderPreview(
+                    venue="hyperliquid",
+                    symbol="ARB",
+                    fee_profile="tier0",
+                    side="buy",
+                    target_notional=11.0,
+                    quantity=119.3,
+                    quantity_text="119.3",
+                    reference_price=0.0922,
+                    reference_price_source="best_ask",
+                    worst_acceptable_price=0.09229,
+                    worst_price_text="0.09229",
+                    endpoint_path_hint="/exchange",
+                    auth_scheme="account address + API wallet private key",
+                    payload={"coin": "ARB"},
+                    notes=[],
+                ),
+            ],
+        ),
+        note="operator confirmed",
+    )
+
+    class StubService:
+        def __init__(self, venue: str) -> None:
+            self.venue = venue
+
+        async def submit_confirmed_preview(
+            self,
+            *,
+            paper_trade: PaperTradeEntry,
+            confirmation: PreviewConfirmationEntry,
+            executed_at: datetime | None = None,
+        ) -> ExecutionJournalEntry:
+            symbol = next(
+                leg.symbol for leg in confirmation.preview.legs if leg.venue == self.venue
+            )
+            fee_profile = "default" if self.venue == "extended" else "tier0"
+            side: Literal["buy", "sell"] = (
+                "sell" if self.venue == "extended" else "buy"
+            )
+            return ExecutionJournalEntry(
+                executed_at=executed_at or datetime.now(UTC),
+                adapter=f"{self.venue}_live",
+                mode="live",
+                status="submitted",
+                paper_trade_id=paper_trade.entry_id,
+                preview_hash=confirmation.preview_hash,
+                confirmation_entry_id=confirmation.entry_id,
+                paper_trade=paper_trade,
+                legs=[
+                    ExecutionLegResult(
+                        venue=self.venue,
+                        symbol=symbol,
+                        fee_profile=fee_profile,
+                        side=side,
+                        target_notional=11.0,
+                        status="submitted",
+                        simulated=False,
+                        external_reference=f"{self.venue}-1",
+                    )
+                ],
+            )
+
+    async def run() -> None:
+        service = PairedLiveExecutionCoordinator(
+            services={
+                "extended": StubService("extended"),
+                "hyperliquid": StubService("hyperliquid"),
+            }
+        )
+        entry = await service.submit_confirmed_preview(
+            paper_trade=paper_trade,
+            confirmation=confirmation,
+            first_venue="extended",
+        )
+        assert entry.status == "submitted"
+        assert entry.adapter == "paired_live:extended_then_hyperliquid"
+        assert [leg.venue for leg in entry.legs] == ["extended", "hyperliquid"]
 
     asyncio.run(run())
 


### PR DESCRIPTION
Wire Hyperliquid into the paired live execution coordinator and cover the generic extended-to-hyperliquid path in tests.\n\nTesting:\n- uv run pytest tests/test_runtime.py -q\n- uv run pytest tests/test_api.py -q\n- uv run ruff check .\n- uv run mypy \src/carryme_dev/__init__.py
apps/api/src/carryme_api/config.py
apps/api/src/carryme_api/__init__.py
apps/api/src/carryme_api/history_view.py
apps/api/src/carryme_api/app.py
apps/api/src/carryme_api/main.py
apps/worker/src/carryme_worker/config.py
apps/worker/src/carryme_worker/__init__.py
apps/worker/src/carryme_worker/poller.py
apps/worker/src/carryme_worker/main.py
packages/connectors/src/carryme_connectors/paradex_private.py
packages/connectors/src/carryme_connectors/hyperliquid.py
packages/connectors/src/carryme_connectors/paradex_auth.py
packages/connectors/src/carryme_connectors/extended_auth.py
packages/connectors/src/carryme_connectors/extended.py
packages/connectors/src/carryme_connectors/__init__.py
packages/connectors/src/carryme_connectors/extended_private.py
packages/connectors/src/carryme_connectors/paradex.py
packages/connectors/src/carryme_connectors/hyperliquid_auth.py
packages/connectors/src/carryme_connectors/base.py
packages/normalizers/src/carryme_normalizers/fees.py
packages/normalizers/src/carryme_normalizers/funding.py
packages/normalizers/src/carryme_normalizers/__init__.py
packages/normalizers/src/carryme_normalizers/symbols.py
packages/runtime/src/carryme_runtime/intents.py
packages/runtime/src/carryme_runtime/execution.py
packages/runtime/src/carryme_runtime/cleanup_live_execution.py
packages/runtime/src/carryme_runtime/execution_reconciliation.py
packages/runtime/src/carryme_runtime/hyperliquid_live_execution.py
packages/runtime/src/carryme_runtime/order_preview.py
packages/runtime/src/carryme_runtime/__init__.py
packages/runtime/src/carryme_runtime/execution_pair_status.py
packages/runtime/src/carryme_runtime/cleanup_preview.py
packages/runtime/src/carryme_runtime/extended_cleanup_preview.py
packages/runtime/src/carryme_runtime/paradex_live_execution.py
packages/runtime/src/carryme_runtime/opportunities.py
packages/runtime/src/carryme_runtime/confirmation.py
packages/runtime/src/carryme_runtime/execution_order_state.py
packages/runtime/src/carryme_runtime/extended_live_execution.py
packages/runtime/src/carryme_runtime/hyperliquid_cleanup_preview.py
packages/runtime/src/carryme_runtime/readiness.py
packages/runtime/src/carryme_runtime/account_preflight.py
packages/runtime/src/carryme_runtime/candidates.py
packages/runtime/src/carryme_runtime/paradex_cleanup_preview.py
packages/runtime/src/carryme_runtime/paired_live_execution.py
packages/runtime/src/carryme_runtime/preflight.py
packages/models/src/carryme_models/intent.py
packages/models/src/carryme_models/preview.py
packages/models/src/carryme_models/execution.py
packages/models/src/carryme_models/market.py
packages/models/src/carryme_models/health.py
packages/models/src/carryme_models/__init__.py
packages/models/src/carryme_models/confirmation.py
packages/models/src/carryme_models/opportunity.py
packages/models/src/carryme_models/readiness.py
packages/models/src/carryme_models/account_preflight.py
packages/models/src/carryme_models/normalization.py
packages/models/src/carryme_models/preflight.py
packages/models/src/carryme_models/history.py
packages/storage/src/carryme_storage/alerts.py
packages/storage/src/carryme_storage/executions.py
packages/storage/src/carryme_storage/paper_trades.py
packages/storage/src/carryme_storage/cleanup_preview_confirmations.py
packages/storage/src/carryme_storage/__init__.py
packages/storage/src/carryme_storage/preview_confirmations.py
packages/storage/src/carryme_storage/watchlist.py
packages/storage/src/carryme_storage/history.py
packages/scoring/src/carryme_scoring/__init__.py
packages/scoring/src/carryme_scoring/funding_arb.py
tests/test_normalizers.py
tests/test_runtime.py
tests/test_scoring.py
tests/test_storage.py
tests/test_worker.py
tests/test_api.py
tests/test_connectors.py\n- uv run pytest

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended paired live execution coordinator to support Hyperliquid as a new execution venue

* **Tests**
  * Added unit tests validating Hyperliquid venue integration in the coordinator
  * Added integration tests for paired trade execution involving Hyperliquid

<!-- end of auto-generated comment: release notes by coderabbit.ai -->