### PR TITLE
feat: add lightweight canary snapshot summaries

### DIFF
--- a/apps/api/src/carryme_api/app.py
+++ b/apps/api/src/carryme_api/app.py
@@ -213,6 +213,80 @@ class ConfirmPreviewRequest(BaseModel):
     note: str | None = None
 
 
+class ApprovedCanarySnapshotSummary(BaseModel):
+    """Lightweight approved-canary snapshot payload for production operators."""
+
+    snapshot_id: int | None = None
+    captured_at: datetime
+    label: str
+    canonical_symbol: str
+    long_venue: str
+    short_venue: str
+    long_fee_profile: str
+    short_fee_profile: str
+    suggested_canary_notional: float
+    max_live_notional: float
+    one_day_net_edge_after_round_trip: float
+    estimated_one_day_pnl_after_round_trip: float | None = None
+    deployable_notional: float | None = None
+    route_adjusted_quality_score: float | None = None
+    execution_adjusted_quality_score: float | None = None
+
+
+class LaunchReadyCanarySnapshotSummary(ApprovedCanarySnapshotSummary):
+    """Lightweight launch-ready snapshot payload for production operators."""
+
+    launch_ready_snapshot_id: int | None = None
+    approved_snapshot_id: int | None = None
+    max_snapshot_age_seconds: int
+    system_state_ready: bool
+    system_state_blocking_reasons: list[str] = Field(default_factory=list)
+
+
+def _summarize_approved_canary_snapshot(
+    snapshot: ApprovedCanarySnapshot,
+) -> ApprovedCanarySnapshotSummary:
+    """Return the operator-safe scalar fields from one approved canary snapshot."""
+
+    opportunity = snapshot.candidate.opportunity
+    route = opportunity.opportunity
+    return ApprovedCanarySnapshotSummary(
+        snapshot_id=snapshot.snapshot_id,
+        captured_at=snapshot.captured_at,
+        label=snapshot.label,
+        canonical_symbol=route.canonical_symbol,
+        long_venue=route.long_venue,
+        short_venue=route.short_venue,
+        long_fee_profile=route.long_fee_profile,
+        short_fee_profile=route.short_fee_profile,
+        suggested_canary_notional=snapshot.candidate.suggested_canary_notional,
+        max_live_notional=snapshot.approval.max_live_notional,
+        one_day_net_edge_after_round_trip=route.one_day_net_edge_after_round_trip,
+        estimated_one_day_pnl_after_round_trip=(
+            opportunity.estimated_one_day_pnl_after_round_trip
+        ),
+        deployable_notional=opportunity.deployable_notional,
+        route_adjusted_quality_score=opportunity.route_adjusted_quality_score,
+        execution_adjusted_quality_score=opportunity.execution_adjusted_quality_score,
+    )
+
+
+def _summarize_launch_ready_canary_snapshot(
+    snapshot: LaunchReadyCanarySnapshot,
+) -> LaunchReadyCanarySnapshotSummary:
+    """Return the operator-safe scalar fields from one launch-ready canary snapshot."""
+
+    approved_summary = _summarize_approved_canary_snapshot(snapshot.approved_snapshot)
+    return LaunchReadyCanarySnapshotSummary(
+        **approved_summary.model_dump(mode="python"),
+        launch_ready_snapshot_id=snapshot.launch_ready_snapshot_id,
+        approved_snapshot_id=snapshot.approved_snapshot.snapshot_id,
+        max_snapshot_age_seconds=snapshot.max_snapshot_age_seconds,
+        system_state_ready=snapshot.system_state.ready,
+        system_state_blocking_reasons=snapshot.system_state.blocking_reasons,
+    )
+
+
 def get_app_environment() -> str:
     """Return the runtime environment exposed by the API health endpoints."""
 
@@ -532,6 +606,19 @@ def _validated_history_limit(name: str, value: int) -> int:
 
     if value < 1:
         raise HTTPException(status_code=400, detail=f"{name} must be at least 1")
