### PR TITLE
feat: add execution accounting summaries

### DIFF
--- a/apps/api/src/carryme_api/app.py
+++ b/apps/api/src/carryme_api/app.py
@@ -34,11 +34,13 @@ from carryme_models import (
     LiveSubmissionReadiness,
     OpportunityRecord,
     PairClosePreviewConfirmationEntry,
+    PaperTradeAccountingSummary,
     PaperTradeAccountPreflight,
     PaperTradeEntry,
     PaperTradeExecutionPreflight,
     PaperTradeOrderPreview,
     PreviewConfirmationEntry,
+    RouteAccountingSummary,
     RouteStabilitySummary,
     ServiceHealth,
     TradingFeeProfile,
@@ -53,6 +55,7 @@ from carryme_runtime import (
     CleanupLiveExecutionRouter,
     CleanupPreviewRouter,
     ConnectorError,
+    ExecutionAccountingService,
     ExecutionAdapter,
     ExecutionOrderStateService,
     ExecutionQualityService,
@@ -443,6 +446,14 @@ def get_execution_adapter() -> ExecutionAdapter:
     """Return the default explicitly simulated execution adapter."""
 
     return MockExecutionAdapter()
+
+
+def get_execution_accounting_service(
+    store: Annotated[ExecutionJournalStore, Depends(get_execution_journal_store)],
+) -> ExecutionAccountingService:
+    """Return the derived execution accounting service."""
+
+    return ExecutionAccountingService(journal_store=store)
 
 
 def get_paradex_live_execution_service(
@@ -3456,6 +3467,41 @@ def create_app() -> FastAPI:
             short_venue=short_venue,
             long_venue=long_venue,
             min_sample_size=min_sample_size,
+            limit=limit,
+        )
+
+    @app.get(
+        "/v1/executions/accounting/latest/from-paper-trade/{paper_trade_id}",
+        response_model=PaperTradeAccountingSummary,
+    )
+    async def execution_accounting_for_paper_trade(
+        paper_trade_id: int,
+        service: Annotated[
+            ExecutionAccountingService, Depends(get_execution_accounting_service)
+        ],
+    ) -> PaperTradeAccountingSummary:
+        summary = service.latest_for_paper_trade(paper_trade_id)
+        if summary is None:
+            raise HTTPException(status_code=404, detail="No execution accounting found")
+        return summary
+
+    @app.get(
+        "/v1/executions/accounting/routes",
+        response_model=list[RouteAccountingSummary],
+    )
+    async def execution_accounting_routes(
+        service: Annotated[
+            ExecutionAccountingService, Depends(get_execution_accounting_service)
+        ],
+        canonical_symbol: str | None = None,
+        label: str | None = None,
+        limit: int = 50,
+    ) -> list[RouteAccountingSummary]:
+        if limit < 0:
+            raise HTTPException(status_code=400, detail="limit must be non-negative")
+        return service.list_route_summaries(
+            canonical_symbol=canonical_symbol,
+            label=label,
             limit=limit,
         )
 

--- a/packages/models/src/carryme_models/__init__.py
+++ b/packages/models/src/carryme_models/__init__.py
@@ -4,6 +4,12 @@ from carryme_models.account_preflight import (
     PaperTradeAccountPreflight,
     VenueAccountPreflight,
 )
+from carryme_models.accounting import (
+    ExecutionAccountingSummary,
+    ExecutionLegAccounting,
+    PaperTradeAccountingSummary,
+    RouteAccountingSummary,
+)
 from carryme_models.confirmation import (
     CleanupPreviewConfirmationEntry,
     PairClosePreviewConfirmationEntry,
@@ -70,8 +76,10 @@ __all__ = [
     "ExecutionAlertEvent",
     "CleanupPreviewConfirmationEntry",
     "CredentialRequirementStatus",
+    "ExecutionAccountingSummary",
     "ExecutionPairClosePreview",
     "ExecutionJournalEntry",
+    "ExecutionLegAccounting",
     "ExecutionLegResult",
     "ExecutionLegOrderState",
     "ExecutionObservationEntry",
@@ -99,6 +107,7 @@ __all__ = [
     "NormalizedMarketSnapshot",
     "OpportunityRecord",
     "PaperTradeAccountPreflight",
+    "PaperTradeAccountingSummary",
     "PaperTradeEntry",
     "PaperTradeExecutionPreflight",
     "ExecutionCleanupPreview",
@@ -111,6 +120,7 @@ __all__ = [
     "TradeLegIntent",
     "TradingFeeProfile",
     "RouteStabilitySummary",
+    "RouteAccountingSummary",
     "VenueAccountPreflight",
     "VenueExecutionPreflight",
     "VenueOrderPreview",

--- a/packages/models/src/carryme_models/accounting.py
+++ b/packages/models/src/carryme_models/accounting.py
@@ -1,0 +1,72 @@
+"""Execution accounting models."""
+
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+
+class ExecutionLegAccounting(BaseModel):
+    """Derived fill and fee accounting for one executed leg."""
+
+    venue: str = Field(min_length=1)
+    symbol: str = Field(min_length=1)
+    fee_profile: str = Field(min_length=1)
+    side: Literal["buy", "sell"]
+    status: Literal["accepted", "rejected", "submitted", "partial"]
+    auth_usage: str | None = None
+    derived_fill_state: Literal["filled", "partial_fill", "unfilled", "unknown"]
+    filled_size: float | None = Field(default=None, ge=0)
+    avg_fill_price: float | None = Field(default=None, ge=0)
+    filled_notional: float | None = Field(default=None, ge=0)
+    estimated_fee_rate: float | None = Field(default=None, ge=0)
+    estimated_fee_paid: float | None = Field(default=None, ge=0)
+    notes: list[str] = Field(default_factory=list)
+
+
+class ExecutionAccountingSummary(BaseModel):
+    """Derived accounting summary for one journaled execution entry."""
+
+    execution_entry_id: int | None = None
+    paper_trade_id: int | None = None
+    label: str = Field(min_length=1)
+    canonical_symbol: str = Field(min_length=1)
+    adapter: str = Field(min_length=1)
+    mode: Literal["mock", "live"]
+    status: Literal["accepted", "rejected", "submitted", "partial"]
+    executed_at: datetime
+    total_leg_count: int = Field(ge=0)
+    filled_leg_count: int = Field(ge=0)
+    total_filled_notional: float = Field(ge=0)
+    total_estimated_fee_paid: float = Field(ge=0)
+    legs: list[ExecutionLegAccounting] = Field(default_factory=list)
+    notes: list[str] = Field(default_factory=list)
+
+
+class PaperTradeAccountingSummary(BaseModel):
+    """Aggregated accounting summary across all execution entries for one paper trade."""
+
+    paper_trade_id: int
+    label: str = Field(min_length=1)
+    canonical_symbol: str = Field(min_length=1)
+    execution_count: int = Field(ge=0)
+    latest_executed_at: datetime | None = None
+    total_filled_notional: float = Field(ge=0)
+    total_estimated_fee_paid: float = Field(ge=0)
+    entries: list[ExecutionAccountingSummary] = Field(default_factory=list)
+
+
+class RouteAccountingSummary(BaseModel):
+    """Aggregated accounting across execution history for one route label."""
+
+    label: str = Field(min_length=1)
+    canonical_symbol: str = Field(min_length=1)
+    short_venue: str = Field(min_length=1)
+    long_venue: str = Field(min_length=1)
+    short_fee_profile: str = Field(min_length=1)
+    long_fee_profile: str = Field(min_length=1)
+    execution_count: int = Field(ge=0)
+    paper_trade_count: int = Field(ge=0)
+    latest_executed_at: datetime | None = None
+    total_filled_notional: float = Field(ge=0)
+    total_estimated_fee_paid: float = Field(ge=0)

--- a/packages/runtime/src/carryme_runtime/__init__.py
+++ b/packages/runtime/src/carryme_runtime/__init__.py
@@ -17,6 +17,7 @@ from carryme_runtime.confirmation import (
     require_confirmed_preview,
 )
 from carryme_runtime.execution import ExecutionAdapter, MockExecutionAdapter
+from carryme_runtime.execution_accounting import ExecutionAccountingService
 from carryme_runtime.execution_order_state import (
     ExecutionOrderStateService,
     ExtendedOrderStateObserver,
@@ -64,6 +65,7 @@ __all__ = [
     "CleanupLiveExecutionRouter",
     "CleanupPreviewRouter",
     "ExecutionAdapter",
+    "ExecutionAccountingService",
     "ExecutionQualityService",
     "ExecutionOrderStateService",
     "build_execution_pair_status",

--- a/packages/runtime/src/carryme_runtime/execution_accounting.py
+++ b/packages/runtime/src/carryme_runtime/execution_accounting.py
@@ -1,0 +1,238 @@
+"""Derived execution accounting from journaled live submissions."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Literal
+
+from carryme_connectors.base import parse_float
+from carryme_models import (
+    ExecutionAccountingSummary,
+    ExecutionJournalEntry,
+    ExecutionLegAccounting,
+    PaperTradeAccountingSummary,
+    RouteAccountingSummary,
+)
+from carryme_normalizers import get_fee_profile
+from carryme_storage import ExecutionJournalStore
+
+
+@dataclass
+class ExecutionAccountingService:
+    """Build derived accounting summaries from append-only execution history."""
+
+    journal_store: ExecutionJournalStore
+    sample_limit: int = 500
+
+    def summarize_entry(self, entry: ExecutionJournalEntry) -> ExecutionAccountingSummary:
+        """Return derived accounting for one journal entry."""
+
+        leg_summaries = [self._summarize_leg(leg) for leg in entry.legs]
+        total_filled_notional = sum(item.filled_notional or 0.0 for item in leg_summaries)
+        total_estimated_fee_paid = sum(item.estimated_fee_paid or 0.0 for item in leg_summaries)
+        filled_leg_count = sum(
+            1 for item in leg_summaries if item.derived_fill_state in {"filled", "partial_fill"}
+        )
+        return ExecutionAccountingSummary(
+            execution_entry_id=entry.entry_id,
+            paper_trade_id=entry.paper_trade_id,
+            label=entry.paper_trade.intent.label,
+            canonical_symbol=entry.paper_trade.intent.canonical_symbol,
+            adapter=entry.adapter,
+            mode=entry.mode,
+            status=entry.status,
+            executed_at=entry.executed_at,
+            total_leg_count=len(leg_summaries),
+            filled_leg_count=filled_leg_count,
+            total_filled_notional=total_filled_notional,
+            total_estimated_fee_paid=total_estimated_fee_paid,
+            legs=leg_summaries,
+        )
+
+    def latest_for_paper_trade(self, paper_trade_id: int) -> PaperTradeAccountingSummary | None:
+        """Return aggregated accounting for one paper trade."""
+
+        entries = self.journal_store.list_for_paper_trade(paper_trade_id, limit=self.sample_limit)
+        if not entries:
+            return None
+        return self._summarize_paper_trade(entries)
+
+    def list_route_summaries(
+        self,
+        *,
+        canonical_symbol: str | None = None,
+        label: str | None = None,
+        limit: int = 50,
+    ) -> list[RouteAccountingSummary]:
+        """Aggregate execution accounting by route label."""
+
+        entries = self.journal_store.list_recent(limit=self.sample_limit)
+        buckets: dict[tuple[str, str, str, str, str, str], list[ExecutionJournalEntry]] = {}
+        for entry in entries:
+            intent = entry.paper_trade.intent
+            if (
+                canonical_symbol
+                and intent.canonical_symbol.upper() != canonical_symbol.strip().upper()
+            ):
+                continue
+            if label and intent.label != label:
+                continue
+            key = (
+                intent.label,
+                intent.canonical_symbol,
+                intent.short_leg.venue,
+                intent.long_leg.venue,
+                intent.short_leg.fee_profile,
+                intent.long_leg.fee_profile,
+            )
+            buckets.setdefault(key, []).append(entry)
+
+        summaries: list[RouteAccountingSummary] = []
+        for key, grouped_entries in buckets.items():
+            entry_summaries = [self.summarize_entry(item) for item in grouped_entries]
+            paper_trade_ids = {
+                item.paper_trade_id
+                for item in grouped_entries
+                if item.paper_trade_id is not None
+            }
+            latest_executed_at = max(item.executed_at for item in grouped_entries)
+            summaries.append(
+                RouteAccountingSummary(
+                    label=key[0],
+                    canonical_symbol=key[1],
+                    short_venue=key[2],
+                    long_venue=key[3],
+                    short_fee_profile=key[4],
+                    long_fee_profile=key[5],
+                    execution_count=len(grouped_entries),
+                    paper_trade_count=len(paper_trade_ids),
+                    latest_executed_at=latest_executed_at,
+                    total_filled_notional=sum(
+                        item.total_filled_notional for item in entry_summaries
+                    ),
+                    total_estimated_fee_paid=sum(
+                        item.total_estimated_fee_paid for item in entry_summaries
+                    ),
+                )
+            )
+
+        ranked = sorted(
+            summaries,
+            key=lambda item: (item.total_estimated_fee_paid, item.execution_count, item.label),
+            reverse=True,
+        )
+        if limit > 0:
+            return ranked[:limit]
+        return ranked
+
+    def _summarize_paper_trade(
+        self,
+        entries: list[ExecutionJournalEntry],
+    ) -> PaperTradeAccountingSummary:
+        entry_summaries = [self.summarize_entry(item) for item in entries]
+        latest_executed_at = max((item.executed_at for item in entries), default=None)
+        first_intent = entries[0].paper_trade.intent
+        return PaperTradeAccountingSummary(
+            paper_trade_id=entries[0].paper_trade_id or 0,
+            label=first_intent.label,
+            canonical_symbol=first_intent.canonical_symbol,
+            execution_count=len(entries),
+            latest_executed_at=latest_executed_at,
+            total_filled_notional=sum(
+                item.total_filled_notional for item in entry_summaries
+            ),
+            total_estimated_fee_paid=sum(
+                item.total_estimated_fee_paid for item in entry_summaries
+            ),
+            entries=entry_summaries,
+        )
+
+    def _summarize_leg(self, leg: Any) -> ExecutionLegAccounting:
+        payload = leg.response_payload if isinstance(leg.response_payload, dict) else {}
+        fills = self._extract_fill_events(payload)
+        filled_size = sum(item["filled_size"] for item in fills) if fills else None
+        filled_notional = sum(item["filled_notional"] for item in fills) if fills else None
+        avg_fill_price = None
+        if fills and filled_size and filled_size > 0 and filled_notional is not None:
+            avg_fill_price = filled_notional / filled_size
+        fee_rate = None
+        fee_paid = None
+        notes: list[str] = []
+        try:
+            fee_rate = get_fee_profile(leg.venue, leg.fee_profile).taker_fee_rate
+        except ValueError:
+            notes.append("No known fee profile available for this leg.")
+        if fee_rate is not None and filled_notional is not None:
+            fee_paid = filled_notional * fee_rate
+        return ExecutionLegAccounting(
+            venue=leg.venue,
+            symbol=leg.symbol,
+            fee_profile=leg.fee_profile,
+            side=leg.side,
+            status=leg.status,
+            auth_usage=leg.auth_usage,
+            derived_fill_state=self._derive_fill_state(fills),
+            filled_size=filled_size,
+            avg_fill_price=avg_fill_price,
+            filled_notional=filled_notional,
+            estimated_fee_rate=fee_rate,
+            estimated_fee_paid=fee_paid,
+            notes=notes,
+        )
+
+    def _extract_fill_events(self, payload: dict[str, Any]) -> list[dict[str, float]]:
+        attempt_history = payload.get("attempt_history")
+        if isinstance(attempt_history, list):
+            events = [
+                event
+                for item in attempt_history
+                for event in self._fill_events_from_attempt(item)
+            ]
+            if events:
+                return events
+        observed = payload.get("observed_order_state")
+        if isinstance(observed, dict):
+            event = self._fill_event_from_state(observed)
+            return [event] if event is not None else []
+        return []
+
+    def _fill_events_from_attempt(self, attempt: Any) -> list[dict[str, float]]:
+        if not isinstance(attempt, dict):
+            return []
+        observed = attempt.get("observed_order_state")
+        if not isinstance(observed, dict):
+            return []
+        event = self._fill_event_from_state(observed)
+        return [event] if event is not None else []
+
+    def _fill_event_from_state(self, state: dict[str, Any]) -> dict[str, float] | None:
+        derived_state = state.get("derived_state")
+        if derived_state not in {"filled", "partial_fill"}:
+            return None
+        size = parse_float(state.get("size"))
+        remaining_size = parse_float(state.get("remaining_size"))
+        avg_fill_price = parse_float(state.get("avg_fill_price"))
+        if size is None:
+            return None
+        if derived_state == "filled":
+            filled_size = size
+        else:
+            if remaining_size is None:
+                return None
+            filled_size = max(size - remaining_size, 0.0)
+        if filled_size <= 0:
+            return None
+        if avg_fill_price is None:
+            return None
+        return {
+            "filled_size": filled_size,
+            "filled_notional": filled_size * avg_fill_price,
+        }
+
+    def _derive_fill_state(
+        self,
+        fills: list[dict[str, float]],
+    ) -> Literal["filled", "partial_fill", "unfilled", "unknown"]:
+        if not fills:
+            return "unfilled"
+        return "filled"

--- a/packages/storage/src/carryme_storage/executions.py
+++ b/packages/storage/src/carryme_storage/executions.py
@@ -424,3 +424,34 @@ class ExecutionJournalStore:
                 "entry_id": stored_id,
             }
         )
+
+    def list_for_paper_trade(
+        self,
+        paper_trade_id: int,
+        *,
+        limit: int = 100,
+    ) -> list[ExecutionJournalEntry]:
+        """Return recent execution journal entries for one paper trade."""
+
+        self.initialize()
+        with sqlite3.connect(self.database_path) as connection:
+            rows = connection.execute(
+                """
+                SELECT id, entry_json
+                FROM execution_journal_entries
+                WHERE paper_trade_id = ?
+                ORDER BY executed_at DESC, id DESC
+                LIMIT ?
+                """,
+                (paper_trade_id, limit),
+            ).fetchall()
+
+        return [
+            ExecutionJournalEntry.model_validate(
+                {
+                    **json.loads(entry_json),
+                    "entry_id": stored_id,
+                }
+            )
+            for stored_id, entry_json in rows
+        ]

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -8,6 +8,7 @@ import carryme_models as carryme_models_module
 import pytest
 from carryme_api.app import (
     app,
+    get_execution_accounting_service,
     get_execution_quality_service,
     get_history_store,
     get_opportunity_service,
@@ -19,6 +20,7 @@ from carryme_models import (
     CandidateAlertEvent,
     CapacityEstimate,
     CleanupPreviewConfirmationEntry,
+    ExecutionAccountingSummary,
     ExecutionAlertEvent,
     ExecutionCleanupPreview,
     ExecutionJournalEntry,
@@ -40,10 +42,12 @@ from carryme_models import (
     FundingUniverseScan,
     FundingUniverseVenueMarket,
     OpportunityRecord,
+    PaperTradeAccountingSummary,
     PaperTradeAccountPreflight,
     PaperTradeEntry,
     PaperTradeOrderPreview,
     PreviewConfirmationEntry,
+    RouteAccountingSummary,
     RouteStabilitySummary,
     TradeLegIntent,
     VenueAccountPreflight,
@@ -603,6 +607,99 @@ def test_route_stability_endpoint_uses_service_dependency() -> None:
     assert payload[0]["stability_weight"] == 0.6
     assert captured["min_sample_size"] == 2
     assert captured["min_presence_ratio"] == 0.5
+
+
+def test_execution_accounting_latest_endpoint_uses_service_dependency() -> None:
+    class StubAccountingService:
+        def latest_for_paper_trade(self, paper_trade_id: int) -> PaperTradeAccountingSummary | None:
+            assert paper_trade_id == 7
+            return PaperTradeAccountingSummary(
+                paper_trade_id=7,
+                label="arb_extended_paradex",
+                canonical_symbol="ARB-USD-PERP",
+                execution_count=2,
+                latest_executed_at=datetime(2026, 3, 29, 13, 10, tzinfo=UTC),
+                total_filled_notional=21.31,
+                total_estimated_fee_paid=0.004262,
+                entries=[
+                    ExecutionAccountingSummary(
+                        execution_entry_id=12,
+                        paper_trade_id=7,
+                        label="arb_extended_paradex",
+                        canonical_symbol="ARB-USD-PERP",
+                        adapter="paradex_cleanup_live",
+                        mode="live",
+                        status="submitted",
+                        executed_at=datetime(2026, 3, 29, 13, 10, tzinfo=UTC),
+                        total_leg_count=1,
+                        filled_leg_count=1,
+                        total_filled_notional=21.31,
+                        total_estimated_fee_paid=0.004262,
+                        legs=[],
+                        notes=[],
+                    )
+                ],
+            )
+
+    app.dependency_overrides[get_execution_accounting_service] = (
+        lambda: StubAccountingService()
+    )
+    client = TestClient(app)
+
+    response = client.get("/v1/executions/accounting/latest/from-paper-trade/7")
+
+    app.dependency_overrides.clear()
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["paper_trade_id"] == 7
+    assert payload["total_estimated_fee_paid"] == 0.004262
+
+
+def test_execution_accounting_routes_endpoint_uses_service_dependency() -> None:
+    class StubAccountingService:
+        def list_route_summaries(
+            self,
+            *,
+            canonical_symbol: str | None = None,
+            label: str | None = None,
+            limit: int = 50,
+        ) -> list[RouteAccountingSummary]:
+            assert canonical_symbol == "ARB-USD-PERP"
+            assert label is None
+            assert limit == 5
+            return [
+                RouteAccountingSummary(
+                    label="arb_extended_paradex",
+                    canonical_symbol="ARB-USD-PERP",
+                    short_venue="extended",
+                    long_venue="paradex",
+                    short_fee_profile="default",
+                    long_fee_profile="pro",
+                    execution_count=3,
+                    paper_trade_count=1,
+                    latest_executed_at=datetime(2026, 3, 29, 13, 10, tzinfo=UTC),
+                    total_filled_notional=42.0,
+                    total_estimated_fee_paid=0.0084,
+                )
+            ]
+
+    app.dependency_overrides[get_execution_accounting_service] = (
+        lambda: StubAccountingService()
+    )
+    client = TestClient(app)
+
+    response = client.get(
+        "/v1/executions/accounting/routes",
+        params=[("canonical_symbol", "ARB-USD-PERP"), ("limit", "5")],
+    )
+
+    app.dependency_overrides.clear()
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload[0]["label"] == "arb_extended_paradex"
+    assert payload[0]["total_estimated_fee_paid"] == 0.0084
 
 
 def test_route_stability_service_provider_uses_shared_history_store(tmp_path: Path) -> None:

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -17,8 +17,10 @@ from carryme_connectors import (
 from carryme_models import (
     CapacityEstimate,
     CleanupPreviewConfirmationEntry,
+    ExecutionAccountingSummary,
     ExecutionCleanupPreview,
     ExecutionJournalEntry,
+    ExecutionLegAccounting,
     ExecutionLegOrderState,
     ExecutionLegResult,
     ExecutionObservationEntry,
@@ -40,11 +42,13 @@ from carryme_models import (
     NormalizedMarketSnapshot,
     OpportunityRecord,
     PairClosePreviewConfirmationEntry,
+    PaperTradeAccountingSummary,
     PaperTradeAccountPreflight,
     PaperTradeEntry,
     PaperTradeExecutionPreflight,
     PaperTradeOrderPreview,
     PreviewConfirmationEntry,
+    RouteAccountingSummary,
     RouteStabilitySummary,
     TopOfBook,
     TradeLegIntent,
@@ -57,6 +61,7 @@ from carryme_runtime import (
     AccountPreflightService,
     CleanupLiveExecutionRouter,
     CleanupPreviewRouter,
+    ExecutionAccountingService,
     ExtendedCleanupPreviewService,
     ExtendedLiveExecutionService,
     HyperliquidCleanupPreviewService,
@@ -10596,6 +10601,103 @@ def test_cleanup_live_execution_router_rejects_mismatched_trade_or_non_reduce_on
             )
 
     asyncio.run(run())
+
+
+def test_execution_accounting_service_summarizes_filled_attempt_history(tmp_path: Path) -> None:
+    store = ExecutionJournalStore(tmp_path / "history.sqlite3")
+    paper_trade = PaperTradeEntry(
+        entry_id=7,
+        created_at=datetime(2026, 3, 29, 13, 0, tzinfo=UTC),
+        intent=FundingPairTradeIntent(
+            label="arb_extended_paradex",
+            canonical_symbol="ARB-USD-PERP",
+            source_recorded_at=datetime(2026, 3, 29, 12, 55, tzinfo=UTC),
+            one_day_net_edge_after_entry=0.0005,
+            break_even_days_entry=0.5,
+            capacity_limit_notional=4500.0,
+            target_notional=11.0,
+            capacity_fraction=0.25,
+            max_target_notional=11.0,
+            long_leg=TradeLegIntent(
+                venue="paradex",
+                symbol="ARB-USD-PERP",
+                fee_profile="pro",
+                side="buy",
+                target_notional=11.0,
+            ),
+            short_leg=TradeLegIntent(
+                venue="extended",
+                symbol="ARB-USD",
+                fee_profile="default",
+                side="sell",
+                target_notional=11.0,
+            ),
+        ),
+    )
+    saved = store.append(
+        ExecutionJournalEntry(
+            executed_at=datetime(2026, 3, 29, 13, 1, tzinfo=UTC),
+            adapter="paradex_cleanup_live",
+            mode="live",
+            status="submitted",
+            paper_trade_id=7,
+            paper_trade=paper_trade,
+            legs=[
+                ExecutionLegResult(
+                    venue="paradex",
+                    symbol="ARB-USD-PERP",
+                    fee_profile="pro",
+                    side="sell",
+                    target_notional=21.48,
+                    status="submitted",
+                    simulated=False,
+                    auth_usage="subkey_jwt",
+                    response_payload={
+                        "attempt_history": [
+                            {
+                                "observed_order_state": {
+                                    "derived_state": "unfilled",
+                                    "size": "241.9",
+                                    "remaining_size": "241.9",
+                                    "avg_fill_price": "",
+                                }
+                            },
+                            {
+                                "observed_order_state": {
+                                    "derived_state": "filled",
+                                    "size": "241.9",
+                                    "remaining_size": "0",
+                                    "avg_fill_price": "0.0881",
+                                }
+                            },
+                        ]
+                    },
+                )
+            ],
+        )
+    )
+
+    service = ExecutionAccountingService(journal_store=store)
+    summary = service.summarize_entry(saved)
+    paper_trade_summary = service.latest_for_paper_trade(7)
+    route_summaries = service.list_route_summaries(limit=10)
+
+    assert isinstance(summary, ExecutionAccountingSummary)
+    assert summary.filled_leg_count == 1
+    assert summary.total_filled_notional == pytest.approx(241.9 * 0.0881)
+    assert summary.total_estimated_fee_paid == pytest.approx((241.9 * 0.0881) * 0.0002)
+    assert isinstance(summary.legs[0], ExecutionLegAccounting)
+    assert summary.legs[0].derived_fill_state == "filled"
+    assert paper_trade_summary is not None
+    assert isinstance(paper_trade_summary, PaperTradeAccountingSummary)
+    assert paper_trade_summary.total_estimated_fee_paid == pytest.approx(
+        summary.total_estimated_fee_paid
+    )
+    assert route_summaries
+    assert isinstance(route_summaries[0], RouteAccountingSummary)
+    assert route_summaries[0].total_estimated_fee_paid == pytest.approx(
+        summary.total_estimated_fee_paid
+    )
 
 
 def test_extended_live_execution_service_rejects_cleanup_for_wrong_venue() -> None:

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -2231,3 +2231,84 @@ def test_execution_observation_store_rejects_non_positive_limits(
 
     with pytest.raises(ValueError, match="limit must be at least 1"):
         store.list_recent(limit=invalid_limit)
+
+
+def test_execution_journal_store_lists_entries_for_paper_trade(tmp_path: Path) -> None:
+    store = ExecutionJournalStore(tmp_path / "history.sqlite3")
+    paper_trade = PaperTradeEntry(
+        entry_id=7,
+        created_at=datetime(2026, 3, 29, 13, 0, tzinfo=UTC),
+        intent=FundingPairTradeIntent(
+            label="arb_extended_paradex",
+            canonical_symbol="ARB-USD-PERP",
+            source_recorded_at=datetime(2026, 3, 29, 12, 55, tzinfo=UTC),
+            one_day_net_edge_after_entry=0.0005,
+            break_even_days_entry=0.5,
+            capacity_limit_notional=4500.0,
+            target_notional=11.0,
+            capacity_fraction=0.25,
+            max_target_notional=11.0,
+            long_leg=TradeLegIntent(
+                venue="paradex",
+                symbol="ARB-USD-PERP",
+                fee_profile="pro",
+                side="buy",
+                target_notional=11.0,
+            ),
+            short_leg=TradeLegIntent(
+                venue="extended",
+                symbol="ARB-USD",
+                fee_profile="default",
+                side="sell",
+                target_notional=11.0,
+            ),
+        ),
+    )
+    store.append(
+        ExecutionJournalEntry(
+            executed_at=datetime(2026, 3, 29, 13, 1, tzinfo=UTC),
+            adapter="extended_live",
+            mode="live",
+            status="submitted",
+            paper_trade_id=7,
+            paper_trade=paper_trade,
+            legs=[
+                ExecutionLegResult(
+                    venue="extended",
+                    symbol="ARB-USD",
+                    fee_profile="default",
+                    side="sell",
+                    target_notional=11.0,
+                    status="submitted",
+                    simulated=False,
+                )
+            ],
+        )
+    )
+    store.append(
+        ExecutionJournalEntry(
+            executed_at=datetime(2026, 3, 29, 13, 2, tzinfo=UTC),
+            adapter="paradex_live",
+            mode="live",
+            status="submitted",
+            paper_trade_id=7,
+            paper_trade=paper_trade,
+            legs=[
+                ExecutionLegResult(
+                    venue="paradex",
+                    symbol="ARB-USD-PERP",
+                    fee_profile="pro",
+                    side="buy",
+                    target_notional=11.0,
+                    status="submitted",
+                    simulated=False,
+                )
+            ],
+        )
+    )
+
+    results = store.list_for_paper_trade(7, limit=10)
+
+    assert len(results) == 2
+    assert results[0].adapter == "paradex_live"
+    assert results[1].adapter == "extended_live"


### PR DESCRIPTION
## Summary
- add derived execution accounting models and runtime summaries from journaled live executions
- expose paper-trade and route-level accounting endpoints in the API
- add storage/runtime/API tests for execution accounting aggregation

## Validation
- uv run ruff check .
- uv run mypy $(find src apps packages tests -name "*.py" -type f)
- uv run pytest

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  - Added execution accounting API endpoints to retrieve execution metrics and estimated fees aggregated by paper trade and by route
  - View detailed execution summaries including filled notional, leg-level accounting data, and fee information for individual paper trades or across trading routes with optional filtering
<!-- end of auto-generated comment: release notes by coderabbit.ai -->