### PR TITLE
feat: add FastFill-aware Paradex liquidity weighting

### DIFF
--- a/packages/connectors/src/carryme_connectors/paradex.py
+++ b/packages/connectors/src/carryme_connectors/paradex.py
@@ -80,14 +80,44 @@ class ParadexPublicConnector(BaseHttpConnector):
         )
 
     async def fetch_top_of_book(self, symbol: str) -> TopOfBook:
-        payload = await self._request_json("GET", f"/v1/bbo/{symbol}/interactive")
+        payload = await self._request_json("GET", f"/v1/orderbook/{symbol}/interactive")
         if not isinstance(payload, dict):
-            raise ConnectorError("Paradex BBO payload must be an object")
+            raise ConnectorError("Paradex orderbook payload must be an object")
+        best_bid = _first_level(payload.get("bids"), field="bids")
+        best_ask = _first_level(payload.get("asks"), field="asks")
+        best_bid_api = _price_size_pair(
+            payload.get("best_bid_api"),
+            field="best_bid_api",
+            optional=True,
+        )
+        best_ask_api = _price_size_pair(
+            payload.get("best_ask_api"),
+            field="best_ask_api",
+            optional=True,
+        )
+        best_bid_interactive = _price_size_pair(
+            payload.get("best_bid_interactive"),
+            field="best_bid_interactive",
+            optional=True,
+        )
+        best_ask_interactive = _price_size_pair(
+            payload.get("best_ask_interactive"),
+            field="best_ask_interactive",
+            optional=True,
+        )
         return TopOfBook(
-            best_bid_price=parse_float(payload.get("bid")),
-            best_bid_size=parse_float(payload.get("bid_size")),
-            best_ask_price=parse_float(payload.get("ask")),
-            best_ask_size=parse_float(payload.get("ask_size")),
+            best_bid_price=best_bid[0],
+            best_bid_size=best_bid[1],
+            best_ask_price=best_ask[0],
+            best_ask_size=best_ask[1],
+            best_bid_api_price=best_bid_api[0],
+            best_bid_api_size=best_bid_api[1],
+            best_ask_api_price=best_ask_api[0],
+            best_ask_api_size=best_ask_api[1],
+            best_bid_interactive_price=best_bid_interactive[0],
+            best_bid_interactive_size=best_bid_interactive[1],
+            best_ask_interactive_price=best_ask_interactive[0],
+            best_ask_interactive_size=best_ask_interactive[1],
         )
 
 
@@ -98,3 +128,33 @@ def _find_market(rows: Any, symbol: str) -> dict[str, Any]:
         if isinstance(row, dict) and row.get("symbol") == symbol:
             return row
     raise ConnectorError(f"Paradex market {symbol} not found")
+
+
+def _first_level(
+    levels: Any,
+    *,
+    field: str,
+) -> tuple[float | None, float | None]:
+    if levels is None:
+        raise ConnectorError(f"Paradex orderbook missing {field}")
+    if not isinstance(levels, list):
+        raise ConnectorError(f"Paradex orderbook {field} must be a list")
+    if not levels:
+        return None, None
+    first = levels[0]
+    return _price_size_pair(first, field=f"{field}[0]")
+
+
+def _price_size_pair(
+    raw: Any,
+    *,
+    field: str,
+    optional: bool = False,
+) -> tuple[float | None, float | None]:
+    if raw is None:
+        if optional:
+            return None, None
+        raise ConnectorError(f"Paradex orderbook missing {field}")
+    if not isinstance(raw, list | tuple) or len(raw) < 2:
+        raise ConnectorError(f"Paradex orderbook {field} must be [price, size]")
+    return parse_float(raw[0]), parse_float(raw[1])

--- a/packages/models/src/carryme_models/market.py
+++ b/packages/models/src/carryme_models/market.py
@@ -13,6 +13,14 @@ class TopOfBook(BaseModel):
     best_bid_size: float | None = None
     best_ask_price: float | None = None
     best_ask_size: float | None = None
+    best_bid_api_price: float | None = None
+    best_bid_api_size: float | None = None
+    best_ask_api_price: float | None = None
+    best_ask_api_size: float | None = None
+    best_bid_interactive_price: float | None = None
+    best_bid_interactive_size: float | None = None
+    best_ask_interactive_price: float | None = None
+    best_ask_interactive_size: float | None = None
 
 
 class MarketStats(BaseModel):

--- a/packages/models/src/carryme_models/universe.py
+++ b/packages/models/src/carryme_models/universe.py
@@ -30,6 +30,10 @@ class FundingUniverseVenueMarket(BaseModel):
     daily_volume: float | None = Field(default=None, ge=0)
     bid_notional: float | None = Field(default=None, ge=0)
     ask_notional: float | None = Field(default=None, ge=0)
+    bid_notional_api: float | None = Field(default=None, ge=0)
+    ask_notional_api: float | None = Field(default=None, ge=0)
+    bid_notional_interactive: float | None = Field(default=None, ge=0)
+    ask_notional_interactive: float | None = Field(default=None, ge=0)
 
 
 class ExecutionQualitySummary(BaseModel):
