### PR TITLE
test: verify render stable launch service

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
   "carryme-runtime",
   "carryme-scoring",
   "carryme-storage",
+  "PyYAML>=6.0,<7",
 ]
 
 [project.scripts]
@@ -54,6 +55,7 @@ dev = [
   "mypy>=1.18,<2",
   "pytest>=8.4,<9",
   "ruff>=0.12,<0.13",
+  "types-PyYAML>=6.0,<7",
 ]
 
 [tool.ruff]

--- a/src/carryme_dev/render.py
+++ b/src/carryme_dev/render.py
@@ -5,10 +5,12 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
 import signal
 import threading
 from collections.abc import Iterator, Mapping
 from contextlib import contextmanager
+from pathlib import Path
 
 from carryme_api.config import ApiSettings
 from carryme_storage.db import Database, redact_database_url
@@ -19,6 +21,39 @@ REQUIRED_RENDER_ENV_VARS = (
     "CARRYME_API_ENVIRONMENT",
     "CARRYME_WORKER_ENVIRONMENT",
 )
+
+REQUIRED_RENDER_DATABASES = ("carryme-postgres",)
+
+REQUIRED_RENDER_SERVICE_SPECS: dict[str, dict[str, str]] = {
+    "carryme-api": {
+        "type": "web",
+        "start_command": "uv run carryme-api",
+    },
+    "carryme-universe-scan": {
+        "type": "worker",
+        "start_command": "uv run carryme-worker --scan-universe-supervise",
+    },
+    "carryme-approved-canary-scan": {
+        "type": "worker",
+        "start_command": "uv run carryme-worker --scan-approved-canary-supervise",
+    },
+    "carryme-launch-ready-cache": {
+        "type": "worker",
+        "start_command": "uv run carryme-worker --cache-launch-ready-canary-supervise",
+    },
+    "carryme-stable-launch": {
+        "type": "worker",
+        "start_command": "uv run carryme-worker --launch-latest-stable-canary-supervise",
+    },
+    "carryme-system-state": {
+        "type": "worker",
+        "start_command": "uv run carryme-worker --observe-system-state-supervise",
+    },
+    "carryme-execution-monitor": {
+        "type": "worker",
+        "start_command": "uv run carryme-worker --observe-executions-supervise",
+    },
+}
 
 LIVE_VENUE_ENV_VARS: dict[str, tuple[str, tuple[str, ...]]] = {
     "extended": (
@@ -63,6 +98,94 @@ def _paradex_missing_env(resolved_env: Mapping[str, str]) -> list[str]:
     ):
         missing.append("CARRYME_API_PARADEX_PRIVATE_KEY|CARRYME_API_PARADEX_BEARER_TOKEN")
     return missing
+
+
+def _parse_render_services(blueprint_text: str) -> dict[str, dict[str, str]]:
+    """Extract the Render service name/type/start command without a YAML dependency."""
+
+    services: dict[str, dict[str, str]] = {}
+    for block in re.split(r"\n(?=\s{2}- type:)", blueprint_text):
+        service_type_match = re.search(r"^\s*-\s*type:\s*(?P<value>\S+)\s*$", block, re.M)
+        name_match = re.search(r"^\s+name:\s*(?P<value>\S+)\s*$", block, re.M)
+        if service_type_match is None or name_match is None:
+            continue
+        start_command_match = re.search(
+            r"^\s+startCommand:\s*(?P<value>.+?)\s*$",
+            block,
+            re.M,
+        )
+        services[name_match.group("value")] = {
+            "type": service_type_match.group("value"),
+            "start_command": (
+                start_command_match.group("value").strip("'\"")
+                if start_command_match is not None
+                else ""
+            ),
+        }
+    return services
+
+
+def build_render_blueprint_validation_report(
+    blueprint_path: str | Path = "render.yaml",
+) -> dict[str, object]:
+    """Validate that the checked-in Render blueprint contains every production stage."""
+
+    path = Path(blueprint_path)
+    if not path.is_file():
+        return {
+            "status": "degraded",
+            "path": str(path),
+            "missing_databases": list(REQUIRED_RENDER_DATABASES),
+            "missing_services": list(REQUIRED_RENDER_SERVICE_SPECS),
+            "invalid_services": [],
+        }
+
+    blueprint_text = path.read_text()
+    services = _parse_render_services(blueprint_text)
+    missing_databases = [
+        name
+        for name in REQUIRED_RENDER_DATABASES
+        if re.search(rf"^\s*-\s*name:\s*{re.escape(name)}\s*$", blueprint_text, re.M)
+        is None
+    ]
+    missing_services = [
+        name for name in REQUIRED_RENDER_SERVICE_SPECS if name not in services
+    ]
+    invalid_services: list[dict[str, str]] = []
+    for name, spec in REQUIRED_RENDER_SERVICE_SPECS.items():
+        service = services.get(name)
+        if service is None:
+            continue
+        if service["type"] != spec["type"]:
+            invalid_services.append(
+                {
+                    "name": name,
+                    "field": "type",
+                    "expected": spec["type"],
+                    "actual": service["type"],
+                }
+            )
+        if spec["start_command"] not in service["start_command"]:
+            invalid_services.append(
+                {
+                    "name": name,
+                    "field": "startCommand",
+                    "expected": spec["start_command"],
+                    "actual": service["start_command"],
+                }
+            )
+
+    return {
+        "status": (
+            "ready"
+            if not missing_databases and not missing_services and not invalid_services
+            else "degraded"
+        ),
+        "path": str(path),
+        "missing_databases": missing_databases,
+        "missing_services": missing_services,
+        "invalid_services": invalid_services,
+    }
 
 
 @contextmanager
@@ -131,6 +254,7 @@ def build_render_validation_report(
     *,
     ping_database: bool = True,
     database_ping_timeout_seconds: float = DEFAULT_DATABASE_PING_TIMEOUT_SECONDS,
+    blueprint_path: str | Path | None = "render.yaml",
 ) -> dict[str, object]:
     """Validate the current environment for Render-style deployment."""
 
@@ -207,6 +331,12 @@ def build_render_validation_report(
         database_ready = None
         database_skipped = True
 
+    blueprint_report = (
+        build_render_blueprint_validation_report(blueprint_path)
+        if blueprint_path is not None
+        else {"status": "skipped"}
+    )
+
     status = "ready"
     if (
         missing_required
@@ -215,6 +345,7 @@ def build_render_validation_report(
         or worker_error is not None
         or live_missing
         or (database_ready is False)
+        or blueprint_report["status"] == "degraded"
     ):
         status = "degraded"
 
@@ -241,6 +372,7 @@ def build_render_validation_report(
             "error": worker_error,
         },
         "live_venues": live_venues,
+        "render_blueprint": blueprint_report,
     }
 
 

--- a/src/carryme_dev/render.py
+++ b/src/carryme_dev/render.py
@@ -6,12 +6,14 @@ import argparse
 import json
 import os
 import re
+import shlex
 import signal
 import threading
 from collections.abc import Iterator, Mapping
 from contextlib import contextmanager
 from pathlib import Path
 
+import yaml
 from carryme_api.config import ApiSettings
 from carryme_storage.db import Database, redact_database_url
 from carryme_worker.config import WorkerSettings
@@ -100,29 +102,68 @@ def _paradex_missing_env(resolved_env: Mapping[str, str]) -> list[str]:
     return missing
 
 
-def _parse_render_services(blueprint_text: str) -> dict[str, dict[str, str]]:
-    """Extract the Render service name/type/start command without a YAML dependency."""
+def _discover_render_blueprint_path(start: Path | None = None) -> Path | None:
+    """Search the current directory and parents for the repo Render blueprint."""
+
+    current = (start or Path.cwd()).resolve()
+    for directory in (current, *current.parents):
+        candidate = directory / "render.yaml"
+        if candidate.is_file():
+            return candidate
+    return None
+
+
+def _load_render_blueprint(blueprint_path: str | Path) -> dict[str, object]:
+    """Load one Render blueprint from YAML and normalize to a mapping."""
+
+    path = Path(blueprint_path)
+    loaded = yaml.safe_load(path.read_text())
+    if not isinstance(loaded, dict):
+        raise ValueError("render blueprint must be a top-level mapping")
+    return loaded
+
+
+def _parse_render_services(blueprint: Mapping[str, object]) -> dict[str, dict[str, str]]:
+    """Extract service name, type, and start command from a parsed Render blueprint."""
+
+    services_raw = blueprint.get("services")
+    if not isinstance(services_raw, list):
+        return {}
 
     services: dict[str, dict[str, str]] = {}
-    for block in re.split(r"\n(?=\s{2}- type:)", blueprint_text):
-        service_type_match = re.search(r"^\s*-\s*type:\s*(?P<value>\S+)\s*$", block, re.M)
-        name_match = re.search(r"^\s+name:\s*(?P<value>\S+)\s*$", block, re.M)
-        if service_type_match is None or name_match is None:
+    for service_raw in services_raw:
+        if not isinstance(service_raw, Mapping):
             continue
-        start_command_match = re.search(
-            r"^\s+startCommand:\s*(?P<value>.+?)\s*$",
-            block,
-            re.M,
-        )
-        services[name_match.group("value")] = {
-            "type": service_type_match.group("value"),
-            "start_command": (
-                start_command_match.group("value").strip("'\"")
-                if start_command_match is not None
-                else ""
-            ),
+        name = service_raw.get("name")
+        service_type = service_raw.get("type")
+        start_command = service_raw.get("startCommand", "")
+        if not isinstance(name, str) or not isinstance(service_type, str):
+            continue
+        services[name] = {
+            "type": service_type,
+            "start_command": start_command if isinstance(start_command, str) else "",
         }
     return services
+
+
+def _command_executes_expected(*, service_type: str, actual: str, expected: str) -> bool:
+    """Return whether one Render start command executes the required command."""
+
+    expected_tokens = shlex.split(expected)
+    actual_tokens = shlex.split(actual)
+
+    if service_type == "worker":
+        return actual_tokens == expected_tokens
+
+    if actual_tokens == expected_tokens:
+        return True
+
+    if len(actual_tokens) >= 3 and actual_tokens[0] == "sh" and actual_tokens[1] == "-c":
+        script = actual_tokens[2]
+        for segment in re.split(r"\s*(?:&&|\|\||;)\s*", script):
+            if shlex.split(segment) == expected_tokens:
+                return True
+    return False
 
 
 def build_render_blueprint_validation_report(
@@ -140,13 +181,21 @@ def build_render_blueprint_validation_report(
             "invalid_services": [],
         }
 
-    blueprint_text = path.read_text()
-    services = _parse_render_services(blueprint_text)
+    blueprint = _load_render_blueprint(path)
+    services = _parse_render_services(blueprint)
+    databases_raw = blueprint.get("databases")
+    database_names: set[str] = set()
+    if isinstance(databases_raw, list):
+        for entry in databases_raw:
+            if not isinstance(entry, Mapping):
+                continue
+            name = entry.get("name")
+            if isinstance(name, str):
+                database_names.add(name)
     missing_databases = [
         name
         for name in REQUIRED_RENDER_DATABASES
-        if re.search(rf"^\s*-\s*name:\s*{re.escape(name)}\s*$", blueprint_text, re.M)
-        is None
+        if name not in database_names
     ]
     missing_services = [
         name for name in REQUIRED_RENDER_SERVICE_SPECS if name not in services
@@ -165,7 +214,11 @@ def build_render_blueprint_validation_report(
                     "actual": service["type"],
                 }
             )
-        if spec["start_command"] not in service["start_command"]:
+        if not _command_executes_expected(
+            service_type=spec["type"],
+            actual=service["start_command"],
+            expected=spec["start_command"],
+        ):
             invalid_services.append(
                 {
                     "name": name,
@@ -254,7 +307,7 @@ def build_render_validation_report(
     *,
     ping_database: bool = True,
     database_ping_timeout_seconds: float = DEFAULT_DATABASE_PING_TIMEOUT_SECONDS,
-    blueprint_path: str | Path | None = "render.yaml",
+    blueprint_path: str | Path | None = None,
 ) -> dict[str, object]:
     """Validate the current environment for Render-style deployment."""
 
@@ -331,10 +384,19 @@ def build_render_validation_report(
         database_ready = None
         database_skipped = True
 
-    blueprint_report = (
-        build_render_blueprint_validation_report(blueprint_path)
+    effective_blueprint_path = (
+        Path(blueprint_path)
         if blueprint_path is not None
-        else {"status": "skipped"}
+        else _discover_render_blueprint_path()
+    )
+    blueprint_report = (
+        build_render_blueprint_validation_report(effective_blueprint_path)
+        if effective_blueprint_path is not None
+        else {
+            "status": "skipped",
+            "path": None,
+            "reason": "render.yaml not found from current working directory",
+        }
     )
 
     status = "ready"

--- a/tests/test_render_validate.py
+++ b/tests/test_render_validate.py
@@ -2,7 +2,10 @@ from pathlib import Path
 from typing import Any, cast
 from unittest.mock import patch
 
-from carryme_dev.render import build_render_validation_report
+from carryme_dev.render import (
+    build_render_blueprint_validation_report,
+    build_render_validation_report,
+)
 
 
 def test_render_validation_requires_database_url() -> None:
@@ -17,6 +20,48 @@ def test_render_validation_requires_database_url() -> None:
         ],
         "warnings": [],
     }
+    assert cast(dict[str, Any], report["render_blueprint"])["status"] == "ready"
+
+
+def test_render_blueprint_requires_all_production_services() -> None:
+    report = build_render_blueprint_validation_report()
+
+    assert report == {
+        "status": "ready",
+        "path": "render.yaml",
+        "missing_databases": [],
+        "missing_services": [],
+        "invalid_services": [],
+    }
+
+
+def test_render_blueprint_flags_missing_stable_launch(tmp_path: Path) -> None:
+    blueprint = tmp_path / "render.yaml"
+    blueprint.write_text(
+        """
+databases:
+  - name: carryme-postgres
+
+services:
+  - type: web
+    name: carryme-api
+    startCommand: uv run carryme-api
+  - type: worker
+    name: carryme-approved-canary-scan
+    startCommand: uv run carryme-worker --scan-approved-canary-supervise
+  - type: worker
+    name: carryme-launch-ready-cache
+    startCommand: uv run carryme-worker --cache-launch-ready-canary-supervise
+  - type: worker
+    name: carryme-execution-monitor
+    startCommand: uv run carryme-worker --observe-executions-supervise
+""".lstrip()
+    )
+
+    report = build_render_blueprint_validation_report(blueprint)
+
+    assert report["status"] == "degraded"
+    assert "carryme-stable-launch" in cast(list[str], report["missing_services"])
 
 
 def test_render_validation_accepts_sqlite_database_url_for_smoke(tmp_path: Path) -> None:

--- a/tests/test_render_validate.py
+++ b/tests/test_render_validate.py
@@ -1,3 +1,4 @@
+import os
 from pathlib import Path
 from typing import Any, cast
 from unittest.mock import patch
@@ -62,6 +63,77 @@ services:
 
     assert report["status"] == "degraded"
     assert "carryme-stable-launch" in cast(list[str], report["missing_services"])
+
+
+def test_render_blueprint_rejects_worker_start_command_substring_matches(tmp_path: Path) -> None:
+    blueprint = tmp_path / "render.yaml"
+    blueprint.write_text(
+        """
+databases:
+  - name: carryme-postgres
+
+services:
+  - type: web
+    name: carryme-api
+    startCommand: sh -c 'uv run alembic upgrade head && uv run carryme-api'
+  - type: worker
+    name: carryme-universe-scan
+    startCommand: uv run carryme-worker --scan-universe-supervise
+  - type: worker
+    name: carryme-approved-canary-scan
+    startCommand: uv run carryme-worker --scan-approved-canary-supervise
+  - type: worker
+    name: carryme-launch-ready-cache
+    startCommand: uv run carryme-worker --cache-launch-ready-canary-supervise
+  - type: worker
+    name: carryme-stable-launch
+    startCommand: echo 'uv run carryme-worker --launch-latest-stable-canary-supervise'
+  - type: worker
+    name: carryme-system-state
+    startCommand: uv run carryme-worker --observe-system-state-supervise
+  - type: worker
+    name: carryme-execution-monitor
+    startCommand: uv run carryme-worker --observe-executions-supervise
+""".lstrip()
+    )
+
+    report = build_render_blueprint_validation_report(blueprint)
+
+    assert report["status"] == "degraded"
+    assert {
+        "name": "carryme-stable-launch",
+        "field": "startCommand",
+        "expected": "uv run carryme-worker --launch-latest-stable-canary-supervise",
+        "actual": "echo 'uv run carryme-worker --launch-latest-stable-canary-supervise'",
+    } in cast(list[dict[str, str]], report["invalid_services"])
+
+
+def test_render_validation_skips_blueprint_outside_repo(tmp_path: Path) -> None:
+    watchlist_path = Path(__file__).resolve().parents[1] / "config/watchlists/default.json"
+    original_cwd = Path.cwd()
+    try:
+        os.chdir(tmp_path)
+        report = build_render_validation_report(
+            {
+                "DATABASE_URL": f"sqlite:///{tmp_path / 'render.sqlite3'}",
+                "CARRYME_API_ENVIRONMENT": "production",
+                "CARRYME_WORKER_ENVIRONMENT": "production",
+                "CARRYME_API_EXTENDED_LIVE_ENABLED": "false",
+                "CARRYME_API_PARADEX_LIVE_ENABLED": "false",
+                "CARRYME_API_HYPERLIQUID_LIVE_ENABLED": "false",
+                "CARRYME_WORKER_WATCHLIST_PATH": str(watchlist_path),
+            },
+            blueprint_path=None,
+        )
+    finally:
+        os.chdir(original_cwd)
+
+    assert report["status"] == "ready"
+    assert report["render_blueprint"] == {
+        "status": "skipped",
+        "path": None,
+        "reason": "render.yaml not found from current working directory",
+    }
 
 
 def test_render_validation_accepts_sqlite_database_url_for_smoke(tmp_path: Path) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -168,6 +168,7 @@ dependencies = [
     { name = "carryme-scoring" },
     { name = "carryme-storage" },
     { name = "carryme-worker" },
+    { name = "pyyaml" },
 ]
 
 [package.dev-dependencies]
@@ -176,6 +177,7 @@ dev = [
     { name = "mypy" },
     { name = "pytest" },
     { name = "ruff" },
+    { name = "types-pyyaml" },
 ]
 
 [package.metadata]
@@ -189,6 +191,7 @@ requires-dist = [
     { name = "carryme-scoring", editable = "packages/scoring" },
     { name = "carryme-storage", editable = "packages/storage" },
     { name = "carryme-worker", editable = "apps/worker" },
+    { name = "pyyaml", specifier = ">=6.0,<7" },
 ]
 
 [package.metadata.requires-dev]
@@ -197,6 +200,7 @@ dev = [
     { name = "mypy", specifier = ">=1.18,<2" },
     { name = "pytest", specifier = ">=8.4,<9" },
     { name = "ruff", specifier = ">=0.12,<0.13" },
+    { name = "types-pyyaml", specifier = ">=6.0,<7" },
 ]
 
 [[package]]
@@ -659,7 +663,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ac/48/f8b875fa7dea7dd9b33245e37f065af59df6a25af2f9561efa8d822fde51/greenlet-3.3.2-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:aa6ac98bdfd716a749b84d4034486863fd81c3abde9aa3cf8eff9127981a4ae4", size = 279120, upload-time = "2026-02-20T20:19:01.9Z" },
     { url = "https://files.pythonhosted.org/packages/49/8d/9771d03e7a8b1ee456511961e1b97a6d77ae1dea4a34a5b98eee706689d3/greenlet-3.3.2-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ab0c7e7901a00bc0a7284907273dc165b32e0d109a6713babd04471327ff7986", size = 603238, upload-time = "2026-02-20T20:47:32.873Z" },
     { url = "https://files.pythonhosted.org/packages/59/0e/4223c2bbb63cd5c97f28ffb2a8aee71bdfb30b323c35d409450f51b91e3e/greenlet-3.3.2-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:d248d8c23c67d2291ffd47af766e2a3aa9fa1c6703155c099feb11f526c63a92", size = 614219, upload-time = "2026-02-20T20:55:59.817Z" },
-    { url = "https://files.pythonhosted.org/packages/94/2b/4d012a69759ac9d77210b8bfb128bc621125f5b20fc398bce3940d036b1c/greenlet-3.3.2-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ccd21bb86944ca9be6d967cf7691e658e43417782bce90b5d2faeda0ff78a7dd", size = 628268, upload-time = "2026-02-20T21:02:48.024Z" },
     { url = "https://files.pythonhosted.org/packages/7a/34/259b28ea7a2a0c904b11cd36c79b8cef8019b26ee5dbe24e73b469dea347/greenlet-3.3.2-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b6997d360a4e6a4e936c0f9625b1c20416b8a0ea18a8e19cabbefc712e7397ab", size = 616774, upload-time = "2026-02-20T20:21:02.454Z" },
     { url = "https://files.pythonhosted.org/packages/0a/03/996c2d1689d486a6e199cb0f1cf9e4aa940c500e01bdf201299d7d61fa69/greenlet-3.3.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:64970c33a50551c7c50491671265d8954046cb6e8e2999aacdd60e439b70418a", size = 1571277, upload-time = "2026-02-20T20:49:34.795Z" },
     { url = "https://files.pythonhosted.org/packages/d9/c4/2570fc07f34a39f2caf0bf9f24b0a1a0a47bc2e8e465b2c2424821389dfc/greenlet-3.3.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1a9172f5bf6bd88e6ba5a84e0a68afeac9dc7b6b412b245dd64f52d83c81e55b", size = 1640455, upload-time = "2026-02-20T20:21:10.261Z" },
@@ -668,7 +671,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/3f/ae/8bffcbd373b57a5992cd077cbe8858fff39110480a9d50697091faea6f39/greenlet-3.3.2-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:8d1658d7291f9859beed69a776c10822a0a799bc4bfe1bd4272bb60e62507dab", size = 279650, upload-time = "2026-02-20T20:18:00.783Z" },
     { url = "https://files.pythonhosted.org/packages/d1/c0/45f93f348fa49abf32ac8439938726c480bd96b2a3c6f4d949ec0124b69f/greenlet-3.3.2-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:18cb1b7337bca281915b3c5d5ae19f4e76d35e1df80f4ad3c1a7be91fadf1082", size = 650295, upload-time = "2026-02-20T20:47:34.036Z" },
     { url = "https://files.pythonhosted.org/packages/b3/de/dd7589b3f2b8372069ab3e4763ea5329940fc7ad9dcd3e272a37516d7c9b/greenlet-3.3.2-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c2e47408e8ce1c6f1ceea0dffcdf6ebb85cc09e55c7af407c99f1112016e45e9", size = 662163, upload-time = "2026-02-20T20:56:01.295Z" },
-    { url = "https://files.pythonhosted.org/packages/cd/ac/85804f74f1ccea31ba518dcc8ee6f14c79f73fe36fa1beba38930806df09/greenlet-3.3.2-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:e3cb43ce200f59483eb82949bf1835a99cf43d7571e900d7c8d5c62cdf25d2f9", size = 675371, upload-time = "2026-02-20T21:02:49.664Z" },
     { url = "https://files.pythonhosted.org/packages/d2/d8/09bfa816572a4d83bccd6750df1926f79158b1c36c5f73786e26dbe4ee38/greenlet-3.3.2-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:63d10328839d1973e5ba35e98cccbca71b232b14051fd957b6f8b6e8e80d0506", size = 664160, upload-time = "2026-02-20T20:21:04.015Z" },
     { url = "https://files.pythonhosted.org/packages/48/cf/56832f0c8255d27f6c35d41b5ec91168d74ec721d85f01a12131eec6b93c/greenlet-3.3.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:8e4ab3cfb02993c8cc248ea73d7dae6cec0253e9afa311c9b37e603ca9fad2ce", size = 1619181, upload-time = "2026-02-20T20:49:36.052Z" },
     { url = "https://files.pythonhosted.org/packages/0a/23/b90b60a4aabb4cec0796e55f25ffbfb579a907c3898cd2905c8918acaa16/greenlet-3.3.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:94ad81f0fd3c0c0681a018a976e5c2bd2ca2d9d94895f23e7bb1af4e8af4e2d5", size = 1687713, upload-time = "2026-02-20T20:21:11.684Z" },
@@ -677,7 +679,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/98/6d/8f2ef704e614bcf58ed43cfb8d87afa1c285e98194ab2cfad351bf04f81e/greenlet-3.3.2-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:e26e72bec7ab387ac80caa7496e0f908ff954f31065b0ffc1f8ecb1338b11b54", size = 286617, upload-time = "2026-02-20T20:19:29.856Z" },
     { url = "https://files.pythonhosted.org/packages/5e/0d/93894161d307c6ea237a43988f27eba0947b360b99ac5239ad3fe09f0b47/greenlet-3.3.2-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8b466dff7a4ffda6ca975979bab80bdadde979e29fc947ac3be4451428d8b0e4", size = 655189, upload-time = "2026-02-20T20:47:35.742Z" },
     { url = "https://files.pythonhosted.org/packages/f5/2c/d2d506ebd8abcb57386ec4f7ba20f4030cbe56eae541bc6fd6ef399c0b41/greenlet-3.3.2-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:b8bddc5b73c9720bea487b3bffdb1840fe4e3656fba3bd40aa1489e9f37877ff", size = 658225, upload-time = "2026-02-20T20:56:02.527Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/67/8197b7e7e602150938049d8e7f30de1660cfb87e4c8ee349b42b67bdb2e1/greenlet-3.3.2-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:59b3e2c40f6706b05a9cd299c836c6aa2378cabe25d021acd80f13abf81181cf", size = 666581, upload-time = "2026-02-20T21:02:51.526Z" },
     { url = "https://files.pythonhosted.org/packages/8e/30/3a09155fbf728673a1dea713572d2d31159f824a37c22da82127056c44e4/greenlet-3.3.2-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b26b0f4428b871a751968285a1ac9648944cea09807177ac639b030bddebcea4", size = 657907, upload-time = "2026-02-20T20:21:05.259Z" },
     { url = "https://files.pythonhosted.org/packages/f3/fd/d05a4b7acd0154ed758797f0a43b4c0962a843bedfe980115e842c5b2d08/greenlet-3.3.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:1fb39a11ee2e4d94be9a76671482be9398560955c9e568550de0224e41104727", size = 1618857, upload-time = "2026-02-20T20:49:37.309Z" },
     { url = "https://files.pythonhosted.org/packages/6f/e1/50ee92a5db521de8f35075b5eff060dd43d39ebd46c2181a2042f7070385/greenlet-3.3.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:20154044d9085151bc309e7689d6f7ba10027f8f5a8c0676ad398b951913d89e", size = 1680010, upload-time = "2026-02-20T20:21:13.427Z" },
@@ -1178,6 +1179,42 @@ wheels = [
 ]
 
 [[package]]
+name = "pyyaml"
+version = "6.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/11/0fd08f8192109f7169db964b5707a2f1e8b745d4e239b784a5a1dd80d1db/pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8da9669d359f02c0b91ccc01cac4a67f16afec0dac22c2ad09f46bee0697eba8", size = 181669, upload-time = "2025-09-25T21:32:23.673Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/16/95309993f1d3748cd644e02e38b75d50cbc0d9561d21f390a76242ce073f/pyyaml-6.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2283a07e2c21a2aa78d9c4442724ec1eb15f5e42a723b99cb3d822d48f5f7ad1", size = 173252, upload-time = "2025-09-25T21:32:25.149Z" },
+    { url = "https://files.pythonhosted.org/packages/50/31/b20f376d3f810b9b2371e72ef5adb33879b25edb7a6d072cb7ca0c486398/pyyaml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee2922902c45ae8ccada2c5b501ab86c36525b883eff4255313a253a3160861c", size = 767081, upload-time = "2025-09-25T21:32:26.575Z" },
+    { url = "https://files.pythonhosted.org/packages/49/1e/a55ca81e949270d5d4432fbbd19dfea5321eda7c41a849d443dc92fd1ff7/pyyaml-6.0.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a33284e20b78bd4a18c8c2282d549d10bc8408a2a7ff57653c0cf0b9be0afce5", size = 841159, upload-time = "2025-09-25T21:32:27.727Z" },
+    { url = "https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6", size = 801626, upload-time = "2025-09-25T21:32:28.878Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/11/ba845c23988798f40e52ba45f34849aa8a1f2d4af4b798588010792ebad6/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f7057c9a337546edc7973c0d3ba84ddcdf0daa14533c2065749c9075001090e6", size = 753613, upload-time = "2025-09-25T21:32:30.178Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e0/7966e1a7bfc0a45bf0a7fb6b98ea03fc9b8d84fa7f2229e9659680b69ee3/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:eda16858a3cab07b80edaf74336ece1f986ba330fdb8ee0d6c0d68fe82bc96be", size = 794115, upload-time = "2025-09-25T21:32:31.353Z" },
+    { url = "https://files.pythonhosted.org/packages/de/94/980b50a6531b3019e45ddeada0626d45fa85cbe22300844a7983285bed3b/pyyaml-6.0.3-cp313-cp313-win32.whl", hash = "sha256:d0eae10f8159e8fdad514efdc92d74fd8d682c933a6dd088030f3834bc8e6b26", size = 137427, upload-time = "2025-09-25T21:32:32.58Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c9/39d5b874e8b28845e4ec2202b5da735d0199dbe5b8fb85f91398814a9a46/pyyaml-6.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:79005a0d97d5ddabfeeea4cf676af11e647e41d81c9a7722a193022accdb6b7c", size = 154090, upload-time = "2025-09-25T21:32:33.659Z" },
+    { url = "https://files.pythonhosted.org/packages/73/e8/2bdf3ca2090f68bb3d75b44da7bbc71843b19c9f2b9cb9b0f4ab7a5a4329/pyyaml-6.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:5498cd1645aa724a7c71c8f378eb29ebe23da2fc0d7a08071d89469bf1d2defb", size = 140246, upload-time = "2025-09-25T21:32:34.663Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/8c/f4bd7f6465179953d3ac9bc44ac1a8a3e6122cf8ada906b4f96c60172d43/pyyaml-6.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:8d1fab6bb153a416f9aeb4b8763bc0f22a5586065f86f7664fc23339fc1c1fac", size = 181814, upload-time = "2025-09-25T21:32:35.712Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/9c/4d95bb87eb2063d20db7b60faa3840c1b18025517ae857371c4dd55a6b3a/pyyaml-6.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:34d5fcd24b8445fadc33f9cf348c1047101756fd760b4dacb5c3e99755703310", size = 173809, upload-time = "2025-09-25T21:32:36.789Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b5/47e807c2623074914e29dabd16cbbdd4bf5e9b2db9f8090fa64411fc5382/pyyaml-6.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:501a031947e3a9025ed4405a168e6ef5ae3126c59f90ce0cd6f2bfc477be31b7", size = 766454, upload-time = "2025-09-25T21:32:37.966Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9e/e5e9b168be58564121efb3de6859c452fccde0ab093d8438905899a3a483/pyyaml-6.0.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b3bc83488de33889877a0f2543ade9f70c67d66d9ebb4ac959502e12de895788", size = 836355, upload-time = "2025-09-25T21:32:39.178Z" },
+    { url = "https://files.pythonhosted.org/packages/88/f9/16491d7ed2a919954993e48aa941b200f38040928474c9e85ea9e64222c3/pyyaml-6.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c458b6d084f9b935061bc36216e8a69a7e293a2f1e68bf956dcd9e6cbcd143f5", size = 794175, upload-time = "2025-09-25T21:32:40.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/3f/5989debef34dc6397317802b527dbbafb2b4760878a53d4166579111411e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7c6610def4f163542a622a73fb39f534f8c101d690126992300bf3207eab9764", size = 755228, upload-time = "2025-09-25T21:32:42.084Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ce/af88a49043cd2e265be63d083fc75b27b6ed062f5f9fd6cdc223ad62f03e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5190d403f121660ce8d1d2c1bb2ef1bd05b5f68533fc5c2ea899bd15f4399b35", size = 789194, upload-time = "2025-09-25T21:32:43.362Z" },
+    { url = "https://files.pythonhosted.org/packages/23/20/bb6982b26a40bb43951265ba29d4c246ef0ff59c9fdcdf0ed04e0687de4d/pyyaml-6.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:4a2e8cebe2ff6ab7d1050ecd59c25d4c8bd7e6f400f5f82b96557ac0abafd0ac", size = 156429, upload-time = "2025-09-25T21:32:57.844Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f4/a4541072bb9422c8a883ab55255f918fa378ecf083f5b85e87fc2b4eda1b/pyyaml-6.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:93dda82c9c22deb0a405ea4dc5f2d0cda384168e466364dec6255b293923b2f3", size = 143912, upload-time = "2025-09-25T21:32:59.247Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/f9/07dd09ae774e4616edf6cda684ee78f97777bdd15847253637a6f052a62f/pyyaml-6.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:02893d100e99e03eda1c8fd5c441d8c60103fd175728e23e431db1b589cf5ab3", size = 189108, upload-time = "2025-09-25T21:32:44.377Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/78/8d08c9fb7ce09ad8c38ad533c1191cf27f7ae1effe5bb9400a46d9437fcf/pyyaml-6.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c1ff362665ae507275af2853520967820d9124984e0f7466736aea23d8611fba", size = 183641, upload-time = "2025-09-25T21:32:45.407Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/5b/3babb19104a46945cf816d047db2788bcaf8c94527a805610b0289a01c6b/pyyaml-6.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6adc77889b628398debc7b65c073bcb99c4a0237b248cacaf3fe8a557563ef6c", size = 831901, upload-time = "2025-09-25T21:32:48.83Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/cc/dff0684d8dc44da4d22a13f35f073d558c268780ce3c6ba1b87055bb0b87/pyyaml-6.0.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a80cb027f6b349846a3bf6d73b5e95e782175e52f22108cfa17876aaeff93702", size = 861132, upload-time = "2025-09-25T21:32:50.149Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/5e/f77dc6b9036943e285ba76b49e118d9ea929885becb0a29ba8a7c75e29fe/pyyaml-6.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c", size = 839261, upload-time = "2025-09-25T21:32:51.808Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/88/a9db1376aa2a228197c58b37302f284b5617f56a5d959fd1763fb1675ce6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:66e1674c3ef6f541c35191caae2d429b967b99e02040f5ba928632d9a7f0f065", size = 805272, upload-time = "2025-09-25T21:32:52.941Z" },
+    { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
 name = "regex"
 version = "2026.3.32"
 source = { registry = "https://pypi.org/simple" }
@@ -1360,6 +1397,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/11/d6/114b492226588d6ff54579d95847662fc69196bdeec318eb45393b24c192/toolz-1.1.0.tar.gz", hash = "sha256:27a5c770d068c110d9ed9323f24f1543e83b2f300a687b7891c1a6d56b697b5b", size = 52613, upload-time = "2025-10-17T04:03:21.661Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fb/12/5911ae3eeec47800503a238d971e51722ccea5feb8569b735184d5fcdbc0/toolz-1.1.0-py3-none-any.whl", hash = "sha256:15ccc861ac51c53696de0a5d6d4607f99c210739caf987b5d2054f3efed429d8", size = 58093, upload-time = "2025-10-17T04:03:20.435Z" },
+]
+
+[[package]]
+name = "types-pyyaml"
+version = "6.0.12.20260408"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/74/73/b759b1e413c31034cc01ecdfb96b38115d0ab4db55a752a3929f0cd449fd/types_pyyaml-6.0.12.20260408.tar.gz", hash = "sha256:92a73f2b8d7f39ef392a38131f76b970f8c66e4c42b3125ae872b7c93b556307", size = 17735, upload-time = "2026-04-08T04:30:50.974Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1c/f0/c391068b86abb708882c6d75a08cd7d25b2c7227dab527b3a3685a3c635b/types_pyyaml-6.0.12.20260408-py3-none-any.whl", hash = "sha256:fbc42037d12159d9c801ebfcc79ebd28335a7c13b08a4cfbc6916df78fee9384", size = 20339, upload-time = "2026-04-08T04:30:50.113Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- add Render blueprint validation for the full production service pipeline
- require `carryme-stable-launch` with `uv run carryme-worker --launch-latest-stable-canary-supervise`
- include the blueprint report in `carryme-render-validate`

## Why
The scan/cache workers can refresh signals, but they cannot move money. The stable launch worker is the actual unattended launcher, so missing or misconfigured blueprint coverage should be caught by tests and deployment validation.

## Validation
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run pytest -q tests/test_render_validate.py`
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run ruff check .`
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run mypy src apps packages tests`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Render deployment validation now includes comprehensive blueprint configuration checks. The system automatically discovers and validates service configurations, ensuring all required services are present and correctly configured with appropriate start commands. Validation reports now feature a dedicated blueprint analysis section detailing any missing or misconfigured services discovered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->