+    if value > MAX_HISTORY_LIMIT:
+        raise HTTPException(
+            status_code=400,
+            detail=f"{name} must be at most {MAX_HISTORY_LIMIT}",
+        )
+    return value
+
+
+def _validated_list_limit(name: str, value: int) -> int:
+    """Validate bounded list query parameters that may intentionally request zero rows."""
+
+    if value < 0:
+        raise HTTPException(status_code=400, detail=f"{name} must be non-negative")
     if value > MAX_HISTORY_LIMIT:
         raise HTTPException(
             status_code=400,
@@ -3797,9 +3884,23 @@ def create_app() -> FastAPI:
         limit: int = 50,
         label: str | None = None,
     ) -> list[ApprovedCanarySnapshot]:
-        if limit < 0:
-            raise HTTPException(status_code=400, detail="limit must be non-negative")
+        limit = _validated_list_limit("limit", limit)
         return store.list_recent(limit=limit, label=label)
+
+    @app.get(
+        "/v1/opportunities/funding-universe/canary/snapshot-summaries",
+        response_model=list[ApprovedCanarySnapshotSummary],
+    )
+    def approved_canary_snapshot_summaries(
+        store: Annotated[ApprovedCanaryStore, Depends(get_approved_canary_store)],
+        limit: int = 50,
+        label: str | None = None,
+    ) -> list[ApprovedCanarySnapshotSummary]:
+        limit = _validated_list_limit("limit", limit)
+        return [
+            _summarize_approved_canary_snapshot(snapshot)
+            for snapshot in store.list_recent(limit=limit, label=label)
+        ]
 
     @app.get(
         "/v1/opportunities/funding-universe/canary/latest-approved",
@@ -3823,9 +3924,23 @@ def create_app() -> FastAPI:
         limit: int = 50,
         label: str | None = None,
     ) -> list[LaunchReadyCanarySnapshot]:
-        if limit < 0:
-            raise HTTPException(status_code=400, detail="limit must be non-negative")
+        limit = _validated_list_limit("limit", limit)
         return store.list_recent(limit=limit, label=label)