@@ -90,8 +94,12 @@ class FundingUniverseOpportunity(BaseModel):
     min_open_interest: float | None = Field(default=None, ge=0)
     target_notional: float | None = Field(default=None, ge=0)
     deployable_notional: float | None = Field(default=None, ge=0)
+    modeled_entry_cost_rate: float | None = Field(default=None, ge=0)
+    modeled_round_trip_cost_rate: float | None = Field(default=None, ge=0)
     estimated_one_day_pnl_after_entry: float | None = None
     estimated_one_day_pnl_after_round_trip: float | None = None
+    paradex_fastfill_share: float | None = Field(default=None, ge=0, le=1)
+    paradex_fastfill_eligible_notional: float | None = Field(default=None, ge=0)
     quality_score: float | None = None
     execution_quality: ExecutionQualitySummary | None = None
     route_stability: RouteStabilitySummary | None = None

--- a/packages/runtime/src/carryme_runtime/universe.py
+++ b/packages/runtime/src/carryme_runtime/universe.py
@@ -31,6 +31,7 @@ from carryme_models import (
     NormalizedMarketSnapshot,
     OpportunityRecord,
     RouteStabilitySummary,
+    TopOfBook,
 )
 from carryme_normalizers import get_fee_profile, normalize_symbol
 from carryme_scoring import score_funding_pair
@@ -290,6 +291,18 @@ class OpportunityUniverseService:
         raise RuntimeError("unreachable snapshot retry loop")
 
 
+@dataclass(frozen=True)
+class ModeledPairEconomics:
+    """Expected-value economics for a routed pair at a concrete notional."""
+
+    entry_cost_rate: float
+    round_trip_cost_rate: float
+    one_day_pnl_after_entry: float | None
+    one_day_pnl_after_round_trip: float | None
+    paradex_fastfill_share: float | None = None
+    paradex_fastfill_eligible_notional: float | None = None
+
+
 async def list_live_symbols(venue: str) -> list[str]:
     """List active perp symbols on a supported venue."""
 
