### PR TITLE
fix: gate launch-ready on live credentials

### DIFF
--- a/apps/api/src/carryme_api/config.py
+++ b/apps/api/src/carryme_api/config.py
@@ -4,7 +4,7 @@ import logging
 from functools import lru_cache
 from pathlib import Path
 
-from carryme_runtime.preflight import LIVE_EXECUTION_VENUE_SPECS
+from carryme_runtime.preflight import build_live_execution_configs, build_venue_execution_preflights
 from carryme_storage.db import redact_database_url
 from pydantic import AliasChoices, Field, SecretStr, field_validator, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
@@ -72,20 +72,14 @@ class ApiSettings(BaseSettings):
     def warn_on_enabled_live_execution_without_credentials(self) -> "ApiSettings":
         """Warn operators when live execution flags are enabled without credentials."""
 
-        for spec in LIVE_EXECUTION_VENUE_SPECS.values():
-            flag_name = spec["enabled_setting"]
-            if not getattr(self, flag_name):
+        for status in build_venue_execution_preflights(build_live_execution_configs(self)):
+            if not status.enabled:
                 continue
-            missing = [
-                attribute_name
-                for attribute_name in spec["credential_settings"].values()
-                if not getattr(self, attribute_name)
-            ]
-            if missing:
+            if status.missing_env_vars:
                 logger.warning(
-                    "%s is enabled but missing live credentials: %s",
-                    flag_name,
-                    ", ".join(missing),
+                    "%s_live_enabled is enabled but missing live credentials: %s",
+                    status.venue,
+                    ", ".join(status.missing_env_vars),
                 )
         return self
 

--- a/apps/worker/src/carryme_worker/poller.py
+++ b/apps/worker/src/carryme_worker/poller.py
@@ -1256,10 +1256,14 @@ async def _probe_candidate_system_state(
         item.venue: item
         for item in await service.probe_venues(_build_system_state_configs(settings))
     }
-    selected = [all_statuses[venue] for venue in _candidate_execution_venue_names(candidate)]
-
+    selected: list[VenueSystemState] = []
     blocking_reasons: list[str] = []
