### PR TITLE
feat: add rate-limit-aware universe snapshot fetching

### DIFF
--- a/packages/runtime/src/carryme_runtime/universe.py
+++ b/packages/runtime/src/carryme_runtime/universe.py
@@ -288,6 +288,8 @@ def _build_connector(venue: str, client: httpx.AsyncClient) -> PublicVenueConnec
 
 def _is_retryable_snapshot_error(exc: ConnectorError | httpx.HTTPError) -> bool:
     if isinstance(exc, ConnectorError):
+        if exc.status_code is None:
+            return True
         return exc.status_code in RETRYABLE_SNAPSHOT_STATUS_CODES
     if isinstance(exc, httpx.HTTPStatusError):
         return exc.response.status_code in RETRYABLE_SNAPSHOT_STATUS_CODES

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -554,8 +554,10 @@ def test_opportunity_universe_service_limits_snapshot_concurrency_by_venue() -> 
                 max_venue_inflight["paradex"],
                 venue_inflight["paradex"],
             )
-            await asyncio.sleep(0.01)
-            venue_inflight["paradex"] -= 1
+            try:
+                await asyncio.sleep(0.01)
+            finally:
+                venue_inflight["paradex"] -= 1
         return snapshots[(venue, symbol)]
 
     async def run() -> None:


### PR DESCRIPTION
## Summary
- add venue-aware snapshot concurrency limits to full-universe scans
- retry retryable public snapshot errors such as HTTP `429`
- prove retry and per-venue concurrency behavior with runtime tests

## Validation
- `uv run ruff check .`
- `uv run mypy $(find src apps packages tests -name '*.py' -type f)`
- `uv run pytest` -> `167 passed`

## Live Notes (March 29, 2026)
- one live `carryme-worker --scan-universe-once` run completed successfully with the bounded-concurrency path
- the run persisted `10` ranked records and emitted `10` candidate alerts
- this slice targets the venue-throttling problem surfaced in the previous worker PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable snapshot retry with exponential backoff and jitter, adjustable attempts and backoff duration.
  * Per-venue concurrency limits to cap simultaneous snapshot requests.

* **Bug Fixes / Resiliency**
  * Expanded failure handling: connector-layer errors and specific HTTP status codes are classified as retryable or fatal to improve robustness.

* **Tests**
  * Added tests validating retry behavior, non-retryable status handling, retry budget exhaustion, and per-venue concurrency enforcement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->