### PR TITLE
feat: add canary route policy

### DIFF
--- a/apps/api/src/carryme_api/app.py
+++ b/apps/api/src/carryme_api/app.py
@@ -27,6 +27,7 @@ from carryme_models import (
     ExecutionReconciliation,
     FundingArbOpportunity,
     FundingPairTradeIntent,
+    FundingUniverseCanaryCandidate,
     FundingUniversePortfolioPlan,
     FundingUniverseScan,
     GuardedPairExecutionResult,
@@ -3299,6 +3300,64 @@ def create_app() -> FastAPI:
         except ValueError as exc:
             raise HTTPException(status_code=400, detail=str(exc)) from exc
         except (ConnectorError, UpstreamDataError, httpx.HTTPError) as exc:
+            raise HTTPException(status_code=502, detail=str(exc)) from exc
+
+    @app.get(
+        "/v1/opportunities/funding-universe/canary",
+        response_model=list[FundingUniverseCanaryCandidate],
+    )
+    async def funding_universe_canary_candidates(
+        service: Annotated[
+            OpportunityUniverseService, Depends(get_opportunity_universe_service)
+        ],
+        venues: Annotated[list[str] | None, Query()] = None,
+        extended_fee_profile: str | None = None,
+        paradex_fee_profile: str | None = "pro_fastfills",
+        hyperliquid_fee_profile: str | None = None,
+        target_notional: float = 5_000.0,
+        canary_max_notional: float = 25.0,
+        min_capacity_notional: float = 25.0,
+        min_daily_volume: float = 0.0,
+        min_open_interest: float = 0.0,
+        min_roundtrip_edge: float = 0.0,
+        min_execution_quality_score: float = 0.5,
+        min_execution_samples: int = 0,
+        min_route_stability_weight: float = 0.35,
+        min_route_presence_ratio: float = 0.35,
+        min_route_samples: int = 2,
+        include_symbols: Annotated[list[str] | None, Query()] = None,
+        exclude_symbols: Annotated[list[str] | None, Query()] = None,
+        exclude_tags: Annotated[list[str] | None, Query()] = None,
+        limit: int = 10,
+    ) -> list[FundingUniverseCanaryCandidate]:
+        try:
+            selected_venues = venues or ["extended", "paradex", "hyperliquid"]
+            return await service.scan_canary_candidates(
+                venues=selected_venues,
+                fee_profile_overrides=_build_fee_profile_overrides(
+                    extended_fee_profile=extended_fee_profile,
+                    paradex_fee_profile=paradex_fee_profile,
+                    hyperliquid_fee_profile=hyperliquid_fee_profile,
+                ),
+                target_notional=target_notional,
+                canary_max_notional=canary_max_notional,
+                min_capacity_notional=min_capacity_notional,
+                min_daily_volume=min_daily_volume,
+                min_open_interest=min_open_interest,
+                min_roundtrip_edge=min_roundtrip_edge,
+                min_execution_quality_score=min_execution_quality_score,
+                min_execution_samples=min_execution_samples,
+                min_route_stability_weight=min_route_stability_weight,
+                min_route_presence_ratio=min_route_presence_ratio,
+                min_route_samples=min_route_samples,
+                include_symbols=include_symbols,
+                exclude_symbols=exclude_symbols,
+                exclude_tags=exclude_tags,
+                limit=limit,
+            )
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+        except (ConnectorError, httpx.HTTPError) as exc:
             raise HTTPException(status_code=502, detail=str(exc)) from exc
 
     @app.get(

--- a/packages/models/src/carryme_models/__init__.py
+++ b/packages/models/src/carryme_models/__init__.py
@@ -53,6 +53,7 @@ from carryme_models.readiness import LiveSubmissionReadiness
 from carryme_models.universe import (
     SUPPORTED_UNIVERSE_VENUES,
     ExecutionQualitySummary,
+    FundingUniverseCanaryCandidate,
     FundingUniverseOpportunity,
     FundingUniverseOverlap,
     FundingUniversePortfolioEntry,
@@ -80,6 +81,7 @@ __all__ = [
     "ExecutionVenueReconciliation",
     "ObservationSource",
     "ExecutionQualitySummary",
+    "FundingUniverseCanaryCandidate",
     "FundingPairSpec",
     "FundingRateNormalization",
     "FundingArbOpportunity",

--- a/packages/models/src/carryme_models/universe.py
+++ b/packages/models/src/carryme_models/universe.py
@@ -137,6 +137,13 @@ class FundingUniverseScan(BaseModel):
         return self
 
 
+class FundingUniverseCanaryCandidate(BaseModel):
+    """A route approved for a tiny controlled live-money canary."""
+
+    opportunity: FundingUniverseOpportunity
+    suggested_canary_notional: float = Field(ge=0)
+
+
 class FundingUniversePortfolioEntry(BaseModel):
     """A selected allocation within a funding-universe portfolio plan."""
 

--- a/packages/runtime/src/carryme_runtime/universe.py
+++ b/packages/runtime/src/carryme_runtime/universe.py
@@ -22,6 +22,7 @@ from carryme_models import (
     ExecutionQualitySummary,
     FundingArbOpportunity,
     FundingPairSpec,
+    FundingUniverseCanaryCandidate,
     FundingUniverseOpportunity,
     FundingUniverseOverlap,
     FundingUniversePortfolioEntry,
@@ -109,6 +110,62 @@ class OpportunityUniverseService:
     snapshot_retry_backoff_seconds: float = 0.25
     execution_quality_service: ExecutionQualityService | None = None
     route_stability_service: RouteStabilityService | None = None
+
+    async def scan_canary_candidates(
+        self,
+        *,
+        venues: list[str],
+        fee_profile_overrides: dict[str, str] | None = None,
+        target_notional: float = 5_000.0,
+        canary_max_notional: float = 25.0,
+        min_capacity_notional: float = 25.0,
+        min_daily_volume: float = 0.0,
+        min_open_interest: float = 0.0,
+        min_roundtrip_edge: float = 0.0,
+        min_execution_quality_score: float = 0.5,
+        min_execution_samples: int = 0,
+        min_route_stability_weight: float = 0.35,
+        min_route_presence_ratio: float = 0.35,
+        min_route_samples: int = 2,
+        include_symbols: list[str] | None = None,
+        exclude_symbols: list[str] | None = None,
+        exclude_tags: list[str] | None = None,
+        limit: int = 10,
+    ) -> list[FundingUniverseCanaryCandidate]:
+        scan = await self.scan(
+            venues=venues,
+            ranking="route_adjusted_quality_pnl",
+            fee_profile_overrides=fee_profile_overrides,
+            target_notional=target_notional,
+            min_capacity_notional=min_capacity_notional,
+            min_daily_volume=min_daily_volume,
+            min_open_interest=min_open_interest,
+            min_roundtrip_edge=min_roundtrip_edge,
+            min_execution_quality_score=min_execution_quality_score,
+            min_execution_samples=min_execution_samples,
+            min_route_stability_weight=min_route_stability_weight,
+            min_route_presence_ratio=min_route_presence_ratio,
+            min_route_samples=min_route_samples,
+            include_symbols=include_symbols,
+            exclude_symbols=exclude_symbols,
+            exclude_tags=exclude_tags or ["meme", "political"],
+            limit=limit,
+        )
+        candidates: list[FundingUniverseCanaryCandidate] = []
+        for opportunity in scan.opportunities:
+            deployable = opportunity.deployable_notional or 0.0
+            if deployable <= 0:
+                continue
+            modeled_round_trip_pnl = opportunity.estimated_one_day_pnl_after_round_trip or 0.0
+            if modeled_round_trip_pnl <= 0:
+                continue
+            candidates.append(
+                FundingUniverseCanaryCandidate(
+                    opportunity=opportunity,
+                    suggested_canary_notional=min(canary_max_notional, deployable),
+                )
+            )
+        return candidates
 
     async def scan(
         self,

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -34,6 +34,7 @@ from carryme_models import (
     FundingArbOpportunity,
     FundingPairSpec,
     FundingPairTradeIntent,
+    FundingUniverseCanaryCandidate,
     FundingUniverseOpportunity,
     FundingUniverseOverlap,
     FundingUniverseScan,
@@ -406,6 +407,39 @@ def test_funding_universe_endpoint_passes_route_stability_filters() -> None:
     assert captured["min_route_stability_weight"] == 0.2
     assert captured["min_route_presence_ratio"] == 0.5
     assert captured["min_route_samples"] == 4
+
+
+def test_funding_universe_canary_endpoint_uses_policy_defaults() -> None:
+    captured: dict[str, object] = {}
+
+    class StubUniverseService:
+        async def scan_canary_candidates(
+            self, **kwargs: object
+        ) -> list[FundingUniverseCanaryCandidate]:
+            captured.update(kwargs)
+            return []
+
+    app.dependency_overrides[get_opportunity_universe_service] = lambda: StubUniverseService()
+    client = TestClient(app)
+
+    response = client.get(
+        "/v1/opportunities/funding-universe/canary",
+        params=[
+            ("venues", "extended"),
+            ("venues", "paradex"),
+        ],
+    )
+
+    app.dependency_overrides.clear()
+
+    assert response.status_code == 200
+    assert captured["fee_profile_overrides"] == {"paradex": "pro_fastfills"}
+    assert captured["min_execution_quality_score"] == 0.5
+    assert captured["min_execution_samples"] == 0
+    assert captured["min_route_stability_weight"] == 0.35
+    assert captured["min_route_presence_ratio"] == 0.35
+    assert captured["min_route_samples"] == 2
+    assert captured["exclude_tags"] is None
 
 
 def test_funding_universe_portfolio_endpoint_uses_service_dependency() -> None:

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -31,6 +31,7 @@ from carryme_models import (
     FundingArbOpportunity,
     FundingPairSpec,
     FundingPairTradeIntent,
+    FundingUniverseCanaryCandidate,
     FundingUniverseOpportunity,
     FundingUniverseScan,
     FundingUniverseVenueMarket,
@@ -657,6 +658,85 @@ def test_opportunity_universe_service_excludes_away_from_top_interactive_liquidi
         candidate = scan.opportunities[0]
         assert candidate.paradex_fastfill_share == pytest.approx(0.0)
         assert candidate.paradex_fastfill_eligible_notional == pytest.approx(0.0)
+
+    asyncio.run(run())
+
+
+def test_opportunity_universe_service_scan_canary_candidates_uses_policy_defaults() -> None:
+    symbol_lists = {
+        "extended": ["ARB-USD", "TRUMP-USD"],
+        "paradex": ["ARB-USD-PERP", "TRUMP-USD-PERP"],
+    }
+    snapshots = {
+        ("extended", "ARB-USD"): _snapshot(
+            "extended",
+            "ARB-USD",
+            0.000013,
+            0.09,
+            20_000,
+            0.0901,
+            18_000,
+            daily_volume=200_000,
+            open_interest=500_000,
+        ),
+        ("paradex", "ARB-USD-PERP"): _snapshot(
+            "paradex",
+            "ARB-USD-PERP",
+            -0.0006,
+            0.09,
+            18_000,
+            0.0901,
+            17_000,
+            daily_volume=180_000,
+            open_interest=450_000,
+        ),
+        ("extended", "TRUMP-USD"): _snapshot(
+            "extended",
+            "TRUMP-USD",
+            0.000013,
+            10.0,
+            500,
+            10.1,
+            400,
+            daily_volume=100_000,
+            open_interest=300_000,
+        ),
+        ("paradex", "TRUMP-USD-PERP"): _snapshot(
+            "paradex",
+            "TRUMP-USD-PERP",
+            -0.0008,
+            10.0,
+            400,
+            10.1,
+            300,
+            daily_volume=90_000,
+            open_interest=250_000,
+        ),
+    }
+
+    async def list_symbols(venue: str) -> list[str]:
+        return symbol_lists[venue]
+
+    async def fetch_snapshot(venue: str, symbol: str) -> NormalizedMarketSnapshot:
+        return snapshots[(venue, symbol)]
+
+    async def run() -> None:
+        service = OpportunityUniverseService(
+            list_symbols=list_symbols,
+            fetch_snapshot=fetch_snapshot,
+        )
+        candidates = await service.scan_canary_candidates(
+            venues=["extended", "paradex"],
+            canary_max_notional=25.0,
+            min_route_stability_weight=0.0,
+            min_route_presence_ratio=0.0,
+            min_route_samples=0,
+        )
+
+        assert len(candidates) == 1
+        assert isinstance(candidates[0], FundingUniverseCanaryCandidate)
+        assert candidates[0].opportunity.opportunity.canonical_symbol == "ARB-USD-PERP"
+        assert candidates[0].suggested_canary_notional == pytest.approx(25.0)
 
     asyncio.run(run())
 


### PR DESCRIPTION
## Summary\n- add a first-class canary route candidate model and scanner method\n- expose a funding-universe canary endpoint with explicit tiny-notional suggestions\n- default the canary policy toward route-adjusted quality, Paradex pro_fastfills, and symbol-policy/risk gates\n\n## Validation\n- uv run ruff check /Users/espejelomar/StarkNet/ai-agents-starknet/carryme/packages/models/src/carryme_models/universe.py /Users/espejelomar/StarkNet/ai-agents-starknet/carryme/packages/models/src/carryme_models/__init__.py /Users/espejelomar/StarkNet/ai-agents-starknet/carryme/packages/runtime/src/carryme_runtime/universe.py /Users/espejelomar/StarkNet/ai-agents-starknet/carryme/apps/api/src/carryme_api/app.py /Users/espejelomar/StarkNet/ai-agents-starknet/carryme/tests/test_runtime.py /Users/espejelomar/StarkNet/ai-agents-starknet/carryme/tests/test_api.py\n- uv run mypy \/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/src/carryme_dev/__init__.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/apps/api/src/carryme_api/config.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/apps/api/src/carryme_api/__init__.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/apps/api/src/carryme_api/history_view.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/apps/api/src/carryme_api/app.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/apps/api/src/carryme_api/main.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/apps/worker/src/carryme_worker/config.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/apps/worker/src/carryme_worker/__init__.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/apps/worker/src/carryme_worker/poller.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/apps/worker/src/carryme_worker/notifications.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/apps/worker/src/carryme_worker/main.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/packages/connectors/src/carryme_connectors/paradex_private.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/packages/connectors/src/carryme_connectors/hyperliquid.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/packages/connectors/src/carryme_connectors/paradex_auth.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/packages/connectors/src/carryme_connectors/extended_auth.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/packages/connectors/src/carryme_connectors/extended.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/packages/connectors/src/carryme_connectors/__init__.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/packages/connectors/src/carryme_connectors/extended_private.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/packages/connectors/src/carryme_connectors/paradex.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/packages/connectors/src/carryme_connectors/hyperliquid_auth.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/packages/connectors/src/carryme_connectors/base.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/packages/normalizers/src/carryme_normalizers/fees.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/packages/normalizers/src/carryme_normalizers/funding.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/packages/normalizers/src/carryme_normalizers/__init__.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/packages/normalizers/src/carryme_normalizers/symbols.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/packages/runtime/src/carryme_runtime/intents.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/packages/runtime/src/carryme_runtime/execution.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/packages/runtime/src/carryme_runtime/universe_policy.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/packages/runtime/src/carryme_runtime/cleanup_live_execution.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/packages/runtime/src/carryme_runtime/execution_reconciliation.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/packages/runtime/src/carryme_runtime/hyperliquid_live_execution.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/packages/runtime/src/carryme_runtime/order_preview.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/packages/runtime/src/carryme_runtime/__init__.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/packages/runtime/src/carryme_runtime/execution_pair_status.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/packages/runtime/src/carryme_runtime/pair_close_preview.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/packages/runtime/src/carryme_runtime/cleanup_preview.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/packages/runtime/src/carryme_runtime/extended_cleanup_preview.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/packages/runtime/src/carryme_runtime/paradex_live_execution.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/packages/runtime/src/carryme_runtime/opportunities.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/packages/runtime/src/carryme_runtime/confirmation.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/packages/runtime/src/carryme_runtime/execution_order_state.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/packages/runtime/src/carryme_runtime/universe.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/packages/runtime/src/carryme_runtime/extended_live_execution.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/packages/runtime/src/carryme_runtime/route_stability.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/packages/runtime/src/carryme_runtime/hyperliquid_cleanup_preview.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/packages/runtime/src/carryme_runtime/readiness.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/packages/runtime/src/carryme_runtime/account_preflight.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/packages/runtime/src/carryme_runtime/candidates.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/packages/runtime/src/carryme_runtime/pair_close_live_execution.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/packages/runtime/src/carryme_runtime/paradex_cleanup_preview.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/packages/runtime/src/carryme_runtime/paired_live_execution.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/packages/runtime/src/carryme_runtime/preflight.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/packages/runtime/src/carryme_runtime/execution_quality.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/packages/models/src/carryme_models/intent.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/packages/models/src/carryme_models/preview.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/packages/models/src/carryme_models/execution.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/packages/models/src/carryme_models/market.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/packages/models/src/carryme_models/health.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/packages/models/src/carryme_models/__init__.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/packages/models/src/carryme_models/confirmation.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/packages/models/src/carryme_models/universe.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/packages/models/src/carryme_models/opportunity.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/packages/models/src/carryme_models/readiness.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/packages/models/src/carryme_models/account_preflight.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/packages/models/src/carryme_models/normalization.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/packages/models/src/carryme_models/preflight.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/packages/models/src/carryme_models/history.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/packages/storage/src/carryme_storage/alerts.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/packages/storage/src/carryme_storage/executions.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/packages/storage/src/carryme_storage/pair_close_preview_confirmations.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/packages/storage/src/carryme_storage/paper_trades.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/packages/storage/src/carryme_storage/cleanup_preview_confirmations.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/packages/storage/src/carryme_storage/__init__.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/packages/storage/src/carryme_storage/preview_confirmations.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/packages/storage/src/carryme_storage/execution_observations.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/packages/storage/src/carryme_storage/watchlist.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/packages/storage/src/carryme_storage/execution_alerts.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/packages/storage/src/carryme_storage/history.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/packages/scoring/src/carryme_scoring/__init__.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/packages/scoring/src/carryme_scoring/funding_arb.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/tests/test_normalizers.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/tests/test_runtime.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/tests/test_scoring.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/tests/test_storage.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/tests/test_worker.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/tests/test_api.py
/Users/espejelomar/StarkNet/ai-agents-starknet/carryme/tests/test_connectors.py\n- uv run pytest\n\nCloses #107

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new API endpoint to discover canary trading opportunities across multiple venues with configurable venue selection, fee-profile overrides, and filtering thresholds (execution quality, route stability, volumes, symbols/tags, and result limit). Responses include suggested canary notional per opportunity.

* **Models**
  * Exposed a new public response model representing canary candidates with opportunity details and a non-negative suggested canary notional.

* **Tests**
  * Added tests covering the new endpoint and service behavior, including policy-default handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->