-    for status in selected:
+    for venue in _candidate_execution_venue_names(candidate):
+        status = all_statuses.get(venue)
+        if status is None:
+            blocking_reasons.append(f"Venue {venue} system state is unknown")
+            continue
+        selected.append(status)
         blocking_reasons.extend(status.blocking_reasons)
 
     return PaperTradeSystemState(

--- a/apps/worker/src/carryme_worker/poller.py
+++ b/apps/worker/src/carryme_worker/poller.py
@@ -45,11 +45,13 @@ from carryme_models import (
     PaperTradeAccountPreflight,
     PaperTradeBalanceAttribution,
     PaperTradeEntry,
+    PaperTradeExecutionPreflight,
     PaperTradeSystemState,
     RouteApprovalEntry,
     StableCanaryLaunchRecord,
     StableLaunchReadyAlertEvent,
     SystemStateAlertEvent,
+    VenueExecutionPreflight,
     VenueSystemState,
 )
 from carryme_runtime import (
@@ -72,8 +74,10 @@ from carryme_runtime import (
     UpstreamDataError,
     build_account_preflight_configs,
     build_execution_pair_status,
+    build_live_execution_configs,
     build_opportunity_record_from_universe_opportunity,
     build_pair_spec_from_universe_opportunity,
+    build_venue_execution_preflights,
     filter_candidate_records,
     reconcile_execution,
 )
@@ -1188,6 +1192,57 @@ def _build_system_state_configs(settings: WorkerSettings) -> SystemStateConfigMa
     }
 
 
+def _candidate_execution_venue_names(candidate: FundingUniverseCanaryCandidate) -> list[str]:
+    """Return de-duplicated venue names touched by a canary candidate."""
+
+    venue_names = [
+        candidate.opportunity.opportunity.long_venue,
+        candidate.opportunity.opportunity.short_venue,
+    ]
+    selected_names: list[str] = []
+    for venue in venue_names:
+        if venue not in selected_names:
+            selected_names.append(venue)
+    return selected_names
+
+
+def _build_candidate_live_execution_preflight(
+    *,
+    settings: WorkerSettings,
+    candidate: FundingUniverseCanaryCandidate,
+    label: str,
+) -> PaperTradeExecutionPreflight:
+    """Build live-execution readiness for the exact venues touched by one canary."""
+
+    all_statuses = {
+        item.venue: item
+        for item in build_venue_execution_preflights(build_live_execution_configs(settings))
+    }
+    selected: list[VenueExecutionPreflight] = []
+    blocking_reasons: list[str] = []
+    for venue in _candidate_execution_venue_names(candidate):
+        status = all_statuses.get(venue)
+        if status is None:
+            blocking_reasons.append(f"Venue {venue} live execution is not configured")
+            continue
+        selected.append(status)
+        if not status.enabled:
+            blocking_reasons.append(f"Venue {venue} live execution is not enabled")
+        if status.missing_env_vars:
+            blocking_reasons.append(
+                f"Venue {venue} is missing required credentials: "
+                + ", ".join(status.missing_env_vars)
+            )
+
+    return PaperTradeExecutionPreflight(
+        paper_trade_id=0,
+        label=label,
+        ready=not blocking_reasons,
+        venues=selected,
+        blocking_reasons=blocking_reasons,
+    )
+
+
 async def _probe_candidate_system_state(
     *,
     settings: WorkerSettings,
@@ -1201,15 +1256,7 @@ async def _probe_candidate_system_state(
         item.venue: item
         for item in await service.probe_venues(_build_system_state_configs(settings))
     }
-    venue_names = [
-        candidate.opportunity.opportunity.long_venue,
-        candidate.opportunity.opportunity.short_venue,
-    ]
-    selected_names: list[str] = []
-    for venue in venue_names:
-        if venue not in selected_names:
-            selected_names.append(venue)
-    selected = [all_statuses[venue] for venue in selected_names]
+    selected = [all_statuses[venue] for venue in _candidate_execution_venue_names(candidate)]
 
     blocking_reasons: list[str] = []
     for status in selected:
@@ -2368,6 +2415,18 @@ async def cache_launch_ready_canaries_once(
                     label,
                     automation_gate_reason,
                 )
+            continue
+        execution_preflight = _build_candidate_live_execution_preflight(
+            settings=settings,
+            candidate=refreshed_candidate,
+            label=label,
+        )
+        if not execution_preflight.ready:
+            loop_logger.debug(
+                "skipping launch-ready snapshot label=%s because live execution is not ready: %s",
+                label,
+                "; ".join(execution_preflight.blocking_reasons),
+            )
             continue
         system_state = await _probe_candidate_system_state(
             settings=settings,

--- a/apps/worker/src/carryme_worker/poller.py
+++ b/apps/worker/src/carryme_worker/poller.py
@@ -2426,6 +2426,7 @@ async def cache_launch_ready_canaries_once(
             label=label,
         )
         if not execution_preflight.ready:
+            ready_store.delete_label(label)
             loop_logger.warning(
                 "skipping launch-ready snapshot label=%s because live execution is not ready: %s",
                 label,

--- a/apps/worker/src/carryme_worker/poller.py
+++ b/apps/worker/src/carryme_worker/poller.py
@@ -2422,7 +2422,7 @@ async def cache_launch_ready_canaries_once(
             label=label,
         )
         if not execution_preflight.ready:
-            loop_logger.debug(
+            loop_logger.warning(
                 "skipping launch-ready snapshot label=%s because live execution is not ready: %s",
                 label,
                 "; ".join(execution_preflight.blocking_reasons),

--- a/apps/worker/src/carryme_worker/poller.py
+++ b/apps/worker/src/carryme_worker/poller.py
@@ -1208,7 +1208,7 @@ def _candidate_execution_venue_names(candidate: FundingUniverseCanaryCandidate) 
 
 def _build_candidate_live_execution_preflight(
     *,
-    settings: WorkerSettings,
+    settings: WorkerSettings | ApiSettings,
     candidate: FundingUniverseCanaryCandidate,
     label: str,
 ) -> PaperTradeExecutionPreflight:
@@ -2426,7 +2426,14 @@ async def cache_launch_ready_canaries_once(
             label=label,
         )
         if not execution_preflight.ready:
-            ready_store.delete_label(label)
+            try:
+                ready_store.delete_label(label)
+            except Exception:
+                loop_logger.exception(
+                    "failed to invalidate launch-ready snapshots for label=%s "
+                    "after live execution preflight failure",
+                    label,
+                )
             loop_logger.warning(
                 "skipping launch-ready snapshot label=%s because live execution is not ready: %s",
                 label,
@@ -3007,6 +3014,32 @@ async def launch_latest_stable_canary_once(
             launch_ready_snapshot_id=snapshot.launch_ready_snapshot_id,
             approved_snapshot_id=snapshot.approved_snapshot.snapshot_id,
             detail=hold_mode_blocker,
+        )
+
+    execution_preflight = _build_candidate_live_execution_preflight(
+        settings=runtime_settings,
+        candidate=selected,
+        label=snapshot.label,
+    )
+    if not execution_preflight.ready:
+        try:
+            launch_ready_store.delete_label(snapshot.label)
+        except Exception:
+            logging.getLogger("carryme.worker").exception(
+                "failed to invalidate launch-ready snapshots for label=%s "
+                "during stable launch preflight",
+                snapshot.label,
+            )
+        return StableCanaryLaunchSummary(
+            status="skipped",
+            database_path=settings.database_target,
+            label=snapshot.label,
+            launch_ready_snapshot_id=snapshot.launch_ready_snapshot_id,
+            approved_snapshot_id=snapshot.approved_snapshot.snapshot_id,
+            detail=(
+                "Latest launch-ready snapshot no longer satisfies live execution "
+                f"readiness: {'; '.join(execution_preflight.blocking_reasons)}"
+            ),
         )
 
     try:

--- a/docs/deploy/render.md
+++ b/docs/deploy/render.md
@@ -69,9 +69,8 @@ Before you host this, rotate any venue secrets that were ever pasted into chat o
 
 1. `CARRYME_API_PARADEX_LIVE_ENABLED=true`
 2. `CARRYME_API_PARADEX_ACCOUNT_ADDRESS`
-3. One of:
-   - `CARRYME_API_PARADEX_PRIVATE_KEY`
-   - `CARRYME_API_PARADEX_BEARER_TOKEN`
+3. `CARRYME_API_PARADEX_PRIVATE_KEY` for live trading and cleanup submission
+4. optional `CARRYME_API_PARADEX_BEARER_TOKEN` only for authenticated read-only probes; it does not satisfy live execution readiness
 
 ### Hyperliquid
 
@@ -143,8 +142,8 @@ Use this to avoid over-sharing secrets across workers:
 | `CARRYME_API_EXTENDED_API_KEY` | if API live actions enabled | yes | yes | yes | no |
 | `CARRYME_API_EXTENDED_STARK_PRIVATE_KEY` | if API live actions enabled | yes | yes | yes | no |
 | `CARRYME_API_PARADEX_ACCOUNT_ADDRESS` | if API live actions enabled | yes | yes | yes | no |
-| `CARRYME_API_PARADEX_PRIVATE_KEY` | if using subkey auth | if using subkey auth | if using subkey auth | if using subkey auth | no |
-| `CARRYME_API_PARADEX_BEARER_TOKEN` | if using bearer-token auth | if using bearer-token auth | if using bearer-token auth | if using bearer-token auth | no |
+| `CARRYME_API_PARADEX_PRIVATE_KEY` | if API live actions enabled | yes | yes | yes | no |
+| `CARRYME_API_PARADEX_BEARER_TOKEN` | optional for authenticated read-only API/account probes | no | no | no | no |
 | `CARRYME_API_HYPERLIQUID_ACCOUNT_ADDRESS` | if API live actions enabled | yes | yes | yes | no |
 | `CARRYME_API_HYPERLIQUID_VAULT_ADDRESS` | optional | optional | optional | optional | no |
 | `CARRYME_API_HYPERLIQUID_API_WALLET_PRIVATE_KEY` | if API live actions enabled | yes | yes | yes | no |
@@ -225,6 +224,7 @@ Enable only `Extended` and `Paradex` first.
 3. keep `CARRYME_API_HYPERLIQUID_LIVE_ENABLED=false`
 4. add only the `Extended` and `Paradex` secrets to:
    - `carryme-api`
+   - `carryme-launch-ready-cache`
    - `carryme-stable-launch`
    - `carryme-execution-monitor`
 5. leave `Hyperliquid` out until the hosted `Extended/Paradex` loop proves stable

--- a/docs/deploy/render.md
+++ b/docs/deploy/render.md
@@ -69,8 +69,9 @@ Before you host this, rotate any venue secrets that were ever pasted into chat o
 
 1. `CARRYME_API_PARADEX_LIVE_ENABLED=true`
 2. `CARRYME_API_PARADEX_ACCOUNT_ADDRESS`
-3. `CARRYME_API_PARADEX_PRIVATE_KEY`
-4. Optional: `CARRYME_API_PARADEX_BEARER_TOKEN`
+3. One of:
+   - `CARRYME_API_PARADEX_PRIVATE_KEY`
+   - `CARRYME_API_PARADEX_BEARER_TOKEN`
 
 ### Hyperliquid
 
@@ -106,12 +107,16 @@ Do not put webhook URLs in the shared group either. Alert endpoints are service-
 
 ### Per-Service Matrix
 
+`carryme-launch-ready-cache` needs selected-venue live credential env vars for
+readiness checks only. It does not submit orders, but it must fail closed before
+stable launch if a route cannot be executed by the hosted workers.
+
 | Service | Needs `DATABASE_URL` | Needs venue enable flags | Needs live trading secrets | Needs alert webhooks |
 |---|---|---|---|---|
 | `carryme-api` | yes | yes | all venue secrets if you want operator-triggered live actions from the API | no |
 | `carryme-universe-scan` | yes | no | no | no |
 | `carryme-approved-canary-scan` | yes | yes | no | `CARRYME_WORKER_APPROVED_CANARY_ALERT_WEBHOOK_URL` (service-level secret only) |
-| `carryme-launch-ready-cache` | yes | yes | no | `CARRYME_WORKER_STABLE_LAUNCH_READY_ALERT_WEBHOOK_URL` (service-level secret only) |
+| `carryme-launch-ready-cache` | yes | yes | yes, for selected-route readiness checks | `CARRYME_WORKER_STABLE_LAUNCH_READY_ALERT_WEBHOOK_URL` (service-level secret only) |
 | `carryme-stable-launch` | yes | yes | yes, for the venues you intend to launch live on | no |
 | `carryme-system-state` | yes | no | no | `CARRYME_WORKER_SYSTEM_STATE_ALERT_WEBHOOK_URL` (service-level secret only) |
 | `carryme-execution-monitor` | yes | yes | yes, for the venues you intend to reconcile live on | `CARRYME_WORKER_EXECUTION_ALERT_WEBHOOK_URL` (service-level secret only) |
@@ -133,16 +138,16 @@ The worker fails closed if hold mode is requested while auto-close is disabled o
 
 Use this to avoid over-sharing secrets across workers:
 
-| Secret | `carryme-api` | `carryme-stable-launch` | `carryme-execution-monitor` | Other workers |
-|---|---|---|---|---|
-| `CARRYME_API_EXTENDED_API_KEY` | if API live actions enabled | yes | yes | no |
-| `CARRYME_API_EXTENDED_STARK_PRIVATE_KEY` | if API live actions enabled | yes | yes | no |
-| `CARRYME_API_PARADEX_ACCOUNT_ADDRESS` | if API live actions enabled | yes | yes | no |
-| `CARRYME_API_PARADEX_PRIVATE_KEY` | if API live actions enabled | yes | yes | no |
-| `CARRYME_API_PARADEX_BEARER_TOKEN` | optional | optional | optional | no |
-| `CARRYME_API_HYPERLIQUID_ACCOUNT_ADDRESS` | if API live actions enabled | yes | yes | no |
-| `CARRYME_API_HYPERLIQUID_VAULT_ADDRESS` | optional | optional | optional | no |
-| `CARRYME_API_HYPERLIQUID_API_WALLET_PRIVATE_KEY` | if API live actions enabled | yes | yes | no |
+| Secret | `carryme-api` | `carryme-launch-ready-cache` | `carryme-stable-launch` | `carryme-execution-monitor` | Other workers |
+|---|---|---|---|---|---|
+| `CARRYME_API_EXTENDED_API_KEY` | if API live actions enabled | yes | yes | yes | no |
+| `CARRYME_API_EXTENDED_STARK_PRIVATE_KEY` | if API live actions enabled | yes | yes | yes | no |
+| `CARRYME_API_PARADEX_ACCOUNT_ADDRESS` | if API live actions enabled | yes | yes | yes | no |
+| `CARRYME_API_PARADEX_PRIVATE_KEY` | if using subkey auth | if using subkey auth | if using subkey auth | if using subkey auth | no |
+| `CARRYME_API_PARADEX_BEARER_TOKEN` | if using bearer-token auth | if using bearer-token auth | if using bearer-token auth | if using bearer-token auth | no |
+| `CARRYME_API_HYPERLIQUID_ACCOUNT_ADDRESS` | if API live actions enabled | yes | yes | yes | no |
+| `CARRYME_API_HYPERLIQUID_VAULT_ADDRESS` | optional | optional | optional | optional | no |
+| `CARRYME_API_HYPERLIQUID_API_WALLET_PRIVATE_KEY` | if API live actions enabled | yes | yes | yes | no |
 
 ## Health and Readiness
 

--- a/packages/runtime/src/carryme_runtime/preflight.py
+++ b/packages/runtime/src/carryme_runtime/preflight.py
@@ -32,6 +32,7 @@ class RequirementSpec(NamedTuple):
     env_var: str
     description: str
     secret: bool
+    alternative_keys: tuple[str, ...] = ()
 
 
 class VenueSpec(TypedDict):
@@ -76,6 +77,7 @@ LIVE_EXECUTION_VENUE_SPECS: dict[str, VenueSpec] = {
         "credential_settings": {
             "account_address": "paradex_account_address",
             "private_key": "paradex_private_key",
+            "bearer_token": "paradex_bearer_token",
         },
         "requirements": [
             RequirementSpec(
@@ -86,9 +88,13 @@ LIVE_EXECUTION_VENUE_SPECS: dict[str, VenueSpec] = {
             ),
             RequirementSpec(
                 "private_key",
-                "CARRYME_API_PARADEX_PRIVATE_KEY",
-                "Paradex trading subkey private key used to derive authenticated API access.",
+                "CARRYME_API_PARADEX_PRIVATE_KEY|CARRYME_API_PARADEX_BEARER_TOKEN",
+                (
+                    "Paradex trading subkey private key or pre-issued bearer token used "
+                    "for authenticated API access."
+                ),
                 True,
+                ("bearer_token",),
             ),
         ],
         "notes": [
@@ -163,7 +169,10 @@ def build_venue_execution_preflights(
                 env_var=requirement.env_var,
                 description=requirement.description,
                 secret=requirement.secret,
-                present=bool(credentials.get(requirement.key)),
+                present=any(
+                    bool(credentials.get(key))
+                    for key in (requirement.key, *requirement.alternative_keys)
+                ),
             )
             for requirement in spec["requirements"]
         ]

--- a/packages/runtime/src/carryme_runtime/preflight.py
+++ b/packages/runtime/src/carryme_runtime/preflight.py
@@ -44,6 +44,16 @@ class VenueSpec(TypedDict):
     notes: list[str]
 
 
+def _credential_value_present(value: object) -> bool:
+    """Return whether one credential value should count as present."""
+
+    if value is None:
+        return False
+    if isinstance(value, str):
+        return bool(value.strip())
+    return bool(value)
+
+
 LIVE_EXECUTION_VENUE_SPECS: dict[str, VenueSpec] = {
     "extended": {
         "enabled_setting": "extended_live_enabled",
@@ -88,19 +98,15 @@ LIVE_EXECUTION_VENUE_SPECS: dict[str, VenueSpec] = {
             ),
             RequirementSpec(
                 "private_key",
-                "CARRYME_API_PARADEX_PRIVATE_KEY|CARRYME_API_PARADEX_BEARER_TOKEN",
-                (
-                    "Paradex trading subkey private key or pre-issued bearer token used "
-                    "for authenticated API access."
-                ),
+                "CARRYME_API_PARADEX_PRIVATE_KEY",
+                "Paradex trading subkey private key used for authenticated live trading.",
                 True,
-                ("bearer_token",),
             ),
         ],
         "notes": [
             (
                 "Paradex live trading requires the main account address and the "
-                "trading subkey private key used for authenticated API access."
+                "trading subkey private key used for authenticated live trading."
             ),
         ],
     },
@@ -170,7 +176,7 @@ def build_venue_execution_preflights(
                 description=requirement.description,
                 secret=requirement.secret,
                 present=any(
-                    bool(credentials.get(key))
+                    _credential_value_present(credentials.get(key))
                     for key in (requirement.key, *requirement.alternative_keys)
                 ),
             )

--- a/packages/storage/src/carryme_storage/launch_ready_canaries.py
+++ b/packages/storage/src/carryme_storage/launch_ready_canaries.py
@@ -115,3 +115,17 @@ class LaunchReadyCanaryStore:
 
         snapshots = self.list_recent(limit=1, label=label)
         return snapshots[0] if snapshots else None
+
+    def delete_label(self, label: str) -> int:
+        """Delete all launch-ready canary snapshots for one label."""
+
+        self.initialize()
+        with self.database.begin() as connection:
+            result = connection.execute(
+                """
+                DELETE FROM launch_ready_canary_snapshots
+                WHERE label = ?
+                """,
+                (label,),
+            )
+        return int(getattr(result, "rowcount", 0) or 0)

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -4659,7 +4659,7 @@ def test_build_venue_execution_preflights_reports_missing_credentials() -> None:
     assert paradex.missing_env_vars == []
 
 
-def test_build_venue_execution_preflights_accepts_paradex_bearer_token() -> None:
+def test_build_venue_execution_preflights_requires_paradex_private_key() -> None:
     statuses = build_venue_execution_preflights(
         {
             "extended": {
@@ -4689,13 +4689,51 @@ def test_build_venue_execution_preflights_accepts_paradex_bearer_token() -> None
 
     paradex = {status.venue: status for status in statuses}["paradex"]
 
-    assert paradex.ready is True
-    assert paradex.missing_env_vars == []
+    assert paradex.ready is False
+    assert paradex.missing_env_vars == ["CARRYME_API_PARADEX_PRIVATE_KEY"]
     assert any(
-        requirement.env_var
-        == "CARRYME_API_PARADEX_PRIVATE_KEY|CARRYME_API_PARADEX_BEARER_TOKEN"
-        and requirement.present
+        requirement.env_var == "CARRYME_API_PARADEX_PRIVATE_KEY"
+        and not requirement.present
         for requirement in paradex.requirements
+    )
+
+
+def test_build_venue_execution_preflights_treats_whitespace_credentials_as_missing() -> None:
+    statuses = build_venue_execution_preflights(
+        {
+            "extended": {
+                "enabled": True,
+                "credentials": {
+                    "api_key": "   ",
+                    "stark_private_key": "0x123",
+                },
+            },
+            "paradex": {
+                "enabled": False,
+                "credentials": {
+                    "account_address": None,
+                    "private_key": None,
+                    "bearer_token": None,
+                },
+            },
+            "hyperliquid": {
+                "enabled": False,
+                "credentials": {
+                    "account_address": None,
+                    "api_wallet_private_key": None,
+                },
+            },
+        }
+    )
+
+    extended = {status.venue: status for status in statuses}["extended"]
+
+    assert extended.ready is False
+    assert extended.missing_env_vars == ["CARRYME_API_EXTENDED_API_KEY"]
+    assert any(
+        requirement.env_var == "CARRYME_API_EXTENDED_API_KEY"
+        and not requirement.present
+        for requirement in extended.requirements
     )
 
 

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -4659,6 +4659,46 @@ def test_build_venue_execution_preflights_reports_missing_credentials() -> None:
     assert paradex.missing_env_vars == []
 
 
+def test_build_venue_execution_preflights_accepts_paradex_bearer_token() -> None:
+    statuses = build_venue_execution_preflights(
+        {
+            "extended": {
+                "enabled": False,
+                "credentials": {
+                    "api_key": None,
+                    "stark_private_key": None,
+                },
+            },
+            "paradex": {
+                "enabled": True,
+                "credentials": {
+                    "account_address": "0xabc",
+                    "private_key": None,
+                    "bearer_token": "jwt-token",
+                },
+            },
+            "hyperliquid": {
+                "enabled": False,
+                "credentials": {
+                    "account_address": None,
+                    "api_wallet_private_key": None,
+                },
+            },
+        }
+    )
+
+    paradex = {status.venue: status for status in statuses}["paradex"]
+
+    assert paradex.ready is True
+    assert paradex.missing_env_vars == []
+    assert any(
+        requirement.env_var
+        == "CARRYME_API_PARADEX_PRIVATE_KEY|CARRYME_API_PARADEX_BEARER_TOKEN"
+        and requirement.present
+        for requirement in paradex.requirements
+    )
+
+
 def test_build_paper_trade_execution_preflight_filters_to_trade_venues() -> None:
     intent = build_trade_intent(
         OpportunityRecord(

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -2971,6 +2971,7 @@ def test_cache_launch_ready_canaries_once_saves_fresh_ready_snapshots(
         launch_ready_canary_max_snapshot_age_seconds=300,
         extended_live_enabled=True,
         extended_api_key="extended-key",
+        extended_stark_private_key="0x123",
         paradex_live_enabled=True,
         paradex_account_address="0xabc",
         paradex_bearer_token="token",
@@ -3084,6 +3085,153 @@ def test_cache_launch_ready_canaries_once_saves_fresh_ready_snapshots(
     assert snapshots[0].approved_snapshot.approval.max_live_notional == 11.0
     assert snapshots[0].approved_snapshot.candidate.suggested_canary_notional == 11.0
     assert snapshots[0].system_state.ready is True
+
+
+def _append_launch_ready_gate_approved_snapshot(
+    settings: WorkerSettings,
+    *,
+    label: str = "arb_extended_paradex",
+) -> ApprovedCanaryStore:
+    approval_store = RouteApprovalStore(settings.database_path)
+    approval = approval_store.upsert(
+        RouteApprovalEntry(
+            updated_at=datetime(2026, 3, 29, 20, 0, tzinfo=UTC),
+            label=label,
+            canonical_symbol="ARB-USD-PERP",
+            short_venue="extended",
+            long_venue="paradex",
+            short_fee_profile="default",
+            long_fee_profile="pro_fastfills",
+            approved=True,
+            max_live_notional=11.0,
+            note="approved canary",
+        )
+    )
+    approved_store = ApprovedCanaryStore(settings.database_path)
+    approved_store.append(
+        ApprovedCanarySnapshot(
+            captured_at=datetime(2026, 3, 29, 20, 5, tzinfo=UTC),
+            label=label,
+            candidate=FundingUniverseCanaryCandidate(
+                opportunity=FundingUniverseOpportunity(
+                    opportunity=FundingArbOpportunity(
+                        canonical_symbol="ARB-USD-PERP",
+                        long_venue="paradex",
+                        short_venue="extended",
+                        long_fee_profile="pro_fastfills",
+                        short_fee_profile="default",
+                        gross_daily_edge=0.004,
+                        entry_cost_rate=0.00045,
+                        round_trip_cost_rate=0.0009,
+                        one_day_net_edge_after_entry=0.00355,
+                        one_day_net_edge_after_round_trip=0.0031,
+                        break_even_days_entry=0.2,
+                        break_even_days_round_trip=0.3,
+                        capacity=CapacityEstimate(
+                            short_bid_notional=1400.0,
+                            long_ask_notional=900.0,
+                            max_entry_notional=900.0,
+                            limiting_venue="paradex",
+                        ),
+                    ),
+                    venue_markets={
+                        "extended": FundingUniverseVenueMarket(
+                            venue="extended",
+                            symbol="ARB-USD",
+                        ),
+                        "paradex": FundingUniverseVenueMarket(
+                            venue="paradex",
+                            symbol="ARB-USD-PERP",
+                        ),
+                    },
+                    deployable_notional=900.0,
+                    estimated_one_day_pnl_after_round_trip=2.79,
+                ),
+                suggested_canary_notional=25.0,
+            ),
+            approval=approval,
+        )
+    )
+    return approved_store
+
+
+def test_cache_launch_ready_canaries_once_skips_selected_disabled_live_execution_venue(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    settings = WorkerSettings(
+        database_path=str(tmp_path / "history.sqlite3"),
+        launch_ready_canary_max_snapshot_age_seconds=300,
+        extended_live_enabled=True,
+        extended_api_key="extended-key",
+        extended_stark_private_key="0x123",
+        paradex_live_enabled=False,
+        paradex_account_address="0xabc",
+        paradex_bearer_token="token",
+    )
+    approved_store = _append_launch_ready_gate_approved_snapshot(settings)
+
+    class FailingSystemStateService:
+        async def probe_venues(self, configs: dict[str, dict[str, bool]]) -> list[VenueSystemState]:
+            _ = configs
+            raise AssertionError("system-state probe should not run before credential gate passes")
+
+    launch_ready_store = LaunchReadyCanaryStore(settings.database_path)
+    with caplog.at_level(logging.DEBUG):
+        summary = asyncio.run(
+            cache_launch_ready_canaries_once(
+                settings,
+                approved_store=approved_store,
+                launch_ready_store=launch_ready_store,
+                system_state_service=cast(Any, FailingSystemStateService()),
+                now=datetime(2026, 3, 29, 20, 6, tzinfo=UTC),
+            )
+        )
+
+    assert summary.scanned_snapshots == 1
+    assert summary.launch_ready_candidates == 0
+    assert summary.saved_snapshots == 0
+    assert launch_ready_store.list_recent(limit=10, label="arb_extended_paradex") == []
+    assert "Venue paradex live execution is not enabled" in caplog.text
+
+
+def test_cache_launch_ready_canaries_once_skips_selected_missing_live_execution_credentials(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    settings = WorkerSettings(
+        database_path=str(tmp_path / "history.sqlite3"),
+        launch_ready_canary_max_snapshot_age_seconds=300,
+        extended_live_enabled=True,
+        extended_api_key="extended-key",
+        paradex_live_enabled=True,
+        paradex_account_address="0xabc",
+        paradex_bearer_token="token",
+    )
+    approved_store = _append_launch_ready_gate_approved_snapshot(settings)
+
+    class FailingSystemStateService:
+        async def probe_venues(self, configs: dict[str, dict[str, bool]]) -> list[VenueSystemState]:
+            _ = configs
+            raise AssertionError("system-state probe should not run before credential gate passes")
+
+    launch_ready_store = LaunchReadyCanaryStore(settings.database_path)
+    with caplog.at_level(logging.DEBUG):
+        summary = asyncio.run(
+            cache_launch_ready_canaries_once(
+                settings,
+                approved_store=approved_store,
+                launch_ready_store=launch_ready_store,
+                system_state_service=cast(Any, FailingSystemStateService()),
+                now=datetime(2026, 3, 29, 20, 6, tzinfo=UTC),
+            )
+        )
+
+    assert summary.scanned_snapshots == 1
+    assert summary.launch_ready_candidates == 0
+    assert summary.saved_snapshots == 0
+    assert launch_ready_store.list_recent(limit=10, label="arb_extended_paradex") == []
+    assert "CARRYME_API_EXTENDED_STARK_PRIVATE_KEY" in caplog.text
 
 
 def test_cache_launch_ready_canaries_once_skips_decayed_approved_snapshot_chain(
@@ -3443,6 +3591,7 @@ def test_cache_launch_ready_canaries_once_emits_stable_launch_ready_available_al
         stable_launch_ready_min_stable_seconds=30.0,
         extended_live_enabled=True,
         extended_api_key="extended-key",
+        extended_stark_private_key="0x123",
         paradex_live_enabled=True,
         paradex_account_address="0xabc",
         paradex_bearer_token="token",

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -8405,7 +8405,9 @@ def test_launch_latest_stable_canary_once_ignores_unselected_live_credentials(
 
 def test_launch_latest_stable_canary_once_rechecks_live_execution_readiness(
     tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    _clear_worker_env(monkeypatch)
     settings = WorkerSettings(
         database_path=str(tmp_path / "history.sqlite3"),
         extended_live_enabled=True,

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -3310,6 +3310,88 @@ def test_cache_launch_ready_canaries_once_skips_selected_missing_live_execution_
     assert "CARRYME_API_EXTENDED_STARK_PRIVATE_KEY" in caplog.text
 
 
+def test_cache_launch_ready_canaries_once_invalidates_existing_snapshot_when_unready(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _clear_worker_env(monkeypatch)
+    database_path = str(tmp_path / "history.sqlite3")
+    ready_settings = WorkerSettings(
+        database_path=database_path,
+        launch_ready_canary_max_snapshot_age_seconds=300,
+        extended_live_enabled=True,
+        extended_api_key="extended-key",
+        extended_stark_private_key="0x123",
+        paradex_live_enabled=True,
+        paradex_account_address="0xabc",
+        paradex_private_key="token",
+    )
+    approved_store = _append_launch_ready_gate_approved_snapshot(ready_settings)
+
+    class StubSystemStateService:
+        async def probe_venues(self, configs: dict[str, dict[str, bool]]) -> list[VenueSystemState]:
+            _ = configs
+            return [
+                VenueSystemState(
+                    venue="extended",
+                    enabled=True,
+                    checked=False,
+                    healthy=True,
+                    status=None,
+                ),
+                VenueSystemState(
+                    venue="paradex",
+                    enabled=True,
+                    checked=True,
+                    healthy=True,
+                    status="ok",
+                ),
+            ]
+
+    launch_ready_store = LaunchReadyCanaryStore(database_path)
+    first_summary = asyncio.run(
+        cache_launch_ready_canaries_once(
+            ready_settings,
+            approved_store=approved_store,
+            launch_ready_store=launch_ready_store,
+            system_state_service=cast(Any, StubSystemStateService()),
+            now=datetime(2026, 3, 29, 20, 6, tzinfo=UTC),
+        )
+    )
+
+    assert first_summary.saved_snapshots == 1
+    assert len(launch_ready_store.list_recent(limit=10, label="arb_extended_paradex")) == 1
+
+    degraded_settings = WorkerSettings(
+        database_path=database_path,
+        launch_ready_canary_max_snapshot_age_seconds=300,
+        extended_live_enabled=True,
+        extended_api_key="extended-key",
+        paradex_live_enabled=True,
+        paradex_account_address="0xabc",
+        paradex_bearer_token="token",
+    )
+
+    class FailingSystemStateService:
+        async def probe_venues(self, configs: dict[str, dict[str, bool]]) -> list[VenueSystemState]:
+            _ = configs
+            raise AssertionError("system-state probe should not run before credential gate passes")
+
+    second_summary = asyncio.run(
+        cache_launch_ready_canaries_once(
+            degraded_settings,
+            approved_store=approved_store,
+            launch_ready_store=launch_ready_store,
+            system_state_service=cast(Any, FailingSystemStateService()),
+            now=datetime(2026, 3, 29, 20, 7, tzinfo=UTC),
+        )
+    )
+
+    assert second_summary.launch_ready_candidates == 0
+    assert second_summary.saved_snapshots == 0
+    assert launch_ready_store.list_recent(limit=10, label="arb_extended_paradex") == []
+
+
 def test_cache_launch_ready_canaries_once_skips_decayed_approved_snapshot_chain(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -124,6 +124,7 @@ from carryme_worker.poller import (
     _build_order_state_observers,
     _execution_requires_continued_monitoring,
     _maybe_auto_close_open_hedged_execution,
+    _probe_candidate_system_state,
     cache_launch_ready_canaries_once,
     install_signal_handlers,
     launch_latest_stable_canary_once,
@@ -273,7 +274,15 @@ def _clear_worker_env(monkeypatch: pytest.MonkeyPatch) -> None:
         raising=False,
     )
     monkeypatch.delenv("CARRYME_WORKER_PARADEX_RECV_WINDOW_MS", raising=False)
+    monkeypatch.delenv("CARRYME_WORKER_EXTENDED_API_KEY", raising=False)
     monkeypatch.delenv("CARRYME_API_EXTENDED_STARK_PRIVATE_KEY", raising=False)
+    monkeypatch.delenv("CARRYME_API_EXTENDED_API_KEY", raising=False)
+    monkeypatch.delenv("CARRYME_WORKER_PARADEX_ACCOUNT_ADDRESS", raising=False)
+    monkeypatch.delenv("CARRYME_API_PARADEX_ACCOUNT_ADDRESS", raising=False)
+    monkeypatch.delenv("CARRYME_WORKER_PARADEX_PRIVATE_KEY", raising=False)
+    monkeypatch.delenv("CARRYME_API_PARADEX_PRIVATE_KEY", raising=False)
+    monkeypatch.delenv("CARRYME_WORKER_PARADEX_BEARER_TOKEN", raising=False)
+    monkeypatch.delenv("CARRYME_API_PARADEX_BEARER_TOKEN", raising=False)
     monkeypatch.delenv("CARRYME_API_PARADEX_RECV_WINDOW_MS", raising=False)
     monkeypatch.delenv("CARRYME_WORKER_STOP_SIGNALS", raising=False)
 
@@ -3157,8 +3166,10 @@ def _append_launch_ready_gate_approved_snapshot(
 
 def test_cache_launch_ready_canaries_once_skips_selected_disabled_live_execution_venue(
     tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
+    _clear_worker_env(monkeypatch)
     settings = WorkerSettings(
         database_path=str(tmp_path / "history.sqlite3"),
         launch_ready_canary_max_snapshot_age_seconds=300,
@@ -3195,10 +3206,75 @@ def test_cache_launch_ready_canaries_once_skips_selected_disabled_live_execution
     assert "Venue paradex live execution is not enabled" in caplog.text
 
 
-def test_cache_launch_ready_canaries_once_skips_selected_missing_live_execution_credentials(
+def test_cache_launch_ready_canaries_once_skips_selected_unknown_system_state_venue(
     tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
+    _clear_worker_env(monkeypatch)
+    settings = WorkerSettings(
+        database_path=str(tmp_path / "history.sqlite3"),
+        launch_ready_canary_max_snapshot_age_seconds=300,
+        extended_live_enabled=True,
+        extended_api_key="extended-key",
+        extended_stark_private_key="0x123",
+        paradex_live_enabled=True,
+        paradex_account_address="0xabc",
+        paradex_private_key="token",
+    )
+    approved_store = _append_launch_ready_gate_approved_snapshot(settings)
+
+    class PartialSystemStateService:
+        async def probe_venues(self, configs: dict[str, dict[str, bool]]) -> list[VenueSystemState]:
+            _ = configs
+            return [
+                VenueSystemState(
+                    venue="extended",
+                    enabled=True,
+                    checked=False,
+                    healthy=True,
+                    status=None,
+                ),
+            ]
+
+    launch_ready_store = LaunchReadyCanaryStore(settings.database_path)
+    probe_state = asyncio.run(
+        _probe_candidate_system_state(
+            settings=settings,
+            service=cast(Any, PartialSystemStateService()),
+            candidate=approved_store.list_recent(
+                limit=1,
+                label="arb_extended_paradex",
+            )[0].candidate,
+            label="arb_extended_paradex",
+        )
+    )
+    with caplog.at_level(logging.DEBUG):
+        summary = asyncio.run(
+            cache_launch_ready_canaries_once(
+                settings,
+                approved_store=approved_store,
+                launch_ready_store=launch_ready_store,
+                system_state_service=cast(Any, PartialSystemStateService()),
+                now=datetime(2026, 3, 29, 20, 6, tzinfo=UTC),
+            )
+        )
+
+    assert summary.scanned_snapshots == 1
+    assert summary.launch_ready_candidates == 0
+    assert summary.saved_snapshots == 0
+    assert probe_state.ready is False
+    assert probe_state.blocking_reasons == ["Venue paradex system state is unknown"]
+    assert launch_ready_store.list_recent(limit=10, label="arb_extended_paradex") == []
+    assert "system state is not ready" in caplog.text
+
+
+def test_cache_launch_ready_canaries_once_skips_selected_missing_live_execution_credentials(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    _clear_worker_env(monkeypatch)
     settings = WorkerSettings(
         database_path=str(tmp_path / "history.sqlite3"),
         launch_ready_canary_max_snapshot_age_seconds=300,

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -2974,7 +2974,7 @@ def test_cache_launch_ready_canaries_once_saves_fresh_ready_snapshots(
         extended_stark_private_key="0x123",
         paradex_live_enabled=True,
         paradex_account_address="0xabc",
-        paradex_bearer_token="token",
+        paradex_private_key="token",
     )
     approval_store = RouteApprovalStore(settings.database_path)
     approval = approval_store.upsert(
@@ -3245,7 +3245,7 @@ def test_cache_launch_ready_canaries_once_skips_decayed_approved_snapshot_chain(
         extended_api_key="extended-key",
         paradex_live_enabled=True,
         paradex_account_address="0xabc",
-        paradex_bearer_token="token",
+        paradex_private_key="token",
     )
     approval_store = RouteApprovalStore(settings.database_path)
     approval = approval_store.upsert(
@@ -3407,7 +3407,7 @@ def test_cache_launch_ready_canaries_once_skips_long_break_even_routes(
         extended_api_key="extended-key",
         paradex_live_enabled=True,
         paradex_account_address="0xabc",
-        paradex_bearer_token="token",
+        paradex_private_key="token",
     )
     approval_store = RouteApprovalStore(settings.database_path)
     approval = approval_store.upsert(
@@ -3594,7 +3594,7 @@ def test_cache_launch_ready_canaries_once_emits_stable_launch_ready_available_al
         extended_stark_private_key="0x123",
         paradex_live_enabled=True,
         paradex_account_address="0xabc",
-        paradex_bearer_token="token",
+        paradex_private_key="token",
     )
     approval_store = RouteApprovalStore(settings.database_path)
     approval = approval_store.upsert(

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -275,6 +275,7 @@ def _clear_worker_env(monkeypatch: pytest.MonkeyPatch) -> None:
     )
     monkeypatch.delenv("CARRYME_WORKER_PARADEX_RECV_WINDOW_MS", raising=False)
     monkeypatch.delenv("CARRYME_WORKER_EXTENDED_API_KEY", raising=False)
+    monkeypatch.delenv("CARRYME_WORKER_EXTENDED_STARK_PRIVATE_KEY", raising=False)
     monkeypatch.delenv("CARRYME_API_EXTENDED_STARK_PRIVATE_KEY", raising=False)
     monkeypatch.delenv("CARRYME_API_EXTENDED_API_KEY", raising=False)
     monkeypatch.delenv("CARRYME_WORKER_PARADEX_ACCOUNT_ADDRESS", raising=False)
@@ -284,6 +285,20 @@ def _clear_worker_env(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("CARRYME_WORKER_PARADEX_BEARER_TOKEN", raising=False)
     monkeypatch.delenv("CARRYME_API_PARADEX_BEARER_TOKEN", raising=False)
     monkeypatch.delenv("CARRYME_API_PARADEX_RECV_WINDOW_MS", raising=False)
+    monkeypatch.delenv("CARRYME_WORKER_HYPERLIQUID_LIVE_ENABLED", raising=False)
+    monkeypatch.delenv("CARRYME_API_HYPERLIQUID_LIVE_ENABLED", raising=False)
+    monkeypatch.delenv("CARRYME_WORKER_HYPERLIQUID_ACCOUNT_ADDRESS", raising=False)
+    monkeypatch.delenv("CARRYME_API_HYPERLIQUID_ACCOUNT_ADDRESS", raising=False)
+    monkeypatch.delenv("CARRYME_WORKER_HYPERLIQUID_VAULT_ADDRESS", raising=False)
+    monkeypatch.delenv("CARRYME_API_HYPERLIQUID_VAULT_ADDRESS", raising=False)
+    monkeypatch.delenv(
+        "CARRYME_WORKER_HYPERLIQUID_API_WALLET_PRIVATE_KEY",
+        raising=False,
+    )
+    monkeypatch.delenv(
+        "CARRYME_API_HYPERLIQUID_API_WALLET_PRIVATE_KEY",
+        raising=False,
+    )
     monkeypatch.delenv("CARRYME_WORKER_STOP_SIGNALS", raising=False)
 
 
@@ -3390,6 +3405,91 @@ def test_cache_launch_ready_canaries_once_invalidates_existing_snapshot_when_unr
     assert second_summary.launch_ready_candidates == 0
     assert second_summary.saved_snapshots == 0
     assert launch_ready_store.list_recent(limit=10, label="arb_extended_paradex") == []
+
+
+def test_cache_launch_ready_canaries_once_skips_when_snapshot_invalidation_raises(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    _clear_worker_env(monkeypatch)
+    database_path = str(tmp_path / "history.sqlite3")
+    ready_settings = WorkerSettings(
+        database_path=database_path,
+        launch_ready_canary_max_snapshot_age_seconds=300,
+        extended_live_enabled=True,
+        extended_api_key="extended-key",
+        extended_stark_private_key="0x123",
+        paradex_live_enabled=True,
+        paradex_account_address="0xabc",
+        paradex_private_key="token",
+    )
+    approved_store = _append_launch_ready_gate_approved_snapshot(ready_settings)
+
+    class StubSystemStateService:
+        async def probe_venues(self, configs: dict[str, dict[str, bool]]) -> list[VenueSystemState]:
+            _ = configs
+            return [
+                VenueSystemState(
+                    venue="extended",
+                    enabled=True,
+                    checked=False,
+                    healthy=True,
+                    status=None,
+                ),
+                VenueSystemState(
+                    venue="paradex",
+                    enabled=True,
+                    checked=True,
+                    healthy=True,
+                    status="ok",
+                ),
+            ]
+
+    launch_ready_store = LaunchReadyCanaryStore(database_path)
+    asyncio.run(
+        cache_launch_ready_canaries_once(
+            ready_settings,
+            approved_store=approved_store,
+            launch_ready_store=launch_ready_store,
+            system_state_service=cast(Any, StubSystemStateService()),
+            now=datetime(2026, 3, 29, 20, 6, tzinfo=UTC),
+        )
+    )
+
+    degraded_settings = WorkerSettings(
+        database_path=database_path,
+        launch_ready_canary_max_snapshot_age_seconds=300,
+        extended_live_enabled=True,
+        extended_api_key="extended-key",
+        paradex_live_enabled=True,
+        paradex_account_address="0xabc",
+        paradex_bearer_token="token",
+    )
+
+    class FailingDeleteLaunchReadyStore(LaunchReadyCanaryStore):
+        def delete_label(self, label: str) -> int:
+            raise RuntimeError(f"boom {label}")
+
+    class FailingSystemStateService:
+        async def probe_venues(self, configs: dict[str, dict[str, bool]]) -> list[VenueSystemState]:
+            _ = configs
+            raise AssertionError("system-state probe should not run before credential gate passes")
+
+    with caplog.at_level(logging.WARNING):
+        summary = asyncio.run(
+            cache_launch_ready_canaries_once(
+                degraded_settings,
+                approved_store=approved_store,
+                launch_ready_store=FailingDeleteLaunchReadyStore(database_path),
+                system_state_service=cast(Any, FailingSystemStateService()),
+                now=datetime(2026, 3, 29, 20, 7, tzinfo=UTC),
+            )
+        )
+
+    assert summary.launch_ready_candidates == 0
+    assert summary.saved_snapshots == 0
+    assert "failed to invalidate launch-ready snapshots" in caplog.text
 
 
 def test_cache_launch_ready_canaries_once_skips_decayed_approved_snapshot_chain(
@@ -8301,6 +8401,63 @@ def test_launch_latest_stable_canary_once_ignores_unselected_live_credentials(
 
     assert summary.status == "launched"
     assert summary.paper_trade_id == 17
+
+
+def test_launch_latest_stable_canary_once_rechecks_live_execution_readiness(
+    tmp_path: Path,
+) -> None:
+    settings = WorkerSettings(
+        database_path=str(tmp_path / "history.sqlite3"),
+        extended_live_enabled=True,
+        extended_api_key="extended-key",
+        extended_stark_private_key="extended-secret",
+        paradex_live_enabled=True,
+        paradex_account_address="0x123",
+        paradex_bearer_token="token",
+    )
+    approval, candidate, snapshot, stability = _build_stable_launch_test_snapshot(
+        label="arb_extended_paradex"
+    )
+    approved_store = ApprovedCanaryStore(settings.database_path)
+    persisted_snapshot = approved_store.append(snapshot.approved_snapshot)
+    snapshot = snapshot.model_copy(update={"approved_snapshot": persisted_snapshot})
+    stability = stability.model_copy(update={"snapshot": snapshot})
+    LaunchReadyCanaryStore(settings.database_path).append(snapshot)
+
+    async def run_unexpected_lifecycle(**_: object) -> object:
+        pytest.fail("stable launch should not submit when live execution credentials are missing")
+
+    with pytest.MonkeyPatch.context() as monkeypatch:
+        monkeypatch.setattr(
+            "carryme_worker.poller._build_launch_ready_canary_stability",
+            lambda **_: stability,
+        )
+        monkeypatch.setattr(
+            "carryme_worker.poller._select_latest_launch_ready_canary_snapshot",
+            lambda **_: (snapshot, candidate, approval),
+        )
+        monkeypatch.setattr(
+            "carryme_worker.poller._run_guarded_canary_lifecycle",
+            run_unexpected_lifecycle,
+        )
+        summary = asyncio.run(
+            launch_latest_stable_canary_once(
+                settings,
+                now=datetime(2026, 3, 30, 10, 2, tzinfo=UTC),
+            )
+        )
+
+    assert summary.status == "skipped"
+    assert summary.label == "arb_extended_paradex"
+    assert summary.detail == (
+        "Latest launch-ready snapshot no longer satisfies live execution readiness: "
+        "Venue paradex is missing required credentials: "
+        "CARRYME_API_PARADEX_PRIVATE_KEY"
+    )
+    assert (
+        LaunchReadyCanaryStore(settings.database_path).latest(label="arb_extended_paradex")
+        is None
+    )
 
 
 def _build_auto_close_paper_trade(


### PR DESCRIPTION
## Summary
- gate launch-ready canary snapshots on selected-route live execution readiness before system-state probing
- keep Paradex bearer-token auth valid as an alternative to the subkey private key in shared execution preflight checks
- update Render docs so `carryme-launch-ready-cache` receives the selected venue credential env vars it now needs to fail closed correctly

## Why
Launch-ready snapshots should not be persisted when the hosted worker cannot execute the selected venues. Before this change, disabled live flags or missing selected-venue execution credentials could still pass the public system-state-only gate and leave stable launch to fail later during the opportunity window.

## Deployment Note
After this merges, attach the selected-route live venue flags and credential env vars to `carryme-launch-ready-cache` as well as `carryme-stable-launch` and `carryme-execution-monitor`. The cache worker does not submit orders, but it now checks credential presence and will intentionally produce zero launch-ready snapshots if those env vars are missing.

## Validation
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run pytest -q tests/test_worker.py -k 'cache_launch_ready_canaries_once'`
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run pytest -q tests/test_runtime.py -k 'venue_execution_preflights' tests/test_render_validate.py`
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run pytest -q tests/test_api.py -k 'live_execution_preflight or live_submission_readiness_endpoint_combines_gates'`
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run pytest -q tests/test_worker.py`
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run ruff check .`
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run mypy src apps packages tests`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Launch-ready caching now enforces per-venue live-execution readiness and will skip/block candidates when a venue is disabled, unknown, or missing required credentials.
  * Added ability to delete persisted launch-ready canary snapshots by label.

* **Documentation**
  * Deployment guide clarifies which secrets are required/optional for launch-readiness checks and updates rollout/ownership guidance.

* **Tests**
  * Expanded tests for credential alternatives, whitespace-handling, live-gating behavior, and launch-ready cache lifecycle.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->