@@ -350,16 +363,13 @@ def _build_universe_opportunity(
     min_daily_volume = _min_metric(list(venue_markets.values()), "daily_volume")
     min_open_interest = _min_metric(list(venue_markets.values()), "open_interest")
     deployable_notional = _deployable_notional(opportunity, target_notional)
-    pnl_after_entry = (
-        deployable_notional * opportunity.one_day_net_edge_after_entry
-        if deployable_notional is not None
-        else None
+    modeled = _model_pair_economics(
+        opportunity=opportunity,
+        venue_markets=venue_markets,
+        notional=deployable_notional,
     )
-    pnl_after_round_trip = (
-        deployable_notional * opportunity.one_day_net_edge_after_round_trip
-        if deployable_notional is not None
-        else None
-    )
+    pnl_after_entry = modeled.one_day_pnl_after_entry
+    pnl_after_round_trip = modeled.one_day_pnl_after_round_trip
     quality_score = _quality_score(
         estimated_one_day_pnl_after_round_trip=pnl_after_round_trip,
         deployable_notional=deployable_notional,
@@ -417,8 +427,12 @@ def _build_universe_opportunity(
         min_open_interest=min_open_interest,
         target_notional=target_notional,
         deployable_notional=deployable_notional,
+        modeled_entry_cost_rate=modeled.entry_cost_rate,
+        modeled_round_trip_cost_rate=modeled.round_trip_cost_rate,
         estimated_one_day_pnl_after_entry=pnl_after_entry,
         estimated_one_day_pnl_after_round_trip=pnl_after_round_trip,
+        paradex_fastfill_share=modeled.paradex_fastfill_share,
+        paradex_fastfill_eligible_notional=modeled.paradex_fastfill_eligible_notional,
         quality_score=quality_score,
         execution_quality=execution_quality,
         route_stability=route_stability,
@@ -432,13 +446,8 @@ def _build_universe_opportunity(
 
 def _venue_market(snapshot: NormalizedMarketSnapshot) -> FundingUniverseVenueMarket:
     book = snapshot.market.top_of_book
-    bid_notional = None
-    ask_notional = None
-    if book is not None:
-        if book.best_bid_price is not None and book.best_bid_size is not None:
-            bid_notional = book.best_bid_price * book.best_bid_size
-        if book.best_ask_price is not None and book.best_ask_size is not None:
-            ask_notional = book.best_ask_price * book.best_ask_size
+    bid_notional = _book_side_notional(book, "bid")
+    ask_notional = _book_side_notional(book, "ask")
     return FundingUniverseVenueMarket(
         venue=snapshot.identity.venue,
         symbol=snapshot.identity.venue_symbol,
@@ -448,6 +457,10 @@ def _venue_market(snapshot: NormalizedMarketSnapshot) -> FundingUniverseVenueMar
         daily_volume=snapshot.market.daily_volume,
         bid_notional=bid_notional,
         ask_notional=ask_notional,
+        bid_notional_api=_book_side_api_notional(book, "bid"),
+        ask_notional_api=_book_side_api_notional(book, "ask"),
+        bid_notional_interactive=_book_side_interactive_notional(book, "bid"),
+        ask_notional_interactive=_book_side_interactive_notional(book, "ask"),
     )
 
 
@@ -516,7 +529,7 @@ def _passes_filters(
         return False
     if (opportunity.min_open_interest or 0.0) < min_open_interest:
         return False
-    if opportunity.opportunity.one_day_net_edge_after_round_trip < min_roundtrip_edge:
+    if _modeled_net_edge_after_round_trip(opportunity) < min_roundtrip_edge:
         return False
     execution_quality_score = (
         opportunity.execution_quality.weighted_score
@@ -554,11 +567,200 @@ def _passes_filters(
     return route_sample_size >= min_route_samples
 
 
+def _model_pair_economics(
+    *,
+    opportunity: FundingArbOpportunity,
+    venue_markets: dict[str, FundingUniverseVenueMarket],
+    notional: float | None,
+) -> ModeledPairEconomics:
+    short_market = venue_markets.get(opportunity.short_venue)
+    long_market = venue_markets.get(opportunity.long_venue)
+    if short_market is None or long_market is None:
+        return ModeledPairEconomics(
+            entry_cost_rate=opportunity.entry_cost_rate,
+            round_trip_cost_rate=opportunity.round_trip_cost_rate,
+            one_day_pnl_after_entry=(
+                notional * opportunity.one_day_net_edge_after_entry
+                if notional is not None
+                else None
+            ),
+            one_day_pnl_after_round_trip=(
+                notional * opportunity.one_day_net_edge_after_round_trip
+                if notional is not None
+                else None
+            ),
+        )
+
+    short_fee_rate, short_fastfill_share, short_fastfill_eligible = _modeled_taker_fee_rate(
+        market=short_market,
+        fee_profile=opportunity.short_fee_profile,
+        side="bid",
+        notional=notional,
+    )
+    long_fee_rate, long_fastfill_share, long_fastfill_eligible = _modeled_taker_fee_rate(
+        market=long_market,
+        fee_profile=opportunity.long_fee_profile,
+        side="ask",
+        notional=notional,
+    )
+    entry_cost_rate = short_fee_rate + long_fee_rate
+    round_trip_cost_rate = entry_cost_rate * 2.0
+    one_day_pnl_after_entry = (
+        notional * (opportunity.gross_daily_edge - entry_cost_rate)
+        if notional is not None
+        else None
+    )
+    one_day_pnl_after_round_trip = (
+        notional * (opportunity.gross_daily_edge - round_trip_cost_rate)
+        if notional is not None
+        else None
+    )
+    paradex_fastfill_share = short_fastfill_share
+    paradex_fastfill_eligible = short_fastfill_eligible
+    if paradex_fastfill_share is None:
+        paradex_fastfill_share = long_fastfill_share
+        paradex_fastfill_eligible = long_fastfill_eligible
+    return ModeledPairEconomics(
+        entry_cost_rate=entry_cost_rate,
+        round_trip_cost_rate=round_trip_cost_rate,
+        one_day_pnl_after_entry=one_day_pnl_after_entry,
+        one_day_pnl_after_round_trip=one_day_pnl_after_round_trip,
+        paradex_fastfill_share=paradex_fastfill_share,
+        paradex_fastfill_eligible_notional=paradex_fastfill_eligible,
+    )
+
+
+def _modeled_taker_fee_rate(
+    *,
+    market: FundingUniverseVenueMarket,
+    fee_profile: str,
+    side: Literal["bid", "ask"],
+    notional: float | None,
+) -> tuple[float, float | None, float | None]:
+    selected_fee = get_fee_profile(market.venue, fee_profile).taker_fee_rate
+    if market.venue != "paradex" or fee_profile != "pro_fastfills":
+        return selected_fee, None, None
+    pro_fee = get_fee_profile("paradex", "pro").taker_fee_rate
+    fastfill_fee = get_fee_profile("paradex", "pro_fastfills").taker_fee_rate
+    if notional is None or notional <= 0:
+        return pro_fee, 0.0, 0.0
+    interactive_notional = _market_side_interactive_notional(market, side)
+    if interactive_notional is None or interactive_notional <= 0:
+        return pro_fee, 0.0, 0.0
+    eligible_notional = min(interactive_notional, notional)
+    eligible_share = min(eligible_notional / notional, 1.0)
+    effective_fee = pro_fee - ((pro_fee - fastfill_fee) * eligible_share)
+    return effective_fee, eligible_share, eligible_notional
+
+
+def _market_side_interactive_notional(
+    market: FundingUniverseVenueMarket,
+    side: Literal["bid", "ask"],
+) -> float | None:
+    if side == "bid":
+        return market.bid_notional_interactive
+    return market.ask_notional_interactive
+
+
+def _book_side_notional(book: object, side: Literal["bid", "ask"]) -> float | None:
+    if not isinstance(book, TopOfBook):
+        return None
+    if side == "bid":
+        return _notional_from_price_size(book.best_bid_price, book.best_bid_size)
+    return _notional_from_price_size(book.best_ask_price, book.best_ask_size)
+
+
+def _book_side_api_notional(book: object, side: Literal["bid", "ask"]) -> float | None:
+    if not isinstance(book, TopOfBook):
+        return None
+    if side == "bid":
+        return _notional_from_price_size(book.best_bid_api_price, book.best_bid_api_size)
+    return _notional_from_price_size(book.best_ask_api_price, book.best_ask_api_size)
+
+
+def _book_side_interactive_notional(book: object, side: Literal["bid", "ask"]) -> float | None:
+    if not isinstance(book, TopOfBook):
+        return None
+    total_price, total_size, api_price, api_size = _book_side_components(book, side)
+    explicit = _book_side_explicit_interactive_notional(book, side)
+    if explicit is not None:
+        interactive_price = (
+            book.best_bid_interactive_price if side == "bid" else book.best_ask_interactive_price
+        )
+        if total_price is None or interactive_price is None or interactive_price != total_price:
+            return 0.0
+        return explicit
+    if total_price is None or total_size is None:
+        return None
+    if api_price is None:
+        return None
+    if api_price != total_price:
+        return 0.0
+    if api_size is None:
+        return None
+    interactive_size = max(total_size - api_size, 0.0)
+    return total_price * interactive_size
+
+
+def _book_side_explicit_interactive_notional(
+    book: TopOfBook,
+    side: Literal["bid", "ask"],
+) -> float | None:
+    if side == "bid":
+        return _notional_from_price_size(
+            book.best_bid_interactive_price,
+            book.best_bid_interactive_size,
+        )
+    return _notional_from_price_size(
+        book.best_ask_interactive_price,
+        book.best_ask_interactive_size,
+    )
+
+
+def _book_side_components(
+    book: TopOfBook,
+    side: Literal["bid", "ask"],
+) -> tuple[float | None, float | None, float | None, float | None]:
+    if side == "bid":
+        return (
+            book.best_bid_price,
+            book.best_bid_size,
+            book.best_bid_api_price,
+            book.best_bid_api_size,
+        )
+    return (
+        book.best_ask_price,
+        book.best_ask_size,
+        book.best_ask_api_price,
+        book.best_ask_api_size,
+    )
+
+
+def _notional_from_price_size(price: float | None, size: float | None) -> float | None:
+    if price is None or size is None:
+        return None
+    return price * size
+
+
+def _modeled_net_edge_after_entry(opportunity: FundingUniverseOpportunity) -> float:
+    modeled_entry_cost_rate = opportunity.modeled_entry_cost_rate
+    if modeled_entry_cost_rate is None:
+        return opportunity.opportunity.one_day_net_edge_after_entry
+    return opportunity.opportunity.gross_daily_edge - modeled_entry_cost_rate
+
+
+def _modeled_net_edge_after_round_trip(opportunity: FundingUniverseOpportunity) -> float:
+    modeled_round_trip_cost_rate = opportunity.modeled_round_trip_cost_rate
+    if modeled_round_trip_cost_rate is None:
+        return opportunity.opportunity.one_day_net_edge_after_round_trip
+    return opportunity.opportunity.gross_daily_edge - modeled_round_trip_cost_rate
+
+
 def _ranking_value(opportunity: FundingUniverseOpportunity, ranking: UniverseRanking) -> float:
     if ranking == "roundtrip_edge":
-        return opportunity.opportunity.one_day_net_edge_after_round_trip
+        return _modeled_net_edge_after_round_trip(opportunity)
     if ranking == "entry_edge":
-        return opportunity.opportunity.one_day_net_edge_after_entry
+        return _modeled_net_edge_after_entry(opportunity)
     if ranking == "roundtrip_pnl":
         return opportunity.estimated_one_day_pnl_after_round_trip or float("-inf")
     if ranking == "entry_pnl":
@@ -652,21 +854,22 @@ def build_portfolio_plan(
         if selected_notional < min_selected_notional:
             continue
 
-        entry_edge = opportunity.opportunity.one_day_net_edge_after_entry
-        round_trip_edge = opportunity.opportunity.one_day_net_edge_after_round_trip
+        modeled = _model_pair_economics(
+            opportunity=opportunity.opportunity,
+            venue_markets=opportunity.venue_markets,
+            notional=selected_notional,
+        )
+        execution_weight = _execution_weight(opportunity)
         stability_weight = (
             opportunity.route_stability.stability_weight
             if opportunity.route_stability is not None
             else 1.0
         )
-        entry_pnl = selected_notional * entry_edge
-        round_trip_pnl = selected_notional * round_trip_edge
-        execution_weight = _execution_weight(opportunity)
-        execution_adjusted_round_trip_pnl = selected_notional * round_trip_edge * execution_weight
-        stability_adjusted_round_trip_pnl = selected_notional * round_trip_edge * stability_weight
-        route_adjusted_round_trip_pnl = (
-            selected_notional * round_trip_edge * execution_weight * stability_weight
-        )
+        entry_pnl = modeled.one_day_pnl_after_entry or 0.0
+        round_trip_pnl = modeled.one_day_pnl_after_round_trip or 0.0
+        execution_adjusted_round_trip_pnl = round_trip_pnl * execution_weight
+        stability_adjusted_round_trip_pnl = round_trip_pnl * stability_weight
+        route_adjusted_round_trip_pnl = round_trip_pnl * execution_weight * stability_weight
 
         entries.append(
             FundingUniversePortfolioEntry(

--- a/tests/test_connectors.py
+++ b/tests/test_connectors.py
@@ -197,10 +197,10 @@ def test_paradex_connector_parses_stats_and_top_of_book() -> None:
             200,
             json={
                 "market": "ARB-USD-PERP",
-                "bid": "0.0913",
-                "bid_size": "42584.8",
-                "ask": "0.0919",
-                "ask_size": "42473",
+                "bids": [["0.0913", "42584.8"]],
+                "asks": [["0.0919", "42473"]],
+                "best_bid_api": ["0.0913", "12000"],
+                "best_ask_api": ["0.0919", "8000"],
             },
         )
 
@@ -221,6 +221,10 @@ def test_paradex_connector_parses_stats_and_top_of_book() -> None:
         assert book.best_bid_size == pytest.approx(42584.8)
         assert book.best_ask_price == pytest.approx(0.0919)
         assert book.best_ask_size == pytest.approx(42473.0)
+        assert book.best_bid_api_price == pytest.approx(0.0913)
+        assert book.best_bid_api_size == pytest.approx(12000.0)
+        assert book.best_ask_api_price == pytest.approx(0.0919)
+        assert book.best_ask_api_size == pytest.approx(8000.0)
 
     asyncio.run(_run_with_client("https://api.prod.paradex.trade", handler, exercise))
 
@@ -324,6 +328,26 @@ def test_paradex_connector_lists_deterministic_symbols_and_rejects_malformed_row
     async def exercise(client: httpx.AsyncClient) -> None:
         connector = ParadexPublicConnector(client)
         assert await connector.list_market_symbols() == ["ARB-USD-PERP", "STRK-USD-PERP"]
+
+    asyncio.run(_run_with_client("https://api.prod.paradex.trade", handler, exercise))
+
+
+def test_paradex_connector_rejects_malformed_orderbook_shapes() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "bids": {"price": "0.0913", "size": "42584.8"},
+                "asks": [["0.0919", "42473"]],
+                "best_bid_api": ["0.0913", "12000"],
+                "best_ask_api": ["0.0919", "8000"],
+            },
+        )
+
+    async def exercise(client: httpx.AsyncClient) -> None:
+        connector = ParadexPublicConnector(client)
+        with pytest.raises(ConnectorError, match="Paradex orderbook bids must be a list"):
+            await connector.fetch_top_of_book("ARB-USD-PERP")
 
     asyncio.run(_run_with_client("https://api.prod.paradex.trade", handler, exercise))
 

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -33,6 +33,7 @@ from carryme_models import (
     FundingPairTradeIntent,
     FundingUniverseOpportunity,
     FundingUniverseScan,
+    FundingUniverseVenueMarket,
     LiveSubmissionReadiness,
     MarketStats,
     NormalizedMarketSnapshot,
@@ -112,6 +113,7 @@ def _snapshot(
     open_interest: float = 1_000_000,
     daily_volume: float = 500_000,
     raw: dict[str, object] | None = None,
+    top_of_book: TopOfBook | None = None,
 ) -> NormalizedMarketSnapshot:
     return normalize_market_snapshot(
         venue,
@@ -122,7 +124,8 @@ def _snapshot(
             funding_rate=funding_rate,
             open_interest=open_interest,
             daily_volume=daily_volume,
-            top_of_book=TopOfBook(
+            top_of_book=top_of_book
+            or TopOfBook(
                 best_bid_price=bid_price,
                 best_bid_size=bid_size,
                 best_ask_price=ask_price,
@@ -440,6 +443,72 @@ def test_funding_universe_scan_rejects_unknown_fee_profile_venues() -> None:
         )
 
 
+def test_opportunity_universe_service_models_paradex_fastfills_from_visible_book_share() -> None:
+    symbol_lists = {
+        "extended": ["ARB-USD"],
+        "paradex": ["ARB-USD-PERP"],
+    }
+    snapshots = {
+        ("extended", "ARB-USD"): _snapshot(
+            "extended",
+            "ARB-USD",
+            0.000013,
+            0.09,
+            20_000,
+            0.0901,
+            18_000,
+        ),
+        ("paradex", "ARB-USD-PERP"): _snapshot(
+            "paradex",
+            "ARB-USD-PERP",
+            -0.0006,
+            0.09,
+            18_000,
+            0.0901,
+            1_000,
+            top_of_book=TopOfBook(
+                best_bid_price=0.09,
+                best_bid_size=18_000,
+                best_ask_price=0.0901,
+                best_ask_size=1_000,
+                best_ask_api_price=0.0901,
+                best_ask_api_size=900,
+            ),
+        ),
+    }
+
+    async def list_symbols(venue: str) -> list[str]:
+        return symbol_lists[venue]
+
+    async def fetch_snapshot(venue: str, symbol: str) -> NormalizedMarketSnapshot:
+        return snapshots[(venue, symbol)]
+
+    async def run() -> None:
+        service = OpportunityUniverseService(
+            list_symbols=list_symbols,
+            fetch_snapshot=fetch_snapshot,
+        )
+        scan = await service.scan(
+            venues=["extended", "paradex"],
+            fee_profile_overrides={"paradex": "pro_fastfills"},
+            target_notional=50.0,
+            limit=10,
+        )
+
+        assert len(scan.opportunities) == 1
+        candidate = scan.opportunities[0]
+        assert candidate.opportunity.long_fee_profile == "pro_fastfills"
+        assert candidate.modeled_entry_cost_rate is not None
+        assert candidate.modeled_entry_cost_rate > candidate.opportunity.entry_cost_rate
+        assert candidate.paradex_fastfill_share == pytest.approx(0.1802, rel=1e-3)
+        assert candidate.paradex_fastfill_eligible_notional == pytest.approx(9.01)
+        assert candidate.estimated_one_day_pnl_after_round_trip is not None
+        naive_round_trip = 50.0 * candidate.opportunity.one_day_net_edge_after_round_trip
+        assert candidate.estimated_one_day_pnl_after_round_trip < naive_round_trip
+
+    asyncio.run(run())
+
+
 def test_funding_universe_scan_rejects_empty_fee_profile_names() -> None:
     with pytest.raises(
         ValidationError,
@@ -454,6 +523,142 @@ def test_funding_universe_scan_rejects_empty_fee_profile_names() -> None:
             overlaps=[],
             opportunities=[],
         )
+
+
+def test_opportunity_universe_service_filters_fastfill_routes_with_modeled_edge() -> None:
+    symbol_lists = {
+        "extended": ["ARB-USD"],
+        "paradex": ["ARB-USD-PERP"],
+    }
+    snapshots = {
+        ("extended", "ARB-USD"): _snapshot(
+            "extended",
+            "ARB-USD",
+            0.000013,
+            0.09,
+            20_000,
+            0.0901,
+            18_000,
+        ),
+        ("paradex", "ARB-USD-PERP"): _snapshot(
+            "paradex",
+            "ARB-USD-PERP",
+            -0.0006,
+            0.09,
+            18_000,
+            0.0901,
+            1_000,
+            top_of_book=TopOfBook(
+                best_bid_price=0.09,
+                best_bid_size=18_000,
+                best_ask_price=0.0901,
+                best_ask_size=1_000,
+                best_ask_api_price=0.0901,
+                best_ask_api_size=900,
+            ),
+        ),
+    }
+
+    async def list_symbols(venue: str) -> list[str]:
+        return symbol_lists[venue]
+
+    async def fetch_snapshot(venue: str, symbol: str) -> NormalizedMarketSnapshot:
+        return snapshots[(venue, symbol)]
+
+    async def run() -> None:
+        service = OpportunityUniverseService(
+            list_symbols=list_symbols,
+            fetch_snapshot=fetch_snapshot,
+        )
+        baseline_scan = await service.scan(
+            venues=["extended", "paradex"],
+            fee_profile_overrides={"paradex": "pro_fastfills"},
+            target_notional=50.0,
+            limit=10,
+        )
+
+        assert len(baseline_scan.opportunities) == 1
+        candidate = baseline_scan.opportunities[0]
+        assert candidate.modeled_round_trip_cost_rate is not None
+        modeled_roundtrip_edge = (
+            candidate.opportunity.gross_daily_edge - candidate.modeled_round_trip_cost_rate
+        )
+        static_roundtrip_edge = candidate.opportunity.one_day_net_edge_after_round_trip
+        assert modeled_roundtrip_edge < static_roundtrip_edge
+
+        filtered_scan = await service.scan(
+            venues=["extended", "paradex"],
+            fee_profile_overrides={"paradex": "pro_fastfills"},
+            target_notional=50.0,
+            min_roundtrip_edge=(modeled_roundtrip_edge + static_roundtrip_edge) / 2,
+            limit=10,
+        )
+
+        assert filtered_scan.opportunities == []
+
+    asyncio.run(run())
+
+
+def test_opportunity_universe_service_excludes_away_from_top_interactive_liquidity() -> None:
+    symbol_lists = {
+        "extended": ["ARB-USD"],
+        "paradex": ["ARB-USD-PERP"],
+    }
+    snapshots = {
+        ("extended", "ARB-USD"): _snapshot(
+            "extended",
+            "ARB-USD",
+            0.000013,
+            0.09,
+            20_000,
+            0.0901,
+            18_000,
+        ),
+        ("paradex", "ARB-USD-PERP"): _snapshot(
+            "paradex",
+            "ARB-USD-PERP",
+            -0.0006,
+            0.09,
+            18_000,
+            0.0901,
+            1_000,
+            top_of_book=TopOfBook(
+                best_bid_price=0.09,
+                best_bid_size=18_000,
+                best_ask_price=0.0901,
+                best_ask_size=1_000,
+                best_ask_api_price=0.0901,
+                best_ask_api_size=900,
+                best_ask_interactive_price=0.0902,
+                best_ask_interactive_size=100,
+            ),
+        ),
+    }
+
+    async def list_symbols(venue: str) -> list[str]:
+        return symbol_lists[venue]
+
+    async def fetch_snapshot(venue: str, symbol: str) -> NormalizedMarketSnapshot:
+        return snapshots[(venue, symbol)]
+
+    async def run() -> None:
+        service = OpportunityUniverseService(
+            list_symbols=list_symbols,
+            fetch_snapshot=fetch_snapshot,
+        )
+        scan = await service.scan(
+            venues=["extended", "paradex"],
+            fee_profile_overrides={"paradex": "pro_fastfills"},
+            target_notional=50.0,
+            limit=10,
+        )
+
+        assert len(scan.opportunities) == 1
+        candidate = scan.opportunities[0]
+        assert candidate.paradex_fastfill_share == pytest.approx(0.0)
+        assert candidate.paradex_fastfill_eligible_notional == pytest.approx(0.0)
+
+    asyncio.run(run())
 
 
 def test_opportunity_universe_service_retries_retryable_snapshot_errors() -> None:
@@ -2015,6 +2220,69 @@ def test_passes_symbol_policy_accepts_single_string_inputs() -> None:
     assert passes_symbol_policy("ARB-USD-PERP", include_symbols="ARB-USD-PERP")
     assert not passes_symbol_policy("ARB-USD-PERP", exclude_symbols="ARB-USD-PERP")
     assert not passes_symbol_policy("TRUMP-USD-PERP", exclude_tags="political")
+
+
+def test_build_portfolio_plan_reprices_fastfill_route_for_selected_notional() -> None:
+    opportunity = FundingUniverseOpportunity(
+        opportunity=FundingArbOpportunity(
+            canonical_symbol="ARB-USD-PERP",
+            long_venue="paradex",
+            short_venue="extended",
+            long_fee_profile="pro_fastfills",
+            short_fee_profile="default",
+            gross_daily_edge=0.004,
+            entry_cost_rate=0.00039,
+            round_trip_cost_rate=0.00078,
+            one_day_net_edge_after_entry=0.00361,
+            one_day_net_edge_after_round_trip=0.00322,
+            break_even_days_entry=0.2,
+            break_even_days_round_trip=0.3,
+            capacity=CapacityEstimate(
+                short_bid_notional=1_500.0,
+                long_ask_notional=900.0,
+                max_entry_notional=900.0,
+                limiting_venue="paradex",
+            ),
+        ),
+        venue_markets={
+            "extended": FundingUniverseVenueMarket(
+                venue="extended",
+                symbol="ARB-USD",
+                bid_notional=1_500.0,
+                ask_notional=1_400.0,
+            ),
+            "paradex": FundingUniverseVenueMarket(
+                venue="paradex",
+                symbol="ARB-USD-PERP",
+                bid_notional=1_300.0,
+                ask_notional=900.0,
+                ask_notional_api=600.0,
+                ask_notional_interactive=300.0,
+            ),
+        },
+        deployable_notional=900.0,
+        modeled_entry_cost_rate=0.00043,
+        modeled_round_trip_cost_rate=0.00086,
+        estimated_one_day_pnl_after_entry=3.213,
+        estimated_one_day_pnl_after_round_trip=2.826,
+        paradex_fastfill_share=0.333333,
+        paradex_fastfill_eligible_notional=300.0,
+        quality_score=1.8,
+    )
+    scan = FundingUniverseScan(
+        venues=["extended", "paradex"],
+        ranking="quality_adjusted_roundtrip_pnl",
+        target_notional=900.0,
+        overlap_count=1,
+        overlaps=[],
+        opportunities=[opportunity],
+    )
+
+    plan = build_portfolio_plan(scan, target_notional=200.0, max_positions=1)
+
+    assert plan.estimated_one_day_pnl_after_round_trip == pytest.approx(0.644)
+    assert len(plan.entries) == 1
+    assert plan.entries[0].estimated_one_day_pnl_after_round_trip == pytest.approx(0.644)
 
 
 def test_route_stability_service_summarizes_repeated_scan_windows(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary\n- use Paradex interactive orderbook data for book splits instead of flat BBO assumptions\n- model expected pro_fastfills fees from the visible retail/API share at the best price\n- reprice both universe scans and portfolio plans at the selected notional using the modeled economics\n\n## Validation\n- uv run ruff check /Users/espejelomar/StarkNet/ai-agents-starknet/carryme/packages/models/src/carryme_models/market.py /Users/espejelomar/StarkNet/ai-agents-starknet/carryme/packages/connectors/src/carryme_connectors/paradex.py /Users/espejelomar/StarkNet/ai-agents-starknet/carryme/packages/models/src/carryme_models/universe.py /Users/espejelomar/StarkNet/ai-agents-starknet/carryme/packages/runtime/src/carryme_runtime/universe.py /Users/espejelomar/StarkNet/ai-agents-starknet/carryme/tests/test_connectors.py /Users/espejelomar/StarkNet/ai-agents-starknet/carryme/tests/test_runtime.py\n- uv run mypy \/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/src/carryme_dev/__init__.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/apps/api/src/carryme_api/config.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/apps/api/src/carryme_api/__init__.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/apps/api/src/carryme_api/history_view.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/apps/api/src/carryme_api/app.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/apps/api/src/carryme_api/main.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/apps/worker/src/carryme_worker/config.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/apps/worker/src/carryme_worker/__init__.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/apps/worker/src/carryme_worker/poller.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/apps/worker/src/carryme_worker/notifications.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/apps/worker/src/carryme_worker/main.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/packages/connectors/src/carryme_connectors/paradex_private.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/packages/connectors/src/carryme_connectors/hyperliquid.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/packages/connectors/src/carryme_connectors/paradex_auth.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/packages/connectors/src/carryme_connectors/extended_auth.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/packages/connectors/src/carryme_connectors/extended.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/packages/connectors/src/carryme_connectors/__init__.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/packages/connectors/src/carryme_connectors/extended_private.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/packages/connectors/src/carryme_connectors/paradex.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/packages/connectors/src/carryme_connectors/hyperliquid_auth.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/packages/connectors/src/carryme_connectors/base.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/packages/normalizers/src/carryme_normalizers/fees.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/packages/normalizers/src/carryme_normalizers/funding.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/packages/normalizers/src/carryme_normalizers/__init__.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/packages/normalizers/src/carryme_normalizers/symbols.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/packages/runtime/src/carryme_runtime/intents.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/packages/runtime/src/carryme_runtime/execution.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/packages/runtime/src/carryme_runtime/universe_policy.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/packages/runtime/src/carryme_runtime/cleanup_live_execution.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/packages/runtime/src/carryme_runtime/execution_reconciliation.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/packages/runtime/src/carryme_runtime/hyperliquid_live_execution.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/packages/runtime/src/carryme_runtime/order_preview.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/packages/runtime/src/carryme_runtime/__init__.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/packages/runtime/src/carryme_runtime/execution_pair_status.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/packages/runtime/src/carryme_runtime/pair_close_preview.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/packages/runtime/src/carryme_runtime/cleanup_preview.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/packages/runtime/src/carryme_runtime/extended_cleanup_preview.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/packages/runtime/src/carryme_runtime/paradex_live_execution.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/packages/runtime/src/carryme_runtime/opportunities.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/packages/runtime/src/carryme_runtime/confirmation.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/packages/runtime/src/carryme_runtime/execution_order_state.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/packages/runtime/src/carryme_runtime/universe.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/packages/runtime/src/carryme_runtime/extended_live_execution.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/packages/runtime/src/carryme_runtime/route_stability.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/packages/runtime/src/carryme_runtime/hyperliquid_cleanup_preview.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/packages/runtime/src/carryme_runtime/readiness.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/packages/runtime/src/carryme_runtime/account_preflight.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/packages/runtime/src/carryme_runtime/candidates.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/packages/runtime/src/carryme_runtime/pair_close_live_execution.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/packages/runtime/src/carryme_runtime/paradex_cleanup_preview.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/packages/runtime/src/carryme_runtime/paired_live_execution.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/packages/runtime/src/carryme_runtime/preflight.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/packages/runtime/src/carryme_runtime/execution_quality.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/packages/models/src/carryme_models/intent.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/packages/models/src/carryme_models/preview.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/packages/models/src/carryme_models/execution.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/packages/models/src/carryme_models/market.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/packages/models/src/carryme_models/health.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/packages/models/src/carryme_models/__init__.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/packages/models/src/carryme_models/confirmation.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/packages/models/src/carryme_models/universe.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/packages/models/src/carryme_models/opportunity.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/packages/models/src/carryme_models/readiness.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/packages/models/src/carryme_models/account_preflight.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/packages/models/src/carryme_models/normalization.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/packages/models/src/carryme_models/preflight.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/packages/models/src/carryme_models/history.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/packages/storage/src/carryme_storage/alerts.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/packages/storage/src/carryme_storage/executions.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/packages/storage/src/carryme_storage/pair_close_preview_confirmations.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/packages/storage/src/carryme_storage/paper_trades.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/packages/storage/src/carryme_storage/cleanup_preview_confirmations.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/packages/storage/src/carryme_storage/__init__.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/packages/storage/src/carryme_storage/preview_confirmations.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/packages/storage/src/carryme_storage/execution_observations.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/packages/storage/src/carryme_storage/watchlist.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/packages/storage/src/carryme_storage/execution_alerts.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/packages/storage/src/carryme_storage/history.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/packages/scoring/src/carryme_scoring/__init__.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/packages/scoring/src/carryme_scoring/funding_arb.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/tests/test_normalizers.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/tests/test_runtime.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/tests/test_scoring.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/tests/test_storage.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/tests/test_worker.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/tests/test_api.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/tests/test_connectors.py\n- uv run pytest\n- CARRYME_WORKER_LOG_LEVEL=WARNING CARRYME_WORKER_UNIVERSE_SCAN_PARADEX_FEE_PROFILE=pro_fastfills uv run carryme-worker --scan-universe-once\n\nCloses #105

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Paradex fastfill cost modeling with eligible notional support to improve fee accuracy
  * Extended market data tracking with separate API and interactive book sources

* **Enhancements**
  * Improved PnL calculations to account for fastfill mechanics and multi-source book pricing

* **Tests**
  * Added test coverage for fastfill scenarios and portfolio repricing logic

<!-- end of auto-generated comment: release notes by coderabbit.ai -->