+
+    @app.get(
+        "/v1/executions/live/canary-cycle/launch-ready-snapshot-summaries",
+        response_model=list[LaunchReadyCanarySnapshotSummary],
+    )
+    def launch_ready_canary_snapshot_summaries(
+        store: Annotated[LaunchReadyCanaryStore, Depends(get_launch_ready_canary_store)],
+        limit: int = 50,
+        label: str | None = None,
+    ) -> list[LaunchReadyCanarySnapshotSummary]:
+        limit = _validated_list_limit("limit", limit)
+        return [
+            _summarize_launch_ready_canary_snapshot(snapshot)
+            for snapshot in store.list_recent(limit=limit, label=label)
+        ]
 
     @app.get(
         "/v1/executions/live/canary-cycle/latest-launch-ready",

--- a/apps/api/src/carryme_api/app.py
+++ b/apps/api/src/carryme_api/app.py
@@ -278,7 +278,8 @@ def _summarize_launch_ready_canary_snapshot(
 
     approved_summary = _summarize_approved_canary_snapshot(snapshot.approved_snapshot)
     return LaunchReadyCanarySnapshotSummary(
-        **approved_summary.model_dump(mode="python"),
+        **approved_summary.model_dump(mode="python", exclude={"captured_at"}),
+        captured_at=snapshot.captured_at,
         launch_ready_snapshot_id=snapshot.launch_ready_snapshot_id,
         approved_snapshot_id=snapshot.approved_snapshot.snapshot_id,
         max_snapshot_age_seconds=snapshot.max_snapshot_age_seconds,

--- a/apps/api/src/carryme_api/app.py
+++ b/apps/api/src/carryme_api/app.py
@@ -217,7 +217,9 @@ class ApprovedCanarySnapshotSummary(BaseModel):
     """Lightweight approved-canary snapshot payload for production operators."""
 
     snapshot_id: int | None = None
-    captured_at: datetime
+    captured_at: datetime = Field(
+        description="ISO-8601 UTC timestamp when the approved canary snapshot was captured.",
+    )
     label: str
     canonical_symbol: str
     long_venue: str
@@ -238,7 +240,12 @@ class LaunchReadyCanarySnapshotSummary(ApprovedCanarySnapshotSummary):
 
     launch_ready_snapshot_id: int | None = None
     approved_snapshot_id: int | None = None
-    max_snapshot_age_seconds: int
+    max_snapshot_age_seconds: int = Field(
+        description=(
+            "Maximum age in seconds before the launch-ready snapshot should be treated "
+            "as stale."
+        ),
+    )
     system_state_ready: bool
     system_state_blocking_reasons: list[str] = Field(default_factory=list)
 
@@ -285,6 +292,62 @@ def _summarize_launch_ready_canary_snapshot(
         max_snapshot_age_seconds=snapshot.max_snapshot_age_seconds,
         system_state_ready=snapshot.system_state.ready,
         system_state_blocking_reasons=snapshot.system_state.blocking_reasons,
+    )
+
+
+def _summarize_approved_canary_snapshot_payload(
+    *,
+    snapshot_id: int | None,
+    snapshot_payload: dict[str, Any],
+) -> ApprovedCanarySnapshotSummary:
+    """Return a lightweight approved snapshot summary from raw stored JSON."""
+
+    opportunity = cast(dict[str, Any], snapshot_payload["candidate"]["opportunity"])
+    route = cast(dict[str, Any], opportunity["opportunity"])
+    approval = cast(dict[str, Any], snapshot_payload["approval"])
+    candidate = cast(dict[str, Any], snapshot_payload["candidate"])
+    return ApprovedCanarySnapshotSummary(
+        snapshot_id=snapshot_id,
+        captured_at=snapshot_payload["captured_at"],
+        label=snapshot_payload["label"],
+        canonical_symbol=route["canonical_symbol"],
+        long_venue=route["long_venue"],
+        short_venue=route["short_venue"],
+        long_fee_profile=route["long_fee_profile"],
+        short_fee_profile=route["short_fee_profile"],
+        suggested_canary_notional=candidate["suggested_canary_notional"],
+        max_live_notional=approval["max_live_notional"],
+        one_day_net_edge_after_round_trip=route["one_day_net_edge_after_round_trip"],
+        estimated_one_day_pnl_after_round_trip=opportunity.get(
+            "estimated_one_day_pnl_after_round_trip"
+        ),
+        deployable_notional=opportunity.get("deployable_notional"),
+        route_adjusted_quality_score=opportunity.get("route_adjusted_quality_score"),
+        execution_adjusted_quality_score=opportunity.get("execution_adjusted_quality_score"),
+    )
+
+
+def _summarize_launch_ready_canary_snapshot_payload(
+    *,
+    launch_ready_snapshot_id: int | None,
+    snapshot_payload: dict[str, Any],
+) -> LaunchReadyCanarySnapshotSummary:
+    """Return a lightweight launch-ready snapshot summary from raw stored JSON."""
+
+    approved_payload = cast(dict[str, Any], snapshot_payload["approved_snapshot"])
+    approved_summary = _summarize_approved_canary_snapshot_payload(
+        snapshot_id=approved_payload.get("snapshot_id"),
+        snapshot_payload=approved_payload,
+    )
+    system_state = cast(dict[str, Any], snapshot_payload["system_state"])
+    return LaunchReadyCanarySnapshotSummary(
+        **approved_summary.model_dump(mode="python", exclude={"captured_at"}),
+        captured_at=snapshot_payload["captured_at"],
+        launch_ready_snapshot_id=launch_ready_snapshot_id,
+        approved_snapshot_id=approved_payload.get("snapshot_id"),
+        max_snapshot_age_seconds=snapshot_payload["max_snapshot_age_seconds"],
+        system_state_ready=system_state["ready"],
+        system_state_blocking_reasons=system_state.get("blocking_reasons", []),
     )
 
 
@@ -3899,8 +3962,14 @@ def create_app() -> FastAPI:
     ) -> list[ApprovedCanarySnapshotSummary]:
         limit = _validated_list_limit("limit", limit)
         return [
-            _summarize_approved_canary_snapshot(snapshot)
-            for snapshot in store.list_recent(limit=limit, label=label)
+            _summarize_approved_canary_snapshot_payload(
+                snapshot_id=stored_id,
+                snapshot_payload=snapshot_payload,
+            )
+            for stored_id, snapshot_payload in store.list_recent_payloads(
+                limit=limit,
+                label=label,
+            )
         ]
 
     @app.get(
@@ -3939,8 +4008,14 @@ def create_app() -> FastAPI:
     ) -> list[LaunchReadyCanarySnapshotSummary]:
         limit = _validated_list_limit("limit", limit)
         return [
-            _summarize_launch_ready_canary_snapshot(snapshot)
-            for snapshot in store.list_recent(limit=limit, label=label)
+            _summarize_launch_ready_canary_snapshot_payload(
+                launch_ready_snapshot_id=stored_id,
+                snapshot_payload=snapshot_payload,
+            )
+            for stored_id, snapshot_payload in store.list_recent_payloads(
+                limit=limit,
+                label=label,
+            )
         ]
 
     @app.get(

--- a/packages/storage/src/carryme_storage/approved_canaries.py
+++ b/packages/storage/src/carryme_storage/approved_canaries.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from typing import Any
 
 from carryme_models import ApprovedCanarySnapshot
 
@@ -80,6 +81,24 @@ class ApprovedCanaryStore:
     ) -> list[ApprovedCanarySnapshot]:
         """Return recent approved canary snapshots."""
 
+        return [
+            ApprovedCanarySnapshot.model_validate(
+                {
+                    **snapshot_payload,
+                    "snapshot_id": stored_id,
+                }
+            )
+            for stored_id, snapshot_payload in self.list_recent_payloads(limit=limit, label=label)
+        ]
+
+    def list_recent_payloads(
+        self,
+        *,
+        limit: int = 50,
+        label: str | None = None,
+    ) -> list[tuple[int, dict[str, Any]]]:
+        """Return recent approved canary snapshot payloads without model validation."""
+
         self.initialize()
         query = """
             SELECT id, snapshot_json
@@ -89,21 +108,13 @@ class ApprovedCanaryStore:
         if label:
             query += " WHERE label = ?"
             values.append(label)
-        query += " ORDER BY captured_at DESC LIMIT ?"
+        query += " ORDER BY captured_at DESC, id DESC LIMIT ?"
         values.append(limit)
 
         with self.database.begin() as connection:
             rows = connection.execute(query, tuple(values)).fetchall()
 
-        return [
-            ApprovedCanarySnapshot.model_validate(
-                {
-                    **json.loads(snapshot_json),
-                    "snapshot_id": stored_id,
-                }
-            )
-            for stored_id, snapshot_json in rows
-        ]
+        return [(stored_id, json.loads(snapshot_json)) for stored_id, snapshot_json in rows]
 
     def latest(self, *, label: str | None = None) -> ApprovedCanarySnapshot | None:
         """Return the latest approved canary snapshot, if any."""

--- a/packages/storage/src/carryme_storage/launch_ready_canaries.py
+++ b/packages/storage/src/carryme_storage/launch_ready_canaries.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from typing import Any
 
 from carryme_models import LaunchReadyCanarySnapshot
 
@@ -84,6 +85,24 @@ class LaunchReadyCanaryStore:
     ) -> list[LaunchReadyCanarySnapshot]:
         """Return recent launch-ready canary snapshots."""
 
+        return [
+            LaunchReadyCanarySnapshot.model_validate(
+                {
+                    **snapshot_payload,
+                    "launch_ready_snapshot_id": row_id,
+                }
+            )
+            for row_id, snapshot_payload in self.list_recent_payloads(limit=limit, label=label)
+        ]
+
+    def list_recent_payloads(
+        self,
+        *,
+        limit: int = 50,
+        label: str | None = None,
+    ) -> list[tuple[int, dict[str, Any]]]:
+        """Return recent launch-ready snapshot payloads without model validation."""
+
         self.initialize()
         query = """
             SELECT id, snapshot_json
@@ -100,15 +119,7 @@ class LaunchReadyCanaryStore:
         with self.database.begin() as connection:
             rows = connection.execute(query, params).fetchall()
 
-        return [
-            LaunchReadyCanarySnapshot.model_validate(
-                {
-                    **json.loads(snapshot_json),
-                    "launch_ready_snapshot_id": row_id,
-                }
-            )
-            for row_id, snapshot_json in rows
-        ]
+        return [(row_id, json.loads(snapshot_json)) for row_id, snapshot_json in rows]
 
     def latest(self, *, label: str | None = None) -> LaunchReadyCanarySnapshot | None:
         """Return the latest launch-ready canary snapshot, if any."""

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1230,6 +1230,82 @@ def test_latest_approved_canary_snapshot_endpoint_returns_latest(tmp_path: Path)
     assert payload["approval"]["max_live_notional"] == 11.0
 
 
+def test_approved_canary_snapshot_summaries_order_tied_captures_by_id(tmp_path: Path) -> None:
+    store = ApprovedCanaryStore(tmp_path / "history.sqlite3")
+    captured_at = datetime(2026, 3, 29, 16, 6, tzinfo=UTC)
+    for label in ("first_extended_paradex", "second_extended_paradex"):
+        store.append(
+            ApprovedCanarySnapshot(
+                captured_at=captured_at,
+                label=label,
+                candidate=FundingUniverseCanaryCandidate(
+                    opportunity=FundingUniverseOpportunity(
+                        opportunity=FundingArbOpportunity(
+                            canonical_symbol="ARB-USD-PERP",
+                            long_venue="paradex",
+                            short_venue="extended",
+                            long_fee_profile="pro_fastfills",
+                            short_fee_profile="default",
+                            gross_daily_edge=0.004,
+                            entry_cost_rate=0.00045,
+                            round_trip_cost_rate=0.0009,
+                            one_day_net_edge_after_entry=0.00355,
+                            one_day_net_edge_after_round_trip=0.0031,
+                            break_even_days_entry=0.2,
+                            break_even_days_round_trip=0.3,
+                            capacity=CapacityEstimate(
+                                short_bid_notional=1400.0,
+                                long_ask_notional=900.0,
+                                max_entry_notional=900.0,
+                                limiting_venue="paradex",
+                            ),
+                        ),
+                        venue_markets={
+                            "extended": FundingUniverseVenueMarket(
+                                venue="extended",
+                                symbol="ARB-USD",
+                            ),
+                            "paradex": FundingUniverseVenueMarket(
+                                venue="paradex",
+                                symbol="ARB-USD-PERP",
+                            ),
+                        },
+                        deployable_notional=900.0,
+                        estimated_one_day_pnl_after_round_trip=2.79,
+                    ),
+                    suggested_canary_notional=11.0,
+                ),
+                approval=RouteApprovalEntry(
+                    updated_at=datetime(2026, 3, 29, 16, 5, tzinfo=UTC),
+                    label=label,
+                    canonical_symbol="ARB-USD-PERP",
+                    short_venue="extended",
+                    long_venue="paradex",
+                    short_fee_profile="default",
+                    long_fee_profile="pro_fastfills",
+                    approved=True,
+                    max_live_notional=11.0,
+                    note="approved canary",
+                ),
+            )
+        )
+
+    app.dependency_overrides[get_approved_canary_store] = lambda: store
+    client = TestClient(app)
+    response = client.get(
+        "/v1/opportunities/funding-universe/canary/snapshot-summaries",
+        params={"limit": 5},
+    )
+    app.dependency_overrides.clear()
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert [item["label"] for item in payload] == [
+        "second_extended_paradex",
+        "first_extended_paradex",
+    ]
+
+
 def test_launch_ready_canary_snapshots_endpoint_lists_recent(tmp_path: Path) -> None:
     approved_snapshot = ApprovedCanarySnapshot(
         snapshot_id=3,

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1130,6 +1130,14 @@ def test_approved_canary_snapshots_endpoint_lists_recent(tmp_path: Path) -> None
         "/v1/opportunities/funding-universe/canary/snapshots",
         params={"label": "arb_extended_paradex", "limit": 5},
     )
+    summary_response = client.get(
+        "/v1/opportunities/funding-universe/canary/snapshot-summaries",
+        params={"label": "arb_extended_paradex", "limit": 5},
+    )
+    capped_response = client.get(
+        "/v1/opportunities/funding-universe/canary/snapshots",
+        params={"limit": 1001},
+    )
     app.dependency_overrides.clear()
 
     assert response.status_code == 200
@@ -1137,6 +1145,17 @@ def test_approved_canary_snapshots_endpoint_lists_recent(tmp_path: Path) -> None
     assert len(payload) == 1
     assert payload[0]["label"] == "arb_extended_paradex"
     assert payload[0]["candidate"]["suggested_canary_notional"] == 11.0
+    assert capped_response.status_code == 400
+    assert summary_response.status_code == 200
+    summary_payload = summary_response.json()
+    assert len(summary_payload) == 1
+    assert "candidate" not in summary_payload[0]
+    assert "approval" not in summary_payload[0]
+    assert summary_payload[0]["snapshot_id"] == 1
+    assert summary_payload[0]["label"] == "arb_extended_paradex"
+    assert summary_payload[0]["canonical_symbol"] == "ARB-USD-PERP"
+    assert summary_payload[0]["suggested_canary_notional"] == 11.0
+    assert summary_payload[0]["max_live_notional"] == 11.0
 
 
 def test_latest_approved_canary_snapshot_endpoint_returns_latest(tmp_path: Path) -> None:
@@ -1304,6 +1323,14 @@ def test_launch_ready_canary_snapshots_endpoint_lists_recent(tmp_path: Path) -> 
         "/v1/executions/live/canary-cycle/launch-ready-snapshots",
         params={"label": "arb_extended_paradex", "limit": 5},
     )
+    summary_response = client.get(
+        "/v1/executions/live/canary-cycle/launch-ready-snapshot-summaries",
+        params={"label": "arb_extended_paradex", "limit": 5},
+    )
+    capped_response = client.get(
+        "/v1/executions/live/canary-cycle/launch-ready-snapshots",
+        params={"limit": 1001},
+    )
     app.dependency_overrides.clear()
 
     assert response.status_code == 200
@@ -1311,6 +1338,16 @@ def test_launch_ready_canary_snapshots_endpoint_lists_recent(tmp_path: Path) -> 
     assert len(payload) == 1
     assert payload[0]["label"] == "arb_extended_paradex"
     assert payload[0]["approved_snapshot"]["snapshot_id"] == 3
+    assert capped_response.status_code == 400
+    assert summary_response.status_code == 200
+    summary_payload = summary_response.json()
+    assert len(summary_payload) == 1
+    assert "approved_snapshot" not in summary_payload[0]
+    assert "system_state" not in summary_payload[0]
+    assert summary_payload[0]["launch_ready_snapshot_id"] == 1
+    assert summary_payload[0]["approved_snapshot_id"] == 3
+    assert summary_payload[0]["label"] == "arb_extended_paradex"
+    assert summary_payload[0]["system_state_ready"] is True
 
 
 def test_latest_launch_ready_canary_snapshot_endpoint_returns_latest(tmp_path: Path) -> None:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1347,6 +1347,7 @@ def test_launch_ready_canary_snapshots_endpoint_lists_recent(tmp_path: Path) -> 
     assert summary_payload[0]["launch_ready_snapshot_id"] == 1
     assert summary_payload[0]["approved_snapshot_id"] == 3
     assert summary_payload[0]["label"] == "arb_extended_paradex"
+    assert summary_payload[0]["captured_at"] == "2026-03-29T16:07:00Z"
     assert summary_payload[0]["system_state_ready"] is True
 
 


### PR DESCRIPTION
## Summary
- add lightweight approved-canary snapshot summary endpoint
- add lightweight launch-ready snapshot summary endpoint
- cap the existing full snapshot list endpoints at `MAX_HISTORY_LIMIT` to prevent oversized production/debug responses

## Why
The existing list endpoints return full nested canary snapshots. That is useful for deep inspection, but bad for production ops because broad list calls can create large JSON responses and make debugging harder when the system is under load. The new summary endpoints return scalar route/economics/readiness fields without nested candidate, approval, approved_snapshot, or system_state payloads.

## New Endpoints
- `GET /v1/opportunities/funding-universe/canary/snapshot-summaries`
- `GET /v1/executions/live/canary-cycle/launch-ready-snapshot-summaries`

## Validation
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run pytest -q tests/test_api.py -k 'approved_canary_snapshots_endpoint_lists_recent or launch_ready_canary_snapshots_endpoint_lists_recent'`
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run pytest -q tests/test_api.py -k 'canary_snapshots_endpoint_lists_recent or latest_approved_canary_snapshot_endpoint_returns_latest or latest_launch_ready_canary_snapshot_endpoint_returns_latest'`
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run ruff check .`
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run mypy src apps packages tests`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new API endpoints to retrieve approved and launch-ready canary snapshot summaries with streamlined response payloads

* **Bug Fixes**
  * Enhanced `limit` parameter validation to reject excessively large values across snapshot listing endpoints

* **Tests**
  * Added test coverage for new snapshot summary endpoints and limit parameter validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->