### PR TITLE
docs: add carryme production automation agent handoff

### DIFF
--- a/.codex/START_HERE.md
+++ b/.codex/START_HERE.md
@@ -12,6 +12,8 @@ This is not just an execution test. The system must hold profitable hedges long 
 
 Use Render API or dashboard to verify current status before making launch recommendations:
 
+`render.yaml` is the deployment source of truth for these service names. Keep this list aligned with `render.yaml` whenever services are added, removed, or renamed.
+
 - `carryme-api`
 - `carryme-approved-canary-scan`
 - `carryme-launch-ready-cache`

--- a/.codex/START_HERE.md
+++ b/.codex/START_HERE.md
@@ -1,0 +1,55 @@
+# Carryme Production Automation Handoff
+
+Read this before relying on memory or previous chat context.
+
+## Current Goal
+
+Make `carryme` automatically move small live funds between venues when the opportunity is real, route-approved, fresh, launchable, and safely monitorable.
+
+This is not just an execution test. The system must hold profitable hedges long enough to earn funding and must close or clean up automatically when edge decays, profit gives back, hold limits are reached, or pair state becomes unsafe.
+
+## Live Services To Verify
+
+Use Render API or dashboard to verify current status before making launch recommendations:
+
+- `carryme-api`
+- `carryme-approved-canary-scan`
+- `carryme-launch-ready-cache`
+- `carryme-stable-launch`
+- `carryme-execution-monitor`
+- `carryme-system-state`
+- `carryme-universe-scan`
+- `carryme-postgres`
+
+As of the agent handoff that introduced this file, `carryme-approved-canary-scan`, `carryme-launch-ready-cache`, and `carryme-stable-launch` were all live on merge commit `f2591db5d0caa13e8377a5be8f0df0245bd71591`. Treat this as historical context only; re-check live state before acting.
+
+## Production Blockers Being Removed
+
+Work through these in separate scoped PRs unless the user asks otherwise:
+
+1. Stable launch profit-hold mode: stable launch must be able to open and hold instead of always passing `close_position=True`.
+2. Deployment verification: `carryme-stable-launch` must exist and be live before claiming automation can move money.
+3. Launch-ready credential gate: launch-ready must fail closed when selected venues are not live-enabled or are missing required credentials.
+4. Dynamic opportunity promotion: better current routes need a safe approval/proposal path instead of being ignored because they are not statically approved.
+5. Approved-scan coverage: approved route scanning must not silently skip labels because of the default 5-label limit.
+6. Fast universe shortlist: broad scans must shortlist from lightweight market summaries before expensive orderbook snapshots.
+7. Lightweight production summaries: API list endpoints must provide bounded summary responses for operations without returning full nested snapshots.
+
+## Live-Money Defaults
+
+- Keep canary caps small until repeated hosted cycles are clean.
+- Prefer Extended + Paradex only unless Hyperliquid has been explicitly activated and tested.
+- Keep route approvals as the last authorization boundary before live submission.
+- Stable launch should fail closed unless execution monitoring and auto-close conditions are configured for held positions.
+- Never recommend scaling capital from public market data alone; require hosted evidence from launched and monitored cycles.
+
+## Fast Verification Commands
+
+```bash
+uv run ruff check .
+uv run mypy src apps packages tests
+uv run pytest -q tests/test_worker.py
+uv run pytest -q tests/test_api.py tests/test_runtime.py tests/test_storage.py
+```
+
+Prefer targeted tests while iterating, then broaden before PR handoff.

