### PR TITLE
fix: preserve stable launch database credentials

### DIFF
--- a/apps/worker/src/carryme_worker/poller.py
+++ b/apps/worker/src/carryme_worker/poller.py
@@ -2536,7 +2536,9 @@ def _build_api_settings_from_worker_settings(settings: WorkerSettings) -> ApiSet
 
     return ApiSettings(
         environment=settings.environment,
-        database_path=settings.database_target,
+        # Keep the real URL for runtime DB access. `database_target` is redacted and
+        # only safe for summaries/logging.
+        database_path=settings.database_path,
         watchlist_path=settings.watchlist_path,
         extended_live_enabled=settings.extended_live_enabled,
         extended_api_key=settings.extended_api_key,

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -118,6 +118,7 @@ from carryme_worker.poller import (
     SystemStateObservationSummary,
     UniverseScanLoopSummary,
     UniverseScanSummary,
+    _build_api_settings_from_worker_settings,
     _build_open_hedge_auto_close_reason,
     _build_open_hedge_profit_protection_reason,
     _build_order_state_observers,
@@ -494,6 +495,17 @@ def test_worker_database_target_redacts_urls() -> None:
 
     assert settings.database_target == redact_database_url(settings.database_path)
     assert settings.database_target == "postgresql+psycopg://***@db.example.com/carryme"
+
+
+def test_build_api_settings_from_worker_settings_keeps_unredacted_database_url() -> None:
+    settings = WorkerSettings(
+        database_path="postgresql+psycopg://user:secret@db.example.com/carryme"
+    )
+
+    api_settings = _build_api_settings_from_worker_settings(settings)
+
+    assert api_settings.database_path == settings.database_path
+    assert api_settings.database_path != settings.database_target
 
 
 def test_worker_readiness_payload(tmp_path: Path) -> None:
@@ -7319,6 +7331,7 @@ def test_launch_latest_stable_canary_once_uses_worker_settings_when_api_settings
 
     async def run_stub_lifecycle(**kwargs: object) -> StubLifecycleResult:
         runtime_settings = cast(ApiSettings, kwargs["settings"])
+        assert runtime_settings.database_path == settings.database_path
         assert runtime_settings.extended_live_enabled is True
         assert runtime_settings.extended_api_key == "extended-key"
         assert runtime_settings.extended_stark_private_key == "extended-secret"

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -248,6 +248,18 @@ def _clear_worker_env(monkeypatch: pytest.MonkeyPatch) -> None:
         raising=False,
     )
     monkeypatch.delenv(
+        "CARRYME_WORKER_STABLE_CANARY_LAUNCH_RECENT_LAUNCH_WINDOW_SECONDS",
+        raising=False,
+    )
+    monkeypatch.delenv(
+        "CARRYME_WORKER_STABLE_CANARY_LAUNCH_MAX_LAUNCHES_PER_WINDOW",
+        raising=False,
+    )
+    monkeypatch.delenv(
+        "CARRYME_WORKER_STABLE_CANARY_LAUNCH_MAX_LABEL_LAUNCHES_PER_WINDOW",
+        raising=False,
+    )
+    monkeypatch.delenv(
         "CARRYME_WORKER_STABLE_CANARY_LAUNCH_MIN_EXECUTION_QUALITY_SCORE",
         raising=False,
     )


### PR DESCRIPTION
## Summary
- keep the real database URL when building API settings from worker settings
- stop stable launch from using the redacted URL at runtime
- add regression coverage for the unredacted database path

## Validation
- uv run pytest -q tests/test_worker.py -k "build_api_settings_from_worker_settings_keeps_unredacted_database_url or launch_latest_stable_canary_once_uses_worker_settings_when_api_settings_omitted" --basetemp=.pytest-tmp/stable-db-url
- uv run ruff check apps/worker/src/carryme_worker/poller.py tests/test_worker.py
- uv run mypy apps/worker/src/carryme_worker/poller.py tests/test_worker.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected database URL configuration in API operations to use the unredacted database path during runtime.

* **Tests**
  * Added test coverage to verify proper database path configuration and unredacted URL handling.
  * Enhanced test environment cleanup for launch rate configuration variables.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->