### PR TITLE
fix: scan all approved canary labels safely

### DIFF
--- a/.env.render.example
+++ b/.env.render.example
@@ -26,6 +26,11 @@ CARRYME_WORKER_STABLE_LAUNCH_READY_ALERT_WEBHOOK_URL=
 CARRYME_WORKER_SYSTEM_STATE_ALERT_WEBHOOK_URL=
 CARRYME_WORKER_EXECUTION_ALERT_WEBHOOK_URL=
 
+# Approved canary scan coverage
+# 0 scans every approved label while concurrency limits upstream fan-out.
+CARRYME_WORKER_APPROVED_CANARY_SCAN_LIMIT=0
+CARRYME_WORKER_APPROVED_CANARY_SCAN_CONCURRENCY=5
+
 # Stable launch behavior
 # Keep true for execution-only canaries. Set false only when execution auto-close is live.
 CARRYME_WORKER_STABLE_CANARY_LAUNCH_CLOSE_POSITION=true

--- a/apps/worker/src/carryme_worker/config.py
+++ b/apps/worker/src/carryme_worker/config.py
@@ -210,7 +210,9 @@ class WorkerSettings(BaseSettings):
     approved_canary_scan_min_route_stability_weight: float = 0.0
     approved_canary_scan_min_route_presence_ratio: float = 0.0
     approved_canary_scan_min_route_samples: int = 0
-    approved_canary_scan_limit: int = 5
+    # `0` means scan every approved label; concurrency still limits fan-out.
+    approved_canary_scan_limit: int = Field(default=0, ge=0)
+    approved_canary_scan_concurrency: int = Field(default=5, gt=0)
     approved_canary_exact_scan_limit: int = 25
     approved_canary_scan_include_symbols: tuple[str, ...] = ()
     approved_canary_scan_exclude_symbols: tuple[str, ...] = ()