--- a/.codex/production_automation_context.json
+++ b/.codex/production_automation_context.json
@@ -1,0 +1,68 @@
+{
+  "schema_version": 1,
+  "repo": "omarespejel/carryme",
+  "project": "carryme live funding automation",
+  "goal": "automatically open, hold, monitor, and close small route-approved venue hedges when net opportunity is real and fresh",
+  "historical_live_commit": "f2591db5d0caa13e8377a5be8f0df0245bd71591",
+  "render_services": {
+    "api": "carryme-api",
+    "approved_scan": "carryme-approved-canary-scan",
+    "launch_ready_cache": "carryme-launch-ready-cache",
+    "stable_launch": "carryme-stable-launch",
+    "execution_monitor": "carryme-execution-monitor",
+    "system_state": "carryme-system-state",
+    "universe_scan": "carryme-universe-scan",
+    "database": "carryme-postgres"
+  },
+  "automation_pipeline": [
+    "route approval",
+    "approved canary scan",
+    "launch-ready cache",
+    "stable launch",
+    "execution monitor",
+    "auto close or cleanup"
+  ],
+  "known_blockers": [
+    {
+      "id": "stable-launch-profit-hold-mode",
+      "severity": "P0",
+      "summary": "stable launch currently launches via guarded canary lifecycle with close_position=true, which tests execution but does not hold for funding capture"
+    },
+    {
+      "id": "stable-launch-service-required",
+      "severity": "P0",
+      "summary": "approved-scan and launch-ready-cache only create signals; carryme-stable-launch must be deployed and live for unattended submissions"
+    },
+    {
+      "id": "launch-ready-credential-gate",
+      "severity": "P1",
+      "summary": "launch-ready should fail closed when touched venues are not live-enabled or missing live credentials"
+    },
+    {
+      "id": "dynamic-opportunity-promotion",
+      "severity": "P1",
+      "summary": "automation only launches pre-approved static routes; stronger current routes need a safe proposal or approval path"
+    },
+    {
+      "id": "approved-scan-coverage",
+      "severity": "P1",
+      "summary": "default approved_canary_scan_limit=5 can skip approved labels silently when more labels exist"
+    },
+    {
+      "id": "fast-universe-shortlist",
+      "severity": "P1",
+      "summary": "universe scan fetches expensive snapshots for all overlaps before applying result limit"
+    },
+    {
+      "id": "lightweight-production-summaries",
+      "severity": "P2",
+      "summary": "operator list endpoints return full nested snapshots and can trigger large responses or 502s"
+    }
+  ],
+  "agent_rules": [
+    "verify live Render/API state before making current go/no-go claims",
+    "prefer fail-closed behavior for missing credentials, stale data, and ambiguous route identity",
+    "add tests before behavior changes when practical",
+    "do not widen live-money risk without explicit PR body disclosure"
+  ]
+}

--- a/.codex/production_automation_context.json
+++ b/.codex/production_automation_context.json
@@ -4,6 +4,7 @@
   "project": "carryme live funding automation",
   "goal": "automatically open, hold, monitor, and close small route-approved venue hedges when net opportunity is real and fresh",
   "historical_live_commit": "f2591db5d0caa13e8377a5be8f0df0245bd71591",
+  "render_source_of_truth": "render.yaml",
   "render_services": {
     "api": "carryme-api",
     "approved_scan": "carryme-approved-canary-scan",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,30 @@
+# Codex Agent Instructions
+
+This repository is the `carryme` live funding-arbitrage control plane. Before changing code, read `.codex/START_HERE.md` and treat it as the active agent handoff for production automation work.
+
+## Safety Rules
+
+- Do not submit live-money changes without tests that cover the launch or close path being changed.
+- Do not remove live-execution guards to make a trade go through faster.
+- Do not widen notional caps, cooldowns, or approval scope without calling it out in the PR body.
+- Do not assume a route is profitable because a raw funding edge is positive; account for fees, slippage, liquidity, launch freshness, and execution-monitor close behavior.
+- Prefer fail-closed behavior for missing credentials, stale snapshots, unknown venue status, missing monitor state, or ambiguous route approvals.
+
+## Production Pipeline
+
+The hosted production path is split across Render workers:
+
+1. `carryme-approved-canary-scan` refreshes approved live route snapshots.
+2. `carryme-launch-ready-cache` converts fresh approved snapshots into launch-ready snapshots after launch gates pass.
+3. `carryme-stable-launch` launches the latest stable launch-ready route.
+4. `carryme-execution-monitor` observes live executions and applies close/cleanup automation when enabled.
+
+For automated profit capture, all four stages must be healthy. A green scan/cache stage does not mean money will move.
+
+## PR Discipline
+
+- Keep branches scoped to one production risk or capability.
+- Use TDD for behavior changes: add or update failing tests first, then implement.
+- Run at least the targeted test file and `uv run ruff check .` before pushing.
+- For broad launch/monitor changes, also run `uv run mypy src apps packages tests` when practical.
+- Include exact validation commands and any skipped checks in the PR body.


### PR DESCRIPTION
## Summary
- add a repo-level `AGENTS.md` for Codex safety and production PR discipline
- add `.codex/START_HERE.md` as the first-read handoff for carryme production automation work
- add `.codex/production_automation_context.json` with structured service, pipeline, blocker, and agent-rule context

## Why
Future Codex agents need a checked-in source of truth before continuing the live-money automation work. The handoff makes the current production goal, Render service pipeline, and seven known blockers explicit so follow-up PRs do not rely on stale chat memory.

## Validation
- `python -m json.tool .codex/production_automation_context.json`
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv sync --frozen --all-packages`
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run ruff check .`

## Notes
- The existing `.venv/bin/python3` in this checkout points to a Homebrew Python symlink that exits with status 1, so validation used a fresh local `.venv-codex` environment.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a "start here" handoff document outlining operational steps, verification commands, and defaults for live-money automation.
  * Added a production automation context describing pipeline stages, service roles, known blockers with severities, and agent rules for failing-closed and risk disclosure.
  * Introduced repository-level agent operating guidance, safety constraints, and testing/PR discipline for production automation changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->