### PR TITLE
perf: shortlist universe scans before orderbooks

### DIFF
--- a/packages/runtime/src/carryme_runtime/__init__.py
+++ b/packages/runtime/src/carryme_runtime/__init__.py
@@ -33,7 +33,12 @@ from carryme_runtime.extended_live_execution import ExtendedLiveExecutionService
 from carryme_runtime.hyperliquid_cleanup_preview import HyperliquidCleanupPreviewService
 from carryme_runtime.hyperliquid_live_execution import HyperliquidLiveExecutionService
 from carryme_runtime.intents import InvalidTradeCandidateError, build_trade_intent
-from carryme_runtime.opportunities import OpportunityService, UpstreamDataError, fetch_live_snapshot
+from carryme_runtime.opportunities import (
+    OpportunityService,
+    UpstreamDataError,
+    fetch_live_market_stats,
+    fetch_live_snapshot,
+)
 from carryme_runtime.order_preview import OrderPreviewService
 from carryme_runtime.pair_close_live_execution import PairCloseLiveExecutionCoordinator
 from carryme_runtime.pair_close_preview import PairClosePreviewService
@@ -116,6 +121,7 @@ __all__ = [
     "VenueSystemProbe",
     "build_opportunity_record_from_universe_opportunity",
     "build_pair_spec_from_universe_opportunity",
+    "fetch_live_market_stats",
     "fetch_live_snapshot",
     "filter_candidate_records",
     "list_live_symbols",

--- a/packages/runtime/src/carryme_runtime/opportunities.py
+++ b/packages/runtime/src/carryme_runtime/opportunities.py
@@ -14,7 +14,7 @@ from carryme_connectors import (
     ParadexPublicConnector,
     PublicVenueConnector,
 )
-from carryme_models import FundingArbOpportunity, NormalizedMarketSnapshot
+from carryme_models import FundingArbOpportunity, MarketStats, NormalizedMarketSnapshot
 from carryme_normalizers import (
     NormalizationError,
     get_fee_profile,
@@ -28,6 +28,12 @@ class SnapshotFetcher(Protocol):
     """Interface for fetching normalized live market snapshots."""
 
     async def __call__(self, venue: str, symbol: str) -> NormalizedMarketSnapshot: ...
+
+
+class MarketStatsFetcher(Protocol):
+    """Interface for fetching lightweight live market stats without an orderbook."""
+
+    async def __call__(self, venue: str, symbol: str) -> MarketStats: ...
 
 
 ConnectorFactory = Callable[[httpx.AsyncClient], PublicVenueConnector]
@@ -79,6 +85,19 @@ async def fetch_live_snapshot(venue: str, symbol: str) -> NormalizedMarketSnapsh
     return normalized
 
 
+async def fetch_live_market_stats(venue: str, symbol: str) -> MarketStats:
+    """Fetch lightweight live market stats without joining the top of book."""
+
+    key = venue.strip().lower()
+    venue_config = VENUE_REGISTRY.get(key)
+    if venue_config is None:
+        raise ValueError(f"Unsupported venue: {venue}")
+    base_url, _connector_class = venue_config
+
+    async with httpx.AsyncClient(base_url=base_url, timeout=15.0) as client:
+        return await _build_connector(key, client).fetch_market_stats(symbol)
+
+
 @dataclass
 class OpportunityService:
     """Application service for live funding opportunity scoring."""
@@ -121,4 +140,11 @@ def _build_connector(venue: str, client: httpx.AsyncClient) -> PublicVenueConnec
     return connector_class(client)
 
 
-__all__ = ["OpportunityService", "UpstreamDataError", "fetch_live_snapshot"]
+__all__ = [
+    "MarketStatsFetcher",
+    "OpportunityService",
+    "SnapshotFetcher",
+    "UpstreamDataError",
+    "fetch_live_market_stats",
+    "fetch_live_snapshot",
+]

--- a/packages/runtime/src/carryme_runtime/universe.py
+++ b/packages/runtime/src/carryme_runtime/universe.py
@@ -29,19 +29,27 @@ from carryme_models import (
     FundingUniversePortfolioPlan,
     FundingUniverseScan,
     FundingUniverseVenueMarket,
+    MarketStats,
     NormalizedMarketSnapshot,
     OpportunityRecord,
     RouteStabilitySummary,
     TopOfBook,
 )
-from carryme_normalizers import get_fee_profile, normalize_symbol
+from carryme_normalizers import (
+    NormalizationError,
+    get_fee_profile,
+    normalize_market_snapshot,
+    normalize_symbol,
+)
 from carryme_scoring import score_funding_pair
 
 from carryme_runtime.execution_quality import ExecutionQualityService
 from carryme_runtime.opportunities import (
     VENUE_REGISTRY,
+    MarketStatsFetcher,
     SnapshotFetcher,
     UpstreamDataError,
+    fetch_live_market_stats,
     fetch_live_snapshot,
 )
 from carryme_runtime.route_stability import RouteStabilityService
@@ -77,6 +85,8 @@ DEFAULT_SNAPSHOT_CONCURRENCY_BY_VENUE: dict[str, int] = {
     "hyperliquid": 8,
     "paradex": 3,
 }
+DEFAULT_SNAPSHOT_SHORTLIST_MIN_OVERLAPS = 20
+DEFAULT_SNAPSHOT_SHORTLIST_MULTIPLIER = 4
 RETRYABLE_SNAPSHOT_STATUS_CODES = frozenset({408, 429, 500, 502, 503, 504})
 UNIVERSE_RANKINGS: tuple[UniverseRanking, ...] = (
     "roundtrip_edge",
@@ -102,11 +112,14 @@ class OpportunityUniverseService:
 
     list_symbols: VenueSymbolLister = field(default_factory=lambda: list_live_symbols)
     fetch_snapshot: SnapshotFetcher = field(default_factory=lambda: fetch_live_snapshot)
+    fetch_market_stats: MarketStatsFetcher = field(default_factory=lambda: fetch_live_market_stats)
     default_fee_profiles: dict[str, str] = field(default_factory=_default_universe_fee_profiles)
     snapshot_concurrency_by_venue: dict[str, int] = field(
         default_factory=lambda: dict(DEFAULT_SNAPSHOT_CONCURRENCY_BY_VENUE)
     )
     snapshot_batch_size: int | None = None
+    snapshot_shortlist_min_overlaps: int = DEFAULT_SNAPSHOT_SHORTLIST_MIN_OVERLAPS
+    snapshot_shortlist_multiplier: int = DEFAULT_SNAPSHOT_SHORTLIST_MULTIPLIER
     snapshot_retry_attempts: int = 3
     snapshot_retry_backoff_seconds: float = 0.25
     execution_quality_service: ExecutionQualityService | None = None
@@ -248,7 +261,15 @@ class OpportunityUniverseService:
                 exclude_tags=exclude_tags,
             )
         ]
-        snapshots = await self._fetch_overlapping_snapshots(filtered_overlaps)
+        snapshot_overlaps = await self._shortlist_overlaps_for_snapshots(
+            filtered_overlaps,
+            fee_profiles=fee_profiles,
+            limit=limit,
+            min_daily_volume=min_daily_volume,
+            min_open_interest=min_open_interest,
+            min_roundtrip_edge=min_roundtrip_edge,
+        )
+        snapshots = await self._fetch_overlapping_snapshots(snapshot_overlaps)
         (
             execution_quality_index,
             execution_prior_score,
@@ -256,7 +277,7 @@ class OpportunityUniverseService:
         route_stability_index = await self._build_route_stability_index_cached()
 
         opportunities: list[FundingUniverseOpportunity] = []
-        for overlap in filtered_overlaps:
+        for overlap in snapshot_overlaps:
             entries = [
                 (venue, symbol, snapshots[(venue, symbol)])
                 for venue, symbol in overlap.venue_symbols.items()
@@ -389,6 +410,108 @@ class OpportunityUniverseService:
         assert self.route_stability_service is not None
         return self.route_stability_service.build_index()
 
+    async def _shortlist_overlaps_for_snapshots(
+        self,
+        overlaps: list[FundingUniverseOverlap],
+        *,
+        fee_profiles: dict[str, str],
+        limit: int,
+        min_daily_volume: float,
+        min_open_interest: float,
+        min_roundtrip_edge: float,
+    ) -> list[FundingUniverseOverlap]:
+        """Use lightweight market stats to choose which overlaps need full orderbooks."""
+
+        shortlist_size = self._snapshot_shortlist_size(limit)
+        if shortlist_size <= 0 or len(overlaps) <= shortlist_size:
+            return overlaps
+
+        stats = await self._fetch_overlapping_market_stats(overlaps)
+        scored: list[tuple[tuple[float, float, float, str], FundingUniverseOverlap]] = []
+        for overlap in overlaps:
+            best_score: tuple[float, float, float, str] | None = None
+            entries = [
+                (venue, symbol, stats[(venue, symbol)])
+                for venue, symbol in overlap.venue_symbols.items()
+                if (venue, symbol) in stats
+            ]
+            for (left_venue, _left_symbol, left), (
+                right_venue,
+                _right_symbol,
+                right,
+            ) in itertools.combinations(entries, 2):
+                try:
+                    opportunity = score_funding_pair(
+                        left,
+                        right,
+                        get_fee_profile(left_venue, fee_profiles[left_venue]),
+                        get_fee_profile(right_venue, fee_profiles[right_venue]),
+                    )
+                except ValueError:
+                    continue
+                venue_markets = [_venue_market(left), _venue_market(right)]
+                min_volume = _min_metric(venue_markets, "daily_volume")
+                min_oi = _min_metric(venue_markets, "open_interest")
+                if opportunity.one_day_net_edge_after_round_trip < min_roundtrip_edge:
+                    continue
+                if (min_volume or 0.0) < min_daily_volume:
+                    continue
+                if (min_oi or 0.0) < min_open_interest:
+                    continue
+                score = (
+                    opportunity.one_day_net_edge_after_round_trip,
+                    min_volume or 0.0,
+                    min_oi or 0.0,
+                    overlap.canonical_symbol,
+                )
+                if best_score is None or score > best_score:
+                    best_score = score
+            if best_score is not None:
+                scored.append((best_score, overlap))
+
+        ranked = sorted(scored, key=lambda item: item[0], reverse=True)
+        return [overlap for _score, overlap in ranked[:shortlist_size]]
+
+    async def _fetch_overlapping_market_stats(
+        self,
+        overlaps: list[FundingUniverseOverlap],
+    ) -> dict[tuple[str, str], NormalizedMarketSnapshot]:
+        semaphores = {
+            venue: asyncio.Semaphore(max(self.snapshot_concurrency_by_venue.get(venue, 1), 1))
+            for venue in VENUE_REGISTRY
+        }
+        snapshots: dict[tuple[str, str], NormalizedMarketSnapshot] = {}
+        items = [
+            (venue, symbol)
+            for overlap in overlaps
+            for venue, symbol in overlap.venue_symbols.items()
+        ]
+        batch_size = self._effective_snapshot_batch_size()
+        for start in range(0, len(items), batch_size):
+            batch = items[start : start + batch_size]
+            tasks = {
+                (venue, symbol): asyncio.create_task(
+                    self._fetch_market_stats_with_controls(
+                        venue,
+                        symbol,
+                        semaphore=semaphores[venue],
+                    )
+                )
+                for venue, symbol in batch
+            }
+            for key, task in tasks.items():
+                try:
+                    snapshots[key] = await task
+                except (
+                    ValueError,
+                    NormalizationError,
+                    UpstreamDataError,
+                    ConnectorError,
+                    httpx.HTTPError,
+                ):
+                    continue
+        return snapshots
+
     async def _fetch_overlapping_snapshots(
         self,
         overlaps: list[FundingUniverseOverlap],
@@ -433,6 +556,36 @@ class OpportunityUniverseService:
             ),
             1,
         )
+
+    def _snapshot_shortlist_size(self, limit: int) -> int:
+        if limit <= 0:
+            return 0
+        return max(
+            max(self.snapshot_shortlist_min_overlaps, 1),
+            limit * max(self.snapshot_shortlist_multiplier, 1),
+        )
+
+    async def _fetch_market_stats_with_controls(
+        self,
+        venue: str,
+        symbol: str,
+        *,
+        semaphore: asyncio.Semaphore,
+    ) -> NormalizedMarketSnapshot:
+        attempts = max(self.snapshot_retry_attempts, 1)
+        for attempt in range(1, attempts + 1):
+            try:
+                async with semaphore:
+                    market = await self.fetch_market_stats(venue, symbol)
+                return _normalize_market_stats_snapshot(venue, symbol, market)
+            except (ValueError, NormalizationError, UpstreamDataError):
+                raise
+            except (ConnectorError, httpx.HTTPError) as exc:
+                if attempt >= attempts or not _is_retryable_snapshot_error(exc):
+                    raise
+                base_delay = self.snapshot_retry_backoff_seconds * (2 ** (attempt - 1))
+                await asyncio.sleep(base_delay * random.uniform(0.75, 1.25))
+        raise UpstreamDataError(f"Could not fetch market stats for {venue}:{symbol}")
 
     async def _fetch_snapshot_with_controls(
         self,
@@ -480,6 +633,23 @@ async def list_live_symbols(venue: str) -> list[str]:
     async with httpx.AsyncClient(base_url=base_url, timeout=20.0) as client:
         connector = _build_connector(key, client)
         return await connector.list_market_symbols()
+
+
+def _normalize_market_stats_snapshot(
+    venue: str,
+    symbol: str,
+    market: MarketStats,
+) -> NormalizedMarketSnapshot:
+    key = venue.strip().lower()
+    expected_identity = normalize_symbol(key, symbol)
+    normalized = normalize_market_snapshot(key, market)
+    if normalized.identity.canonical_symbol != expected_identity.canonical_symbol:
+        raise UpstreamDataError(
+            f"Upstream market data symbol mismatch for {key}:{symbol}: "
+            "expected "
+            f"{expected_identity.canonical_symbol}, got {normalized.identity.canonical_symbol}"
+        )
+    return normalized
 
 
 def _build_connector(venue: str, client: httpx.AsyncClient) -> PublicVenueConnector:

--- a/packages/runtime/src/carryme_runtime/universe.py
+++ b/packages/runtime/src/carryme_runtime/universe.py
@@ -100,6 +100,7 @@ UNIVERSE_RANKINGS: tuple[UniverseRanking, ...] = (
     "stability_adjusted_quality_pnl",
     "route_adjusted_quality_pnl",
 )
+SHORTLIST_CAPPED_RANKINGS = frozenset({"roundtrip_edge", "entry_edge"})
 
 
 def _default_universe_fee_profiles() -> dict[str, str]:
@@ -263,6 +264,7 @@ class OpportunityUniverseService:
         ]
         snapshot_overlaps = await self._shortlist_overlaps_for_snapshots(
             filtered_overlaps,
+            ranking=normalized_ranking,
             fee_profiles=fee_profiles,
             limit=limit,
             min_daily_volume=min_daily_volume,
@@ -414,6 +416,7 @@ class OpportunityUniverseService:
         self,
         overlaps: list[FundingUniverseOverlap],
         *,
+        ranking: UniverseRanking,
         fee_profiles: dict[str, str],
         limit: int,
         min_daily_volume: float,
@@ -423,11 +426,12 @@ class OpportunityUniverseService:
         """Use lightweight market stats to choose which overlaps need full orderbooks."""
 
         shortlist_size = self._snapshot_shortlist_size(limit)
-        if shortlist_size <= 0 or len(overlaps) <= shortlist_size:
+        if len(overlaps) <= 1:
             return overlaps
 
         stats = await self._fetch_overlapping_market_stats(overlaps)
         scored: list[tuple[tuple[float, float, float, str], FundingUniverseOverlap]] = []
+        unscored: list[FundingUniverseOverlap] = []
         for overlap in overlaps:
             best_score: tuple[float, float, float, str] | None = None
             entries = [
@@ -459,7 +463,7 @@ class OpportunityUniverseService:
                 if (min_oi or 0.0) < min_open_interest:
                     continue
                 score = (
-                    opportunity.one_day_net_edge_after_round_trip,
+                    _shortlist_ranking_value(opportunity, ranking),
                     min_volume or 0.0,
                     min_oi or 0.0,
                     overlap.canonical_symbol,
@@ -468,9 +472,15 @@ class OpportunityUniverseService:
                     best_score = score
             if best_score is not None:
                 scored.append((best_score, overlap))
+            else:
+                unscored.append(overlap)
 
         ranked = sorted(scored, key=lambda item: item[0], reverse=True)
-        return [overlap for _score, overlap in ranked[:shortlist_size]]
+        ordered = [overlap for _score, overlap in ranked]
+        ordered.extend(unscored)
+        if shortlist_size <= 0 or ranking not in SHORTLIST_CAPPED_RANKINGS:
+            return ordered
+        return ordered[:shortlist_size]
 
     async def _fetch_overlapping_market_stats(
         self,
@@ -1106,6 +1116,12 @@ def _ranking_value(opportunity: FundingUniverseOpportunity, ranking: UniverseRan
     if ranking == "stability_adjusted_quality_pnl":
         return _rankable(opportunity.stability_adjusted_quality_score)
     return _rankable(opportunity.quality_score)
+
+
+def _shortlist_ranking_value(opportunity: FundingArbOpportunity, ranking: UniverseRanking) -> float:
+    if ranking == "entry_edge":
+        return opportunity.one_day_net_edge_after_entry
+    return opportunity.one_day_net_edge_after_round_trip
 
 
 def _normalize_venues(venues: list[str]) -> list[str]:

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -1074,6 +1074,88 @@ def test_opportunity_universe_service_filters_overlaps_before_snapshot_fetch() -
     asyncio.run(run())
 
 
+def test_opportunity_universe_service_shortlists_summaries_before_full_snapshots() -> None:
+    symbol_lists = {
+        "extended": ["TOP-USD", "MID-USD", "LOW-USD"],
+        "paradex": ["TOP-USD-PERP", "MID-USD-PERP", "LOW-USD-PERP"],
+    }
+    summary_snapshots = {
+        ("extended", "TOP-USD"): _snapshot(
+            "extended", "TOP-USD", 0.0004, 1.0, 10_000, 1.001, 10_000
+        ),
+        ("paradex", "TOP-USD-PERP"): _snapshot(
+            "paradex", "TOP-USD-PERP", -0.0004, 1.0, 10_000, 1.001, 10_000
+        ),
+        ("extended", "MID-USD"): _snapshot(
+            "extended", "MID-USD", 0.0002, 1.0, 10_000, 1.001, 10_000
+        ),
+        ("paradex", "MID-USD-PERP"): _snapshot(
+            "paradex", "MID-USD-PERP", -0.0001, 1.0, 10_000, 1.001, 10_000
+        ),
+        ("extended", "LOW-USD"): _snapshot(
+            "extended", "LOW-USD", 0.00001, 1.0, 10_000, 1.001, 10_000
+        ),
+        ("paradex", "LOW-USD-PERP"): _snapshot(
+            "paradex", "LOW-USD-PERP", 0.0, 1.0, 10_000, 1.001, 10_000
+        ),
+    }
+    full_snapshots = {
+        ("extended", "TOP-USD"): summary_snapshots[("extended", "TOP-USD")],
+        ("paradex", "TOP-USD-PERP"): summary_snapshots[("paradex", "TOP-USD-PERP")],
+    }
+    fetched_stats: list[tuple[str, str]] = []
+    fetched_full_snapshots: list[tuple[str, str]] = []
+
+    async def list_symbols(venue: str) -> list[str]:
+        return symbol_lists[venue]
+
+    async def fetch_market_stats(venue: str, symbol: str) -> MarketStats:
+        fetched_stats.append((venue, symbol))
+        return summary_snapshots[(venue, symbol)].market.model_copy(
+            update={"top_of_book": None}
+        )
+
+    async def fetch_snapshot(venue: str, symbol: str) -> NormalizedMarketSnapshot:
+        fetched_full_snapshots.append((venue, symbol))
+        try:
+            return full_snapshots[(venue, symbol)]
+        except KeyError as exc:
+            raise AssertionError(
+                f"unexpected full snapshot for non-shortlisted symbol: {(venue, symbol)}"
+            ) from exc
+
+    async def run() -> None:
+        service = OpportunityUniverseService(
+            list_symbols=list_symbols,
+            fetch_market_stats=fetch_market_stats,
+            fetch_snapshot=fetch_snapshot,
+            snapshot_shortlist_min_overlaps=1,
+            snapshot_shortlist_multiplier=1,
+        )
+        scan = await service.scan(
+            venues=["extended", "paradex"],
+            ranking="roundtrip_edge",
+            limit=1,
+        )
+
+        assert scan.overlap_count == 3
+        assert {item.canonical_symbol for item in scan.overlaps} == {
+            "TOP-USD-PERP",
+            "MID-USD-PERP",
+            "LOW-USD-PERP",
+        }
+        assert [item.opportunity.canonical_symbol for item in scan.opportunities] == [
+            "TOP-USD-PERP"
+        ]
+        assert set(fetched_stats) == set(summary_snapshots)
+        assert set(fetched_full_snapshots) == {
+            ("extended", "TOP-USD"),
+            ("paradex", "TOP-USD-PERP"),
+        }
+
+    asyncio.run(run())
+
+
 def test_opportunity_universe_service_excludes_policy_tags() -> None:
     symbol_lists = {
         "extended": ["TRUMP-USD", "LIT-USD"],

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -8,6 +8,7 @@ from typing import Any, Literal, cast
 import httpx
 import pytest
 from carryme_connectors import (
+    ConnectorError,
     ParadexJwtTokenProvider,
     build_paradex_auth_headers,
     build_paradex_auth_request_path,
@@ -1152,6 +1153,198 @@ def test_opportunity_universe_service_shortlists_summaries_before_full_snapshots
             ("extended", "TOP-USD"),
             ("paradex", "TOP-USD-PERP"),
         }
+
+    asyncio.run(run())
+
+
+def test_opportunity_universe_service_orders_unbounded_scans_with_market_stats() -> None:
+    symbol_lists = {
+        "extended": ["TOP-USD", "MID-USD", "LOW-USD"],
+        "paradex": ["TOP-USD-PERP", "MID-USD-PERP", "LOW-USD-PERP"],
+    }
+    summary_snapshots = {
+        ("extended", "TOP-USD"): _snapshot(
+            "extended", "TOP-USD", 0.0004, 1.0, 10_000, 1.001, 10_000
+        ),
+        ("paradex", "TOP-USD-PERP"): _snapshot(
+            "paradex", "TOP-USD-PERP", -0.0004, 1.0, 10_000, 1.001, 10_000
+        ),
+        ("extended", "MID-USD"): _snapshot(
+            "extended", "MID-USD", 0.0002, 1.0, 10_000, 1.001, 10_000
+        ),
+        ("paradex", "MID-USD-PERP"): _snapshot(
+            "paradex", "MID-USD-PERP", -0.0001, 1.0, 10_000, 1.001, 10_000
+        ),
+        ("extended", "LOW-USD"): _snapshot(
+            "extended", "LOW-USD", 0.00001, 1.0, 10_000, 1.001, 10_000
+        ),
+        ("paradex", "LOW-USD-PERP"): _snapshot(
+            "paradex", "LOW-USD-PERP", 0.0, 1.0, 10_000, 1.001, 10_000
+        ),
+    }
+    fetched_stats: list[tuple[str, str]] = []
+    fetched_full_snapshots: list[tuple[str, str]] = []
+
+    async def list_symbols(venue: str) -> list[str]:
+        return symbol_lists[venue]
+
+    async def fetch_market_stats(venue: str, symbol: str) -> MarketStats:
+        fetched_stats.append((venue, symbol))
+        return summary_snapshots[(venue, symbol)].market.model_copy(
+            update={"top_of_book": None}
+        )
+
+    async def fetch_snapshot(venue: str, symbol: str) -> NormalizedMarketSnapshot:
+        fetched_full_snapshots.append((venue, symbol))
+        return summary_snapshots[(venue, symbol)]
+
+    async def run() -> None:
+        service = OpportunityUniverseService(
+            list_symbols=list_symbols,
+            fetch_market_stats=fetch_market_stats,
+            fetch_snapshot=fetch_snapshot,
+            snapshot_batch_size=1,
+            snapshot_shortlist_min_overlaps=1,
+            snapshot_shortlist_multiplier=1,
+        )
+        scan = await service.scan(
+            venues=["extended", "paradex"],
+            ranking="roundtrip_edge",
+            limit=0,
+        )
+
+        assert scan.overlap_count == 3
+        assert set(fetched_stats) == set(summary_snapshots)
+        assert set(fetched_full_snapshots) == set(summary_snapshots)
+        assert fetched_full_snapshots[:2] == [
+            ("extended", "TOP-USD"),
+            ("paradex", "TOP-USD-PERP"),
+        ]
+
+    asyncio.run(run())
+
+
+def test_opportunity_universe_service_preserves_non_edge_ranking_correctness() -> None:
+    symbol_lists = {
+        "extended": ["HIGHEDGE-USD", "BIG-USD"],
+        "paradex": ["HIGHEDGE-USD-PERP", "BIG-USD-PERP"],
+    }
+    summary_snapshots = {
+        ("extended", "HIGHEDGE-USD"): _snapshot(
+            "extended", "HIGHEDGE-USD", 0.0005, 1.0, 10_000, 1.001, 10_000
+        ),
+        ("paradex", "HIGHEDGE-USD-PERP"): _snapshot(
+            "paradex", "HIGHEDGE-USD-PERP", -0.0005, 1.0, 10_000, 1.001, 10_000
+        ),
+        ("extended", "BIG-USD"): _snapshot(
+            "extended", "BIG-USD", 0.0003, 1.0, 10_000, 1.001, 10_000
+        ),
+        ("paradex", "BIG-USD-PERP"): _snapshot(
+            "paradex", "BIG-USD-PERP", -0.0002, 1.0, 10_000, 1.001, 10_000
+        ),
+    }
+    full_snapshots = {
+        ("extended", "HIGHEDGE-USD"): _snapshot(
+            "extended", "HIGHEDGE-USD", 0.0005, 1.0, 5.0, 1.001, 5.0
+        ),
+        ("paradex", "HIGHEDGE-USD-PERP"): _snapshot(
+            "paradex", "HIGHEDGE-USD-PERP", -0.0005, 1.0, 5.0, 1.001, 5.0
+        ),
+        ("extended", "BIG-USD"): _snapshot(
+            "extended", "BIG-USD", 0.0003, 1.0, 10_000, 1.001, 10_000
+        ),
+        ("paradex", "BIG-USD-PERP"): _snapshot(
+            "paradex", "BIG-USD-PERP", -0.0002, 1.0, 10_000, 1.001, 10_000
+        ),
+    }
+    fetched_full_snapshots: list[tuple[str, str]] = []
+
+    async def list_symbols(venue: str) -> list[str]:
+        return symbol_lists[venue]
+
+    async def fetch_market_stats(venue: str, symbol: str) -> MarketStats:
+        return summary_snapshots[(venue, symbol)].market.model_copy(
+            update={"top_of_book": None}
+        )
+
+    async def fetch_snapshot(venue: str, symbol: str) -> NormalizedMarketSnapshot:
+        fetched_full_snapshots.append((venue, symbol))
+        return full_snapshots[(venue, symbol)]
+
+    async def run() -> None:
+        service = OpportunityUniverseService(
+            list_symbols=list_symbols,
+            fetch_market_stats=fetch_market_stats,
+            fetch_snapshot=fetch_snapshot,
+            snapshot_shortlist_min_overlaps=1,
+            snapshot_shortlist_multiplier=1,
+        )
+        scan = await service.scan(
+            venues=["extended", "paradex"],
+            ranking="roundtrip_pnl",
+            limit=1,
+        )
+
+        assert [item.opportunity.canonical_symbol for item in scan.opportunities] == [
+            "BIG-USD-PERP"
+        ]
+        assert set(fetched_full_snapshots) == set(full_snapshots)
+
+    asyncio.run(run())
+
+
+def test_opportunity_universe_service_shortlists_unscored_overlaps_when_stats_fail() -> None:
+    symbol_lists = {
+        "extended": ["GOOD-USD", "BROKEN-USD"],
+        "paradex": ["GOOD-USD-PERP", "BROKEN-USD-PERP"],
+    }
+    snapshots = {
+        ("extended", "GOOD-USD"): _snapshot(
+            "extended", "GOOD-USD", 0.0004, 1.0, 10_000, 1.001, 10_000
+        ),
+        ("paradex", "GOOD-USD-PERP"): _snapshot(
+            "paradex", "GOOD-USD-PERP", -0.0004, 1.0, 10_000, 1.001, 10_000
+        ),
+        ("extended", "BROKEN-USD"): _snapshot(
+            "extended", "BROKEN-USD", 0.0003, 1.0, 10_000, 1.001, 10_000
+        ),
+        ("paradex", "BROKEN-USD-PERP"): _snapshot(
+            "paradex", "BROKEN-USD-PERP", -0.0002, 1.0, 10_000, 1.001, 10_000
+        ),
+    }
+    fetched_full_snapshots: list[tuple[str, str]] = []
+
+    async def list_symbols(venue: str) -> list[str]:
+        return symbol_lists[venue]
+
+    async def fetch_market_stats(venue: str, symbol: str) -> MarketStats:
+        if symbol.startswith("BROKEN"):
+            raise ConnectorError("stats unavailable")
+        return snapshots[(venue, symbol)].market.model_copy(update={"top_of_book": None})
+
+    async def fetch_snapshot(venue: str, symbol: str) -> NormalizedMarketSnapshot:
+        fetched_full_snapshots.append((venue, symbol))
+        return snapshots[(venue, symbol)]
+
+    async def run() -> None:
+        service = OpportunityUniverseService(
+            list_symbols=list_symbols,
+            fetch_market_stats=fetch_market_stats,
+            fetch_snapshot=fetch_snapshot,
+            snapshot_shortlist_min_overlaps=1,
+            snapshot_shortlist_multiplier=1,
+        )
+        scan = await service.scan(
+            venues=["extended", "paradex"],
+            ranking="roundtrip_edge",
+            limit=2,
+        )
+
+        assert {item.opportunity.canonical_symbol for item in scan.opportunities} == {
+            "GOOD-USD-PERP",
+            "BROKEN-USD-PERP",
+        }
+        assert set(fetched_full_snapshots) == set(snapshots)
 
     asyncio.run(run())
 


### PR DESCRIPTION
## Summary
- add lightweight market-stats fetching for universe scans before expensive full snapshot/orderbook fetching
- shortlist overlap symbols from summary funding edge, volume, and open-interest filters before fetching full orderbooks
- keep existing snapshot batch/concurrency controls for both summary and full snapshot phases

## Why
Universe scans previously discovered overlaps and then fetched full snapshots/orderbooks for every filtered overlap before applying `limit`. That is exactly the path that can overload small Render workers. This change still discovers all overlaps, but only fetches full orderbooks for the strongest summary-ranked shortlist when `limit > 0`.

## Notes
- `limit <= 0` preserves the old full-scan behavior.
- Defaults fetch full snapshots for `max(20, limit * 4)` shortlisted overlaps.
- Full opportunity scoring and liquidity filters still run on the final full snapshots.

## Validation
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run pytest -q tests/test_runtime.py -k 'shortlists_summaries_before_full_snapshots or filters_overlaps_before_snapshot_fetch or batches_snapshot_tasks or limits_snapshot_concurrency_by_venue'`
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run pytest -q tests/test_runtime.py -k 'opportunity_universe_service'`
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run pytest -q tests/test_runtime.py`
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run ruff check .`
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run mypy src apps packages tests`