--- a/apps/worker/src/carryme_worker/poller.py
+++ b/apps/worker/src/carryme_worker/poller.py
@@ -2161,14 +2161,21 @@ async def scan_approved_canary_once(
     scanned_labels: set[str] = set()
     scanned_candidates = 0
 
-    selected_labels = list(approvals_by_label)[: settings.approved_canary_scan_limit]
+    all_labels = list(approvals_by_label)
+    selected_labels = (
+        all_labels
+        if settings.approved_canary_scan_limit == 0
+        else all_labels[: settings.approved_canary_scan_limit]
+    )
     if len(selected_labels) < len(approvals_by_label):
         loop_logger.info(
-            "approved canary exact scan limit reached at %s labels",
+            "approved canary label scan limit selected %s of %s labels",
             settings.approved_canary_scan_limit,
+            len(approvals_by_label),
         )
+    label_scan_semaphore = asyncio.Semaphore(settings.approved_canary_scan_concurrency)
 
-    async def _scan_label(
+    async def _scan_label_unbounded(
         label: str,
     ) -> tuple[
         str,
@@ -2235,6 +2242,18 @@ async def scan_approved_canary_once(
             return label, scanned_candidate_count, label_scanned, None, None
         candidate, matched_approval = best_match
         return label, scanned_candidate_count, label_scanned, candidate, matched_approval
+
+    async def _scan_label(
+        label: str,
+    ) -> tuple[
+        str,
+        int,
+        bool,
+        FundingUniverseCanaryCandidate | None,
+        RouteApprovalEntry | None,
+    ]:
+        async with label_scan_semaphore:
+            return await _scan_label_unbounded(label)
 
     results = await asyncio.gather(*(_scan_label(label) for label in selected_labels))
     for label, candidate_count, label_scanned, candidate, matched_approval in results:

--- a/apps/worker/src/carryme_worker/poller.py
+++ b/apps/worker/src/carryme_worker/poller.py
@@ -2136,7 +2136,7 @@ async def scan_approved_canary_once(
         history_store=OpportunityHistoryStore(settings.database_path),
     )
 
-    approvals = route_approval_service.list_recent(limit=1_000, approved=True)
+    approvals = route_approval_service.list_recent(limit=None, approved=True)
     unique_approvals: list[RouteApprovalEntry] = []
     seen_route_keys: set[tuple[str, str, str, str, str, str]] = set()
     for approval in approvals:
@@ -2173,8 +2173,6 @@ async def scan_approved_canary_once(
             settings.approved_canary_scan_limit,
             len(approvals_by_label),
         )
-    label_scan_semaphore = asyncio.Semaphore(settings.approved_canary_scan_concurrency)
-
     async def _scan_label_unbounded(
         label: str,
     ) -> tuple[
@@ -2229,6 +2227,12 @@ async def scan_approved_canary_once(
                     exc,
                 )
                 continue
+            except Exception:
+                loop_logger.exception(
+                    "approved canary exact scan crashed for label=%s",
+                    approved_route.label,
+                )
+                continue
             label_scanned = True
             scanned_candidate_count += candidate_count
             if candidate is None:
@@ -2252,10 +2256,25 @@ async def scan_approved_canary_once(
         FundingUniverseCanaryCandidate | None,
         RouteApprovalEntry | None,
     ]:
-        async with label_scan_semaphore:
+        try:
             return await _scan_label_unbounded(label)
+        except Exception:
+            loop_logger.exception("approved canary label scan crashed for label=%s", label)
+            return label, 0, False, None, None
 
-    results = await asyncio.gather(*(_scan_label(label) for label in selected_labels))
+    results: list[
+        tuple[
+            str,
+            int,
+            bool,
+            FundingUniverseCanaryCandidate | None,
+            RouteApprovalEntry | None,
+        ]
+    ] = []
+    batch_size = settings.approved_canary_scan_concurrency
+    for start in range(0, len(selected_labels), batch_size):
+        batch_labels = selected_labels[start : start + batch_size]
+        results.extend(await asyncio.gather(*(_scan_label(label) for label in batch_labels)))
     for label, candidate_count, label_scanned, candidate, matched_approval in results:
         scanned_candidates += candidate_count
         if label_scanned:

--- a/packages/runtime/src/carryme_runtime/route_approvals.py
+++ b/packages/runtime/src/carryme_runtime/route_approvals.py
@@ -57,7 +57,7 @@ class RouteApprovalService:
     def list_recent(
         self,
         *,
-        limit: int = 50,
+        limit: int | None = 50,
         label: str | None = None,
         canonical_symbol: str | None = None,
         approved: bool | None = None,

--- a/packages/storage/src/carryme_storage/route_approvals.py
+++ b/packages/storage/src/carryme_storage/route_approvals.py
@@ -111,7 +111,7 @@ class RouteApprovalStore:
     def list_recent(
         self,
         *,
-        limit: int = 50,
+        limit: int | None = 50,
         label: str | None = None,
         canonical_symbol: str | None = None,
         approved: bool | None = None,
@@ -136,8 +136,10 @@ class RouteApprovalStore:
             params.append(int(approved))
         if filters:
             query += " WHERE " + " AND ".join(filters)
-        query += " ORDER BY updated_at DESC LIMIT ?"
-        params.append(limit)
+        query += " ORDER BY updated_at DESC"
+        if limit is not None:
+            query += " LIMIT ?"
+            params.append(limit)
 
         with self.database.begin() as connection:
             rows = connection.execute(query, tuple(params)).fetchall()

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -2203,6 +2203,64 @@ def test_scan_approved_canary_once_default_scans_all_approved_labels(
     assert {snapshot.label for snapshot in snapshots} == expected_labels
 
 
+def test_scan_approved_canary_once_scans_all_labels_beyond_recent_approval_window(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    total_labels = 1_005
+    settings = WorkerSettings(
+        database_path=str(tmp_path / "history.sqlite3"),
+        approved_canary_scan_concurrency=25,
+    )
+    approval_store = RouteApprovalStore(settings.database_path)
+    expected_labels = {f"route_{index}_extended_paradex" for index in range(total_labels)}
+    for index, label in enumerate(sorted(expected_labels)):
+        approval_store.upsert(
+            RouteApprovalEntry(
+                updated_at=datetime(2026, 4, 2, 10, 0, tzinfo=UTC) + timedelta(seconds=index),
+                label=label,
+                canonical_symbol=f"ROUTE{index}-USD-PERP",
+                short_venue="extended",
+                long_venue="paradex",
+                short_fee_profile="default",
+                long_fee_profile="pro_fastfills",
+                approved=True,
+                max_live_notional=11.0,
+                note="approved route",
+            )
+        )
+    snapshot_store = ApprovedCanaryStore(settings.database_path)
+    scanned_labels: set[str] = set()
+
+    async def fake_scan_exact_canary_candidate_for_approval(
+        **kwargs: object,
+    ) -> tuple[FundingUniverseCanaryCandidate | None, int]:
+        approval = cast(RouteApprovalEntry, kwargs["approval"])
+        scanned_labels.add(approval.label)
+        return None, 1
+
+    monkeypatch.setattr(
+        "carryme_worker.poller.scan_exact_canary_candidate_for_approval",
+        fake_scan_exact_canary_candidate_for_approval,
+    )
+
+    summary = asyncio.run(
+        scan_approved_canary_once(
+            settings,
+            scanner=cast(Any, object()),
+            approval_service=RouteApprovalService(store=approval_store),
+            store=snapshot_store,
+            alert_sink=ApprovedCanaryAlertStore(settings.database_path),
+            now=datetime(2026, 4, 2, 10, 30, tzinfo=UTC),
+        )
+    )
+
+    assert scanned_labels == expected_labels
+    assert summary.scanned_candidates == total_labels
+    assert summary.approved_candidates == 0
+    assert summary.saved_snapshots == 0
+
+
 def test_scan_approved_canary_once_decouples_exact_scan_depth_from_label_budget(
     tmp_path: Path,
 ) -> None:
@@ -2428,6 +2486,106 @@ def test_scan_approved_canary_once_scans_labels_in_parallel(
     }
 
 
+def test_scan_approved_canary_once_bounds_parallel_label_tasks(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    settings = WorkerSettings(
+        database_path=str(tmp_path / "history.sqlite3"),
+        approved_canary_scan_concurrency=2,
+    )
+    approval_store = RouteApprovalStore(settings.database_path)
+    labels = [f"route_{index}_extended_paradex" for index in range(5)]
+    for index, label in enumerate(labels):
+        approval_store.upsert(
+            RouteApprovalEntry(
+                updated_at=datetime(2026, 4, 2, 10, index, tzinfo=UTC),
+                label=label,
+                canonical_symbol=f"ROUTE{index}-USD-PERP",
+                short_venue="extended",
+                long_venue="paradex",
+                short_fee_profile="default",
+                long_fee_profile="pro_fastfills",
+                approved=True,
+                max_live_notional=11.0,
+                note="approved route",
+            )
+        )
+    snapshot_store = ApprovedCanaryStore(settings.database_path)
+    in_flight = 0
+    max_in_flight = 0
+
+    async def fake_scan_exact_canary_candidate_for_approval(
+        **kwargs: object,
+    ) -> tuple[FundingUniverseCanaryCandidate | None, int]:
+        nonlocal in_flight, max_in_flight
+        approval = cast(RouteApprovalEntry, kwargs["approval"])
+        in_flight += 1
+        max_in_flight = max(max_in_flight, in_flight)
+        await asyncio.sleep(0.01)
+        in_flight -= 1
+        return (
+            FundingUniverseCanaryCandidate(
+                opportunity=FundingUniverseOpportunity(
+                    opportunity=FundingArbOpportunity(
+                        canonical_symbol=approval.canonical_symbol,
+                        long_venue="paradex",
+                        short_venue="extended",
+                        long_fee_profile="pro_fastfills",
+                        short_fee_profile="default",
+                        gross_daily_edge=0.004,
+                        entry_cost_rate=0.00045,
+                        round_trip_cost_rate=0.0009,
+                        one_day_net_edge_after_entry=0.00355,
+                        one_day_net_edge_after_round_trip=0.0031,
+                        break_even_days_entry=0.2,
+                        break_even_days_round_trip=0.3,
+                        capacity=CapacityEstimate(
+                            short_bid_notional=1400.0,
+                            long_ask_notional=900.0,
+                            max_entry_notional=900.0,
+                            limiting_venue="paradex",
+                        ),
+                    ),
+                    venue_markets={
+                        "extended": FundingUniverseVenueMarket(
+                            venue="extended",
+                            symbol=f"{approval.canonical_symbol}-SHORT",
+                        ),
+                        "paradex": FundingUniverseVenueMarket(
+                            venue="paradex",
+                            symbol=f"{approval.canonical_symbol}-LONG",
+                        ),
+                    },
+                    deployable_notional=900.0,
+                    estimated_one_day_pnl_after_round_trip=2.79,
+                ),
+                suggested_canary_notional=11.0,
+            ),
+            1,
+        )
+
+    monkeypatch.setattr(
+        "carryme_worker.poller.scan_exact_canary_candidate_for_approval",
+        fake_scan_exact_canary_candidate_for_approval,
+    )
+
+    summary = asyncio.run(
+        scan_approved_canary_once(
+            settings,
+            scanner=cast(Any, object()),
+            approval_service=RouteApprovalService(store=approval_store),
+            store=snapshot_store,
+            alert_sink=ApprovedCanaryAlertStore(settings.database_path),
+            now=datetime(2026, 4, 2, 10, 10, tzinfo=UTC),
+        )
+    )
+
+    assert max_in_flight == settings.approved_canary_scan_concurrency
+    assert summary.scanned_candidates == len(labels)
+    assert summary.saved_snapshots == len(labels)
+
+
 def test_scan_approved_canary_once_continues_on_recoverable_exact_scan_error(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -2541,6 +2699,117 @@ def test_scan_approved_canary_once_continues_on_recoverable_exact_scan_error(
         "extended temporarily unavailable"
     )
     assert expected_warning in caplog.text
+
+
+def test_scan_approved_canary_once_continues_on_unexpected_exact_scan_error(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    settings = WorkerSettings(database_path=str(tmp_path / "history.sqlite3"))
+    approval_store = RouteApprovalStore(settings.database_path)
+    approval_store.upsert(
+        RouteApprovalEntry(
+            updated_at=datetime(2026, 4, 2, 10, 1, tzinfo=UTC),
+            label="broken_extended_paradex",
+            canonical_symbol="BROKEN-USD-PERP",
+            short_venue="extended",
+            long_venue="paradex",
+            short_fee_profile="default",
+            long_fee_profile="pro",
+            approved=True,
+            max_live_notional=11.0,
+            note="broken exact route",
+        )
+    )
+    approval_store.upsert(
+        RouteApprovalEntry(
+            updated_at=datetime(2026, 4, 2, 10, 0, tzinfo=UTC),
+            label="healthy_extended_paradex",
+            canonical_symbol="HEALTHY-USD-PERP",
+            short_venue="extended",
+            long_venue="paradex",
+            short_fee_profile="default",
+            long_fee_profile="pro_fastfills",
+            approved=True,
+            max_live_notional=11.0,
+            note="healthy exact route",
+        )
+    )
+    snapshot_store = ApprovedCanaryStore(settings.database_path)
+
+    async def fake_scan_exact_canary_candidate_for_approval(
+        **kwargs: object,
+    ) -> tuple[FundingUniverseCanaryCandidate | None, int]:
+        approval = cast(RouteApprovalEntry, kwargs["approval"])
+        if approval.label == "broken_extended_paradex":
+            raise RuntimeError("unexpected schema break")
+        return (
+            FundingUniverseCanaryCandidate(
+                opportunity=FundingUniverseOpportunity(
+                    opportunity=FundingArbOpportunity(
+                        canonical_symbol="HEALTHY-USD-PERP",
+                        long_venue="paradex",
+                        short_venue="extended",
+                        long_fee_profile="pro_fastfills",
+                        short_fee_profile="default",
+                        gross_daily_edge=0.004,
+                        entry_cost_rate=0.00045,
+                        round_trip_cost_rate=0.0009,
+                        one_day_net_edge_after_entry=0.00355,
+                        one_day_net_edge_after_round_trip=0.0031,
+                        break_even_days_entry=0.2,
+                        break_even_days_round_trip=0.3,
+                        capacity=CapacityEstimate(
+                            short_bid_notional=1400.0,
+                            long_ask_notional=900.0,
+                            max_entry_notional=900.0,
+                            limiting_venue="paradex",
+                        ),
+                    ),
+                    venue_markets={
+                        "extended": FundingUniverseVenueMarket(
+                            venue="extended",
+                            symbol="HEALTHY-USD",
+                        ),
+                        "paradex": FundingUniverseVenueMarket(
+                            venue="paradex",
+                            symbol="HEALTHY-USD-PERP",
+                        ),
+                    },
+                    deployable_notional=900.0,
+                    estimated_one_day_pnl_after_round_trip=2.79,
+                ),
+                suggested_canary_notional=11.0,
+            ),
+            1,
+        )
+
+    monkeypatch.setattr(
+        "carryme_worker.poller.scan_exact_canary_candidate_for_approval",
+        fake_scan_exact_canary_candidate_for_approval,
+    )
+
+    with caplog.at_level(logging.ERROR):
+        summary = asyncio.run(
+            scan_approved_canary_once(
+                settings,
+                scanner=cast(Any, object()),
+                approval_service=RouteApprovalService(store=approval_store),
+                store=snapshot_store,
+                alert_sink=ApprovedCanaryAlertStore(settings.database_path),
+                now=datetime(2026, 4, 2, 10, 5, tzinfo=UTC),
+            )
+        )
+
+    snapshots = snapshot_store.list_recent(limit=10)
+
+    assert summary.scanned_candidates == 1
+    assert summary.approved_candidates == 1
+    assert summary.saved_snapshots == 1
+    assert len(snapshots) == 1
+    assert snapshots[0].label == "healthy_extended_paradex"
+    assert "approved canary exact scan crashed for label=broken_extended_paradex" in caplog.text
 
 
 def test_scan_approved_canary_once_does_not_emit_stale_alert_when_label_scan_fails(

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -372,6 +372,8 @@ def test_worker_defaults(monkeypatch: pytest.MonkeyPatch) -> None:
     assert settings.approved_canary_scan_min_route_stability_weight == 0.0
     assert settings.approved_canary_scan_min_route_presence_ratio == 0.0
     assert settings.approved_canary_scan_min_route_samples == 0
+    assert settings.approved_canary_scan_limit == 0
+    assert settings.approved_canary_scan_concurrency == 5
     assert settings.approved_canary_exact_scan_limit == 25
     assert settings.paradex_recv_window_ms == 300000
     assert settings.execution_observation_max_age_seconds == 1800
@@ -481,6 +483,32 @@ def test_worker_rejects_non_positive_snapshot_concurrency(
         WorkerSettings(
             watchlist_path=str(watchlist),
             **cast(Any, {field_name: value}),
+        )
+
+
+def test_worker_rejects_negative_approved_canary_scan_limit(tmp_path: Path) -> None:
+    watchlist = tmp_path / "watchlist.json"
+    watchlist.write_text('{"pairs": []}')
+
+    with pytest.raises(ValidationError, match="approved_canary_scan_limit"):
+        WorkerSettings(
+            watchlist_path=str(watchlist),
+            approved_canary_scan_limit=-1,
+        )
+
+
+@pytest.mark.parametrize("value", (0, -1))
+def test_worker_rejects_non_positive_approved_canary_scan_concurrency(
+    tmp_path: Path,
+    value: int,
+) -> None:
+    watchlist = tmp_path / "watchlist.json"
+    watchlist.write_text('{"pairs": []}')
+
+    with pytest.raises(ValidationError, match="approved_canary_scan_concurrency"):
+        WorkerSettings(
+            watchlist_path=str(watchlist),
+            approved_canary_scan_concurrency=value,
         )
 
 
@@ -2076,6 +2104,103 @@ def test_scan_approved_canary_once_limit_counts_labels_not_duplicate_approvals(
     assert summary.approved_candidates == 2
     assert summary.saved_snapshots == 2
     assert labels == {"s_extended_paradex", "jup_paradex_extended"}
+
+
+def test_scan_approved_canary_once_default_scans_all_approved_labels(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    settings = WorkerSettings(database_path=str(tmp_path / "history.sqlite3"))
+    approval_store = RouteApprovalStore(settings.database_path)
+    expected_labels = {f"route_{index}_extended_paradex" for index in range(6)}
+    for index, label in enumerate(sorted(expected_labels)):
+        approval_store.upsert(
+            RouteApprovalEntry(
+                updated_at=datetime(2026, 4, 2, 10, index, tzinfo=UTC),
+                label=label,
+                canonical_symbol=f"ROUTE{index}-USD-PERP",
+                short_venue="extended",
+                long_venue="paradex",
+                short_fee_profile="default",
+                long_fee_profile="pro_fastfills",
+                approved=True,
+                max_live_notional=11.0,
+                note="approved route",
+            )
+        )
+    snapshot_store = ApprovedCanaryStore(settings.database_path)
+    scanned_labels: set[str] = set()
+
+    def _candidate(symbol: str) -> FundingUniverseCanaryCandidate:
+        return FundingUniverseCanaryCandidate(
+            opportunity=FundingUniverseOpportunity(
+                opportunity=FundingArbOpportunity(
+                    canonical_symbol=symbol,
+                    long_venue="paradex",
+                    short_venue="extended",
+                    long_fee_profile="pro_fastfills",
+                    short_fee_profile="default",
+                    gross_daily_edge=0.004,
+                    entry_cost_rate=0.00045,
+                    round_trip_cost_rate=0.0009,
+                    one_day_net_edge_after_entry=0.00355,
+                    one_day_net_edge_after_round_trip=0.0031,
+                    break_even_days_entry=0.2,
+                    break_even_days_round_trip=0.3,
+                    capacity=CapacityEstimate(
+                        short_bid_notional=1400.0,
+                        long_ask_notional=900.0,
+                        max_entry_notional=900.0,
+                        limiting_venue="paradex",
+                    ),
+                ),
+                venue_markets={
+                    "extended": FundingUniverseVenueMarket(
+                        venue="extended",
+                        symbol=f"{symbol}-SHORT",
+                    ),
+                    "paradex": FundingUniverseVenueMarket(
+                        venue="paradex",
+                        symbol=f"{symbol}-LONG",
+                    ),
+                },
+                deployable_notional=900.0,
+                estimated_one_day_pnl_after_round_trip=2.79,
+            ),
+            suggested_canary_notional=11.0,
+        )
+
+    async def fake_scan_exact_canary_candidate_for_approval(
+        **kwargs: object,
+    ) -> tuple[FundingUniverseCanaryCandidate | None, int]:
+        approval = cast(RouteApprovalEntry, kwargs["approval"])
+        scanned_labels.add(approval.label)
+        return _candidate(approval.canonical_symbol), 1
+
+    monkeypatch.setattr(
+        "carryme_worker.poller.scan_exact_canary_candidate_for_approval",
+        fake_scan_exact_canary_candidate_for_approval,
+    )
+
+    summary = asyncio.run(
+        scan_approved_canary_once(
+            settings,
+            scanner=cast(Any, object()),
+            approval_service=RouteApprovalService(store=approval_store),
+            store=snapshot_store,
+            alert_sink=ApprovedCanaryAlertStore(settings.database_path),
+            now=datetime(2026, 4, 2, 10, 10, tzinfo=UTC),
+        )
+    )
+
+    snapshots = snapshot_store.list_recent(limit=10)
+
+    assert settings.approved_canary_scan_limit == 0
+    assert scanned_labels == expected_labels
+    assert summary.scanned_candidates == 6
+    assert summary.approved_candidates == 6
+    assert summary.saved_snapshots == 6
+    assert {snapshot.label for snapshot in snapshots} == expected_labels
 
 
 def test_scan_approved_canary_once_decouples_exact_scan_depth_from_label_budget(


### PR DESCRIPTION
## Summary
- change approved-canary scanning to scan every approved label by default (`0` means no label budget)
- add `CARRYME_WORKER_APPROVED_CANARY_SCAN_CONCURRENCY` so scanning all labels is bounded instead of unbounded fan-out
- document the Render defaults and add tests for default all-label coverage, explicit label limits, and validation

## Why
The old default label budget was 5, so approved routes after the first five labels could stay stale forever unless an operator noticed and raised the limit. That is unsafe for automated route selection because approved opportunities can be silently excluded from the refresh/cache/launch pipeline.

## Deployment Note
The default is now `CARRYME_WORKER_APPROVED_CANARY_SCAN_LIMIT=0`, meaning scan all approved labels. Keep `CARRYME_WORKER_APPROVED_CANARY_SCAN_CONCURRENCY=5` unless Render metrics show the worker can safely handle more.

## Validation
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run pytest -q tests/test_worker.py -k 'approved_canary_scan_limit or approved_canary_scan_concurrency or default_scans_all_approved_labels or limit_counts_labels or scans_labels_in_parallel or does_not_alert_for_budget_skipped_labels'`
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run pytest -q tests/test_worker.py -k 'scan_approved_canary_once'`
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run pytest -q tests/test_worker.py`
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run ruff check .`
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run mypy src apps packages tests`
