### PR TITLE
feat: add production automation readiness endpoint

### DIFF
--- a/apps/api/src/carryme_api/app.py
+++ b/apps/api/src/carryme_api/app.py
@@ -21,6 +21,7 @@ from carryme_models import (
     ApprovedCanaryAlertEvent,
     ApprovedCanaryBasketPlan,
     ApprovedCanarySnapshot,
+    AutomationSnapshotSummary,
     CanaryBasketBalanceDelta,
     CanaryBasketLaunchResult,
     CanaryBasketRouteOutcome,
@@ -59,6 +60,7 @@ from carryme_models import (
     PaperTradeOrderPreview,
     PaperTradeSystemState,
     PreviewConfirmationEntry,
+    ProductionAutomationReadiness,
     RouteAccountingSummary,
     RouteApprovalEntry,
     RouteApprovalUpsert,
@@ -142,6 +144,7 @@ from carryme_storage import (
     PaperTradeStore,
     PreviewConfirmationStore,
     RouteApprovalStore,
+    StableCanaryLaunchStore,
     StableLaunchReadyAlertStore,
     SystemStateAlertStore,
     WatchlistStore,
@@ -607,6 +610,14 @@ def get_stable_launch_ready_alert_store(
     """Return the shared stable launch-ready alert store."""
 
     return StableLaunchReadyAlertStore(settings.database_path)
+
+
+def get_stable_canary_launch_store(
+    settings: Annotated[ApiSettings, Depends(get_api_settings)],
+) -> StableCanaryLaunchStore:
+    """Return the shared stable canary launch record store."""
+
+    return StableCanaryLaunchStore(settings.database_path)
 
 
 def get_route_stability_service(
@@ -2915,6 +2926,67 @@ def _build_launch_ready_canary_stability(
     )
 
 
+def _append_unique_blocking_reason(reasons: list[str], reason: object) -> None:
+    normalized = str(reason)
+    if normalized not in reasons:
+        reasons.append(normalized)
+
+
+def _automation_snapshot_summary(
+    *,
+    snapshot_id: int | None,
+    label: str,
+    captured_at: datetime,
+    now: datetime,
+) -> AutomationSnapshotSummary:
+    return AutomationSnapshotSummary(
+        snapshot_id=snapshot_id,
+        label=label,
+        captured_at=captured_at,
+        age_seconds=max(0.0, (now - captured_at).total_seconds()),
+    )
+
+
+def _count_blocking_live_executions_for_automation_readiness(
+    *,
+    execution_store: ExecutionJournalStore,
+    observation_store: ExecutionObservationStore,
+    now: datetime,
+    max_observation_age_seconds: int,
+    scan_limit: int,
+) -> int:
+    seen_paper_trade_ids: set[int] = set()
+    blocking_count = 0
+    for execution in execution_store.list_recent(limit=scan_limit):
+        if execution.mode != "live" or execution.paper_trade_id is None:
+            continue
+        paper_trade_id = execution.paper_trade_id
+        if paper_trade_id in seen_paper_trade_ids:
+            continue
+        seen_paper_trade_ids.add(paper_trade_id)
+        latest_observation = observation_store.latest_for_paper_trade(paper_trade_id)
+        if latest_observation is None:
+            blocking_count += 1
+            continue
+        observation_age_seconds = max(
+            0.0,
+            (now - latest_observation.observed_at).total_seconds(),
+        )
+        if observation_age_seconds > max_observation_age_seconds:
+            blocking_count += 1
+            continue
+        pair_status = latest_observation.pair_status
+        if pair_status is None:
+            blocking_count += 1
+            continue
+        if (
+            pair_status.derived_state in {"hedged", "cleanup_needed", "review_required"}
+            or pair_status.recommended_action != "no_action"
+        ):
+            blocking_count += 1
+    return blocking_count
+
+
 def _append_paper_trade_from_canary_candidate(
     *,
     candidate: FundingUniverseCanaryCandidate,
@@ -4086,6 +4158,184 @@ def create_app() -> FastAPI:
             max_snapshot_age_seconds=max_snapshot_age_seconds,
             min_snapshot_count=min_snapshot_count,
             min_stable_seconds=min_stable_seconds,
+        )
+
+    @app.get(
+        "/v1/automation/readiness",
+        response_model=ProductionAutomationReadiness,
+    )
+    def production_automation_readiness(
+        approved_store: Annotated[ApprovedCanaryStore, Depends(get_approved_canary_store)],
+        launch_ready_store: Annotated[
+            LaunchReadyCanaryStore,
+            Depends(get_launch_ready_canary_store),
+        ],
+        stable_launch_store: Annotated[
+            StableCanaryLaunchStore,
+            Depends(get_stable_canary_launch_store),
+        ],
+        execution_store: Annotated[ExecutionJournalStore, Depends(get_execution_journal_store)],
+        observation_store: Annotated[
+            ExecutionObservationStore,
+            Depends(get_execution_observation_store),
+        ],
+        label: str | None = None,
+        max_snapshot_age_seconds: int = 300,
+        min_snapshot_count: int = 2,
+        min_stable_seconds: float = 30.0,
+        max_active_live_executions: int = 0,
+        active_execution_scan_limit: int = 20,
+        max_observation_age_seconds: int = 1800,
+        now: datetime | None = None,
+    ) -> ProductionAutomationReadiness:
+        checked_at = now or datetime.now(UTC)
+        blocking_reasons: list[str] = []
+
+        if max_snapshot_age_seconds < 1:
+            raise HTTPException(
+                status_code=400,
+                detail="max_snapshot_age_seconds must be positive",
+            )
+        if max_active_live_executions < 0:
+            raise HTTPException(
+                status_code=400,
+                detail="max_active_live_executions must be non-negative",
+            )
+        if active_execution_scan_limit < 1:
+            raise HTTPException(
+                status_code=400,
+                detail="active_execution_scan_limit must be positive",
+            )
+        if max_observation_age_seconds < 1:
+            raise HTTPException(
+                status_code=400,
+                detail="max_observation_age_seconds must be positive",
+            )
+
+        latest_approved = approved_store.latest(label=label)
+        approved_summary: AutomationSnapshotSummary | None = None
+        if latest_approved is None:
+            _append_unique_blocking_reason(blocking_reasons, "No approved canary snapshot found")
+        else:
+            approved_summary = _automation_snapshot_summary(
+                snapshot_id=latest_approved.snapshot_id,
+                label=latest_approved.label,
+                captured_at=latest_approved.captured_at,
+                now=checked_at,
+            )
+            if approved_summary.age_seconds > max_snapshot_age_seconds:
+                _append_unique_blocking_reason(
+                    blocking_reasons,
+                    (
+                        "Approved canary snapshot is stale "
+                        f"({approved_summary.age_seconds:.1f}s > "
+                        f"{max_snapshot_age_seconds}s)"
+                    ),
+                )
+
+        latest_launch_ready = launch_ready_store.latest(label=label)
+        launch_ready_summary: AutomationSnapshotSummary | None = None
+        if latest_launch_ready is None:
+            _append_unique_blocking_reason(
+                blocking_reasons,
+                "No launch-ready canary snapshot found",
+            )
+        else:
+            launch_ready_summary = _automation_snapshot_summary(
+                snapshot_id=latest_launch_ready.launch_ready_snapshot_id,
+                label=latest_launch_ready.label,
+                captured_at=latest_launch_ready.captured_at,
+                now=checked_at,
+            )
+            effective_max_age_seconds = min(
+                max_snapshot_age_seconds,
+                latest_launch_ready.max_snapshot_age_seconds,
+            )
+            if launch_ready_summary.age_seconds > effective_max_age_seconds:
+                _append_unique_blocking_reason(
+                    blocking_reasons,
+                    (
+                        "Launch-ready canary snapshot is stale "
+                        f"({launch_ready_summary.age_seconds:.1f}s > "
+                        f"{effective_max_age_seconds}s)"
+                    ),
+                )
+            if not latest_launch_ready.system_state.ready:
+                _append_unique_blocking_reason(
+                    blocking_reasons,
+                    "Latest launch-ready canary snapshot is not ready for live execution",
+                )
+
+        stability: LaunchReadyCanaryStability | None = None
+        try:
+            stability = _build_launch_ready_canary_stability(
+                store=launch_ready_store,
+                label=label,
+                max_snapshot_age_seconds=max_snapshot_age_seconds,
+                min_snapshot_count=min_snapshot_count,
+                min_stable_seconds=min_stable_seconds,
+                now=checked_at,
+            )
+        except HTTPException as exc:
+            if exc.status_code in {404, 409}:
+                _append_unique_blocking_reason(blocking_reasons, exc.detail)
+            else:
+                raise
+
+        latest_stable_launch = None
+        if (
+            stability is not None
+            and stability.snapshot.launch_ready_snapshot_id is not None
+        ):
+            latest_stable_launch = stable_launch_store.latest_for_snapshot(
+                stability.snapshot.launch_ready_snapshot_id
+            )
+            if latest_stable_launch is not None and latest_stable_launch.status != "shadowed":
+                _append_unique_blocking_reason(
+                    blocking_reasons,
+                    (
+                        "Latest stable launch-ready snapshot already launched by worker "
+                        f"as paper trade {latest_stable_launch.paper_trade_id}"
+                    ),
+                )
+
+        active_live_execution_count = (
+            _count_blocking_live_executions_for_automation_readiness(
+                execution_store=execution_store,
+                observation_store=observation_store,
+                now=checked_at,
+                max_observation_age_seconds=max_observation_age_seconds,
+                scan_limit=active_execution_scan_limit,
+            )
+        )
+        if active_live_execution_count > max_active_live_executions:
+            _append_unique_blocking_reason(
+                blocking_reasons,
+                (
+                    "Active live executions still require monitoring before unattended "
+                    f"launch (max_allowed={max_active_live_executions}, "
+                    f"current={active_live_execution_count})"
+                ),
+            )
+
+        ready = not blocking_reasons
+        return ProductionAutomationReadiness(
+            checked_at=checked_at,
+            ready=ready,
+            status="ready" if ready else "blocked",
+            blocking_reasons=blocking_reasons,
+            approved_snapshot=approved_summary,
+            launch_ready_snapshot=launch_ready_summary,
+            stable_launch_ready=stability is not None,
+            stable_launch_consecutive_snapshots=(
+                stability.consecutive_snapshots if stability is not None else None
+            ),
+            stable_launch_stable_seconds=(
+                stability.stable_seconds if stability is not None else None
+            ),
+            latest_stable_launch=latest_stable_launch,
+            active_live_execution_count=active_live_execution_count,
+            max_active_live_executions=max_active_live_executions,
         )
 
     @app.get(

--- a/apps/api/src/carryme_api/app.py
+++ b/apps/api/src/carryme_api/app.py
@@ -169,6 +169,12 @@ DEFAULT_APP_ENVIRONMENT = "development"
 APP_ENVIRONMENT_VARIABLE = "CARRYME_API_ENVIRONMENT"
 MAX_GUARDED_AUTO_CLEANUP_STEPS = 3
 MAX_HISTORY_LIMIT = 1000
+AUTOMATION_READINESS_MAX_SNAPSHOT_AGE_SECONDS = 300
+AUTOMATION_READINESS_MIN_SNAPSHOT_COUNT = 2
+AUTOMATION_READINESS_MIN_STABLE_SECONDS = 30.0
+AUTOMATION_READINESS_MAX_ACTIVE_LIVE_EXECUTIONS = 0
+AUTOMATION_READINESS_ACTIVE_EXECUTION_SCAN_LIMIT = 200
+AUTOMATION_READINESS_MAX_OBSERVATION_AGE_SECONDS = 1800
 PAIR_STATUS_POLL_CALL_TIMEOUT_SECONDS = 10.0
 MUTATING_HTTP_METHODS = frozenset({"POST", "PUT", "PATCH", "DELETE"})
 logger = logging.getLogger(__name__)
@@ -393,6 +399,12 @@ def get_app_environment() -> str:
         os.getenv(APP_ENVIRONMENT_VARIABLE, DEFAULT_APP_ENVIRONMENT).strip()
         or DEFAULT_APP_ENVIRONMENT
     )
+
+
+def get_automation_readiness_checked_at() -> datetime:
+    """Return the authoritative UTC evaluation time for automation readiness."""
+
+    return datetime.now(UTC)
 
 
 async def _resolve_api_settings_for_request(request: Request) -> ApiSettings:
@@ -2776,10 +2788,12 @@ def _select_latest_launch_ready_canary_snapshot(
     if snapshot is None:
         raise HTTPException(status_code=404, detail="No launch-ready canary snapshot found")
     current_time = now or datetime.now(UTC)
-    snapshot_age_seconds = max(
-        0.0,
-        (current_time - snapshot.captured_at).total_seconds(),
-    )
+    snapshot_age_seconds = (current_time - snapshot.captured_at).total_seconds()
+    if snapshot_age_seconds < 0:
+        raise HTTPException(
+            status_code=409,
+            detail="Launch-ready canary snapshot timestamp is in the future",
+        )
     effective_max_age_seconds = min(
         max_snapshot_age_seconds,
         snapshot.max_snapshot_age_seconds,
@@ -2871,10 +2885,12 @@ def _build_launch_ready_canary_stability(
         raise HTTPException(status_code=404, detail="No launch-ready canary snapshot found")
 
     current_time = now or datetime.now(UTC)
-    snapshot_age_seconds = max(
-        0.0,
-        (current_time - latest_snapshot.captured_at).total_seconds(),
-    )
+    snapshot_age_seconds = (current_time - latest_snapshot.captured_at).total_seconds()
+    if snapshot_age_seconds < 0:
+        raise HTTPException(
+            status_code=409,
+            detail="Launch-ready canary snapshot timestamp is in the future",
+        )
     effective_max_age_seconds = min(
         max_snapshot_age_seconds,
         latest_snapshot.max_snapshot_age_seconds,
@@ -2943,7 +2959,7 @@ def _automation_snapshot_summary(
         snapshot_id=snapshot_id,
         label=label,
         captured_at=captured_at,
-        age_seconds=max(0.0, (now - captured_at).total_seconds()),
+        age_seconds=(now - captured_at).total_seconds(),
     )
 
 
@@ -2955,23 +2971,26 @@ def _count_blocking_live_executions_for_automation_readiness(
     max_observation_age_seconds: int,
     scan_limit: int,
 ) -> int:
-    seen_paper_trade_ids: set[int] = set()
     blocking_count = 0
-    for execution in execution_store.list_recent(limit=scan_limit):
-        if execution.mode != "live" or execution.paper_trade_id is None:
-            continue
+    for execution in _list_recent_live_executions_for_automation_readiness(
+        execution_store=execution_store,
+        observation_store=observation_store,
+        now=now,
+        max_age_seconds=max_observation_age_seconds,
+        limit=scan_limit,
+    ):
         paper_trade_id = execution.paper_trade_id
-        if paper_trade_id in seen_paper_trade_ids:
+        if paper_trade_id is None:
+            blocking_count += 1
             continue
-        seen_paper_trade_ids.add(paper_trade_id)
         latest_observation = observation_store.latest_for_paper_trade(paper_trade_id)
         if latest_observation is None:
             blocking_count += 1
             continue
-        observation_age_seconds = max(
-            0.0,
-            (now - latest_observation.observed_at).total_seconds(),
-        )
+        observation_age_seconds = (now - latest_observation.observed_at).total_seconds()
+        if observation_age_seconds < 0:
+            blocking_count += 1
+            continue
         if observation_age_seconds > max_observation_age_seconds:
             blocking_count += 1
             continue
@@ -2985,6 +3004,80 @@ def _count_blocking_live_executions_for_automation_readiness(
         ):
             blocking_count += 1
     return blocking_count
+
+
+def _list_recent_live_executions_for_automation_readiness(
+    *,
+    execution_store: ExecutionJournalStore,
+    observation_store: ExecutionObservationStore,
+    now: datetime,
+    max_age_seconds: int,
+    limit: int,
+) -> list[ExecutionJournalEntry]:
+    """Return recent unique live executions using the same paging semantics as the worker."""
+
+    page_size = max(min(limit, 100), 20)
+    offset = 0
+    seen_paper_trade_ids: set[int] = set()
+    selected: list[ExecutionJournalEntry] = []
+
+    while len(selected) < limit:
+        batch = execution_store.list_recent(limit=page_size, offset=offset)
+        if not batch:
+            break
+        offset += len(batch)
+
+        for execution in batch:
+            if execution.mode != "live" or execution.status not in {"submitted", "partial"}:
+                continue
+            age_seconds = (now - execution.executed_at).total_seconds()
+            if age_seconds > max_age_seconds and not _execution_requires_continued_monitoring(
+                observation_store,
+                execution=execution,
+            ):
+                continue
+            if execution.paper_trade_id is None or execution.paper_trade_id in seen_paper_trade_ids:
+                continue
+            seen_paper_trade_ids.add(execution.paper_trade_id)
+            selected.append(execution)
+            if len(selected) >= limit:
+                break
+
+        if len(batch) < page_size:
+            break
+
+    return selected
+
+
+def _execution_requires_continued_monitoring(
+    observation_store: ExecutionObservationStore,
+    *,
+    execution: ExecutionJournalEntry,
+    latest_observation: ExecutionObservationEntry | None = None,
+) -> bool:
+    """Return whether an older live execution still has an active monitoring state."""
+
+    paper_trade_id = execution.paper_trade_id
+    if paper_trade_id is None:
+        return False
+    latest = latest_observation
+    if latest is None:
+        latest = observation_store.latest_for_paper_trade(paper_trade_id)
+    if latest is None:
+        return False
+    pair_status = latest.pair_status
+    if pair_status is None:
+        for observation in observation_store.list_recent(limit=None, paper_trade_id=paper_trade_id):
+            if observation.pair_status is not None:
+                pair_status = observation.pair_status
+                break
+        else:
+            return True
+    return pair_status.derived_state in {
+        "hedged",
+        "cleanup_needed",
+        "review_required",
+    } or pair_status.recommended_action != "no_action"
 
 
 def _append_paper_trade_from_canary_candidate(
@@ -4179,38 +4272,10 @@ def create_app() -> FastAPI:
             ExecutionObservationStore,
             Depends(get_execution_observation_store),
         ],
+        checked_at: Annotated[datetime, Depends(get_automation_readiness_checked_at)],
         label: str | None = None,
-        max_snapshot_age_seconds: int = 300,
-        min_snapshot_count: int = 2,
-        min_stable_seconds: float = 30.0,
-        max_active_live_executions: int = 0,
-        active_execution_scan_limit: int = 20,
-        max_observation_age_seconds: int = 1800,
-        now: datetime | None = None,
     ) -> ProductionAutomationReadiness:
-        checked_at = now or datetime.now(UTC)
         blocking_reasons: list[str] = []
-
-        if max_snapshot_age_seconds < 1:
-            raise HTTPException(
-                status_code=400,
-                detail="max_snapshot_age_seconds must be positive",
-            )
-        if max_active_live_executions < 0:
-            raise HTTPException(
-                status_code=400,
-                detail="max_active_live_executions must be non-negative",
-            )
-        if active_execution_scan_limit < 1:
-            raise HTTPException(
-                status_code=400,
-                detail="active_execution_scan_limit must be positive",
-            )
-        if max_observation_age_seconds < 1:
-            raise HTTPException(
-                status_code=400,
-                detail="max_observation_age_seconds must be positive",
-            )
 
         latest_approved = approved_store.latest(label=label)
         approved_summary: AutomationSnapshotSummary | None = None
@@ -4223,13 +4288,18 @@ def create_app() -> FastAPI:
                 captured_at=latest_approved.captured_at,
                 now=checked_at,
             )
-            if approved_summary.age_seconds > max_snapshot_age_seconds:
+            if approved_summary.age_seconds < 0:
+                _append_unique_blocking_reason(
+                    blocking_reasons,
+                    "Approved canary snapshot timestamp is in the future",
+                )
+            elif approved_summary.age_seconds > AUTOMATION_READINESS_MAX_SNAPSHOT_AGE_SECONDS:
                 _append_unique_blocking_reason(
                     blocking_reasons,
                     (
                         "Approved canary snapshot is stale "
                         f"({approved_summary.age_seconds:.1f}s > "
-                        f"{max_snapshot_age_seconds}s)"
+                        f"{AUTOMATION_READINESS_MAX_SNAPSHOT_AGE_SECONDS}s)"
                     ),
                 )
 
@@ -4248,10 +4318,15 @@ def create_app() -> FastAPI:
                 now=checked_at,
             )
             effective_max_age_seconds = min(
-                max_snapshot_age_seconds,
+                AUTOMATION_READINESS_MAX_SNAPSHOT_AGE_SECONDS,
                 latest_launch_ready.max_snapshot_age_seconds,
             )
-            if launch_ready_summary.age_seconds > effective_max_age_seconds:
+            if launch_ready_summary.age_seconds < 0:
+                _append_unique_blocking_reason(
+                    blocking_reasons,
+                    "Launch-ready canary snapshot timestamp is in the future",
+                )
+            elif launch_ready_summary.age_seconds > effective_max_age_seconds:
                 _append_unique_blocking_reason(
                     blocking_reasons,
                     (
@@ -4271,9 +4346,9 @@ def create_app() -> FastAPI:
             stability = _build_launch_ready_canary_stability(
                 store=launch_ready_store,
                 label=label,
-                max_snapshot_age_seconds=max_snapshot_age_seconds,
-                min_snapshot_count=min_snapshot_count,
-                min_stable_seconds=min_stable_seconds,
+                max_snapshot_age_seconds=AUTOMATION_READINESS_MAX_SNAPSHOT_AGE_SECONDS,
+                min_snapshot_count=AUTOMATION_READINESS_MIN_SNAPSHOT_COUNT,
+                min_stable_seconds=AUTOMATION_READINESS_MIN_STABLE_SECONDS,
                 now=checked_at,
             )
         except HTTPException as exc:
@@ -4304,16 +4379,16 @@ def create_app() -> FastAPI:
                 execution_store=execution_store,
                 observation_store=observation_store,
                 now=checked_at,
-                max_observation_age_seconds=max_observation_age_seconds,
-                scan_limit=active_execution_scan_limit,
+                max_observation_age_seconds=AUTOMATION_READINESS_MAX_OBSERVATION_AGE_SECONDS,
+                scan_limit=AUTOMATION_READINESS_ACTIVE_EXECUTION_SCAN_LIMIT,
             )
         )
-        if active_live_execution_count > max_active_live_executions:
+        if active_live_execution_count > AUTOMATION_READINESS_MAX_ACTIVE_LIVE_EXECUTIONS:
             _append_unique_blocking_reason(
                 blocking_reasons,
                 (
                     "Active live executions still require monitoring before unattended "
-                    f"launch (max_allowed={max_active_live_executions}, "
+                    f"launch (max_allowed={AUTOMATION_READINESS_MAX_ACTIVE_LIVE_EXECUTIONS}, "
                     f"current={active_live_execution_count})"
                 ),
             )
@@ -4335,7 +4410,7 @@ def create_app() -> FastAPI:
             ),
             latest_stable_launch=latest_stable_launch,
             active_live_execution_count=active_live_execution_count,
-            max_active_live_executions=max_active_live_executions,
+            max_active_live_executions=AUTOMATION_READINESS_MAX_ACTIVE_LIVE_EXECUTIONS,
         )
 
     @app.get(

--- a/packages/models/src/carryme_models/__init__.py
+++ b/packages/models/src/carryme_models/__init__.py
@@ -80,7 +80,11 @@ from carryme_models.preview import (
     PaperTradeOrderPreview,
     VenueOrderPreview,
 )
-from carryme_models.readiness import LiveSubmissionReadiness
+from carryme_models.readiness import (
+    AutomationSnapshotSummary,
+    LiveSubmissionReadiness,
+    ProductionAutomationReadiness,
+)
 from carryme_models.stable_canary_launch import StableCanaryLaunchRecord
 from carryme_models.stable_launch_ready_alert import StableLaunchReadyAlertEvent
 from carryme_models.system_state import PaperTradeSystemState, VenueSystemState
@@ -104,6 +108,7 @@ from carryme_models.universe import (
 
 __all__ = [
     "AppDescriptor",
+    "AutomationSnapshotSummary",
     "ApprovedCanaryBasketEntry",
     "ApprovedCanaryBasketPlan",
     "ApprovedCanaryAlertEvent",
@@ -161,6 +166,7 @@ __all__ = [
     "PaperTradeAccountingSummary",
     "PaperTradeEntry",
     "PaperTradeExecutionPreflight",
+    "ProductionAutomationReadiness",
     "ExecutionCleanupPreview",
     "PairClosePreviewConfirmationEntry",
     "PaperTradeOrderPreview",

--- a/packages/models/src/carryme_models/readiness.py
+++ b/packages/models/src/carryme_models/readiness.py
@@ -1,9 +1,13 @@
-"""Unified live submission readiness models."""
+"""Unified live submission and production automation readiness models."""
+
+from datetime import datetime
+from typing import Literal
 
 from pydantic import BaseModel, Field
 
 from carryme_models.account_preflight import PaperTradeAccountPreflight
 from carryme_models.preflight import PaperTradeExecutionPreflight
+from carryme_models.stable_canary_launch import StableCanaryLaunchRecord
 from carryme_models.system_state import PaperTradeSystemState
 
 
@@ -20,3 +24,29 @@ class LiveSubmissionReadiness(BaseModel):
     account_preflight: PaperTradeAccountPreflight
     system_state: PaperTradeSystemState | None = None
     blocking_reasons: list[str] = Field(default_factory=list)
+
+
+class AutomationSnapshotSummary(BaseModel):
+    """Bounded snapshot identity for production automation status views."""
+
+    snapshot_id: int | None = None
+    label: str = Field(min_length=1)
+    captured_at: datetime
+    age_seconds: float = Field(ge=0)
+
+
+class ProductionAutomationReadiness(BaseModel):
+    """Read-only summary of whether unattended canary launch can proceed."""
+
+    checked_at: datetime
+    ready: bool
+    status: Literal["ready", "blocked"]
+    blocking_reasons: list[str] = Field(default_factory=list)
+    approved_snapshot: AutomationSnapshotSummary | None = None
+    launch_ready_snapshot: AutomationSnapshotSummary | None = None
+    stable_launch_ready: bool
+    stable_launch_consecutive_snapshots: int | None = None
+    stable_launch_stable_seconds: float | None = None
+    latest_stable_launch: StableCanaryLaunchRecord | None = None
+    active_live_execution_count: int = Field(ge=0)
+    max_active_live_executions: int = Field(ge=0)

--- a/packages/models/src/carryme_models/readiness.py
+++ b/packages/models/src/carryme_models/readiness.py
@@ -31,14 +31,23 @@ class AutomationSnapshotSummary(BaseModel):
 
     snapshot_id: int | None = None
     label: str = Field(min_length=1)
-    captured_at: datetime
-    age_seconds: float = Field(ge=0)
+    captured_at: datetime = Field(
+        description="UTC timestamp when the underlying snapshot was captured."
+    )
+    age_seconds: float = Field(
+        description=(
+            "Age of the snapshot in seconds at checked_at. Negative values indicate the "
+            "snapshot timestamp is in the future and should be treated as invalid."
+        )
+    )
 
 
 class ProductionAutomationReadiness(BaseModel):
     """Read-only summary of whether unattended canary launch can proceed."""
 
-    checked_at: datetime
+    checked_at: datetime = Field(
+        description="UTC timestamp when the readiness evaluation was computed."
+    )
     ready: bool
     status: Literal["ready", "blocked"]
     blocking_reasons: list[str] = Field(default_factory=list)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -11,6 +11,7 @@ from carryme_api.app import (
     get_api_settings,
     get_approved_canary_alert_store,
     get_approved_canary_store,
+    get_automation_readiness_checked_at,
     get_balance_accounting_service,
     get_execution_accounting_service,
     get_execution_journal_store,
@@ -2088,17 +2089,12 @@ def test_production_automation_readiness_endpoint_reports_stable_launch_ready(
     app.dependency_overrides[get_stable_canary_launch_store] = lambda: stable_launch_store
     app.dependency_overrides[get_execution_journal_store] = lambda: execution_store
     app.dependency_overrides[get_execution_observation_store] = lambda: observation_store
+    app.dependency_overrides[get_automation_readiness_checked_at] = (
+        lambda: datetime(2026, 3, 29, 16, 1, 10, tzinfo=UTC)
+    )
     try:
         client = TestClient(app)
-        response = client.get(
-            "/v1/automation/readiness",
-            params={
-                "now": "2026-03-29T16:01:10Z",
-                "min_snapshot_count": "2",
-                "min_stable_seconds": "30",
-                "max_snapshot_age_seconds": "300",
-            },
-        )
+        response = client.get("/v1/automation/readiness")
     finally:
         app.dependency_overrides.clear()
 
@@ -2138,7 +2134,7 @@ def test_production_automation_readiness_endpoint_blocks_active_live_execution(
             executed_at=datetime(2026, 3, 29, 16, 1, 2, tzinfo=UTC),
             adapter="paired_live:extended_then_paradex",
             mode="live",
-            status="accepted",
+            status="submitted",
             paper_trade_id=paper_trade.entry_id,
             preview_hash="preview-hash",
             confirmation_entry_id=9,
@@ -2210,17 +2206,12 @@ def test_production_automation_readiness_endpoint_blocks_active_live_execution(
     app.dependency_overrides[get_stable_canary_launch_store] = lambda: stable_launch_store
     app.dependency_overrides[get_execution_journal_store] = lambda: execution_store
     app.dependency_overrides[get_execution_observation_store] = lambda: observation_store
+    app.dependency_overrides[get_automation_readiness_checked_at] = (
+        lambda: datetime(2026, 3, 29, 16, 1, 10, tzinfo=UTC)
+    )
     try:
         client = TestClient(app)
-        response = client.get(
-            "/v1/automation/readiness",
-            params={
-                "now": "2026-03-29T16:01:10Z",
-                "min_snapshot_count": "2",
-                "min_stable_seconds": "30",
-                "max_snapshot_age_seconds": "300",
-            },
-        )
+        response = client.get("/v1/automation/readiness")
     finally:
         app.dependency_overrides.clear()
 
@@ -2234,6 +2225,183 @@ def test_production_automation_readiness_endpoint_blocks_active_live_execution(
         "Active live executions still require monitoring" in reason
         for reason in payload["blocking_reasons"]
     )
+
+
+def test_production_automation_readiness_endpoint_blocks_future_snapshot_timestamps(
+    tmp_path: Path,
+) -> None:
+    database_path = tmp_path / "readiness-future.sqlite3"
+    approved_store = ApprovedCanaryStore(database_path)
+    launch_ready_store = LaunchReadyCanaryStore(database_path)
+    stable_launch_store = StableCanaryLaunchStore(database_path)
+    execution_store = ExecutionJournalStore(database_path)
+    observation_store = ExecutionObservationStore(database_path)
+    snapshot = _build_api_test_launch_ready_snapshot(
+        captured_at=datetime(2026, 3, 29, 16, 5, tzinfo=UTC),
+    )
+    approved_store.append(snapshot.approved_snapshot)
+    launch_ready_store.append(snapshot)
+
+    app.dependency_overrides[get_approved_canary_store] = lambda: approved_store
+    app.dependency_overrides[get_launch_ready_canary_store] = lambda: launch_ready_store
+    app.dependency_overrides[get_stable_canary_launch_store] = lambda: stable_launch_store
+    app.dependency_overrides[get_execution_journal_store] = lambda: execution_store
+    app.dependency_overrides[get_execution_observation_store] = lambda: observation_store
+    app.dependency_overrides[get_automation_readiness_checked_at] = (
+        lambda: datetime(2026, 3, 29, 16, 1, 10, tzinfo=UTC)
+    )
+    try:
+        client = TestClient(app)
+        response = client.get("/v1/automation/readiness")
+    finally:
+        app.dependency_overrides.clear()
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["ready"] is False
+    assert "Approved canary snapshot timestamp is in the future" in payload["blocking_reasons"]
+    assert "Launch-ready canary snapshot timestamp is in the future" in payload["blocking_reasons"]
+    assert payload["approved_snapshot"]["age_seconds"] < 0
+    assert payload["launch_ready_snapshot"]["age_seconds"] < 0
+
+
+def test_production_automation_readiness_endpoint_counts_beyond_scan_window(
+    tmp_path: Path,
+) -> None:
+    database_path = tmp_path / "readiness-scan-window.sqlite3"
+    approved_store = ApprovedCanaryStore(database_path)
+    launch_ready_store = LaunchReadyCanaryStore(database_path)
+    stable_launch_store = StableCanaryLaunchStore(database_path)
+    execution_store = ExecutionJournalStore(database_path)
+    observation_store = ExecutionObservationStore(database_path)
+    first_snapshot = _build_api_test_launch_ready_snapshot(
+        captured_at=datetime(2026, 3, 29, 16, 0, tzinfo=UTC),
+    )
+    second_snapshot = _build_api_test_launch_ready_snapshot(
+        captured_at=datetime(2026, 3, 29, 16, 1, tzinfo=UTC),
+    )
+    approved_store.append(second_snapshot.approved_snapshot)
+    launch_ready_store.append(first_snapshot)
+    launch_ready_store.append(second_snapshot)
+
+    for index in range(app_module.AUTOMATION_READINESS_ACTIVE_EXECUTION_SCAN_LIMIT + 5):
+        execution_store.append(
+            ExecutionJournalEntry(
+                executed_at=datetime(2026, 3, 29, 16, 3, index % 60, tzinfo=UTC),
+                adapter="paper:noop",
+                mode="live",
+                status="accepted",
+                paper_trade_id=10_000 + index,
+                preview_hash=f"irrelevant-{index}",
+                confirmation_entry_id=None,
+                paper_trade=_build_api_test_paper_trade(entry_id=10_000 + index),
+                legs=[
+                    ExecutionLegResult(
+                        venue="extended",
+                        symbol="ARB-USD",
+                        fee_profile="default",
+                        side="sell",
+                        target_notional=1.0,
+                        status="accepted",
+                        simulated=False,
+                        external_reference=f"irrelevant-order-{index}",
+                    )
+                ],
+            )
+        )
+
+    for paper_trade_id, label, preview_hash in (
+        (91, "near_extended_paradex", "blocking-preview-1"),
+        (92, "jup_extended_paradex", "blocking-preview-2"),
+    ):
+        execution = execution_store.append(
+            ExecutionJournalEntry(
+                executed_at=datetime(2026, 3, 29, 16, 0, 30, tzinfo=UTC),
+                adapter="paired_live:extended_then_paradex",
+                mode="live",
+                status="submitted",
+                paper_trade_id=paper_trade_id,
+                preview_hash=preview_hash,
+                confirmation_entry_id=paper_trade_id + 100,
+                paper_trade=_build_api_test_paper_trade(
+                    entry_id=paper_trade_id,
+                    label=label,
+                    created_at=datetime(2026, 3, 29, 15, 55, tzinfo=UTC),
+                ),
+                legs=[
+                    ExecutionLegResult(
+                        venue="extended",
+                        symbol="ARB-USD",
+                        fee_profile="default",
+                        side="sell",
+                        target_notional=11.0,
+                        status="submitted",
+                        simulated=False,
+                        external_reference=f"blocking-order-{paper_trade_id}",
+                    )
+                ],
+            )
+        )
+        observation_store.append(
+            ExecutionObservationEntry(
+                observed_at=datetime(2026, 3, 29, 16, 1, 8, tzinfo=UTC),
+                context="execution_monitor",
+                execution_entry_id=execution.entry_id,
+                paper_trade_id=paper_trade_id,
+                preview_hash=preview_hash,
+                order_state=ExecutionOrderState(
+                    execution_entry_id=execution.entry_id,
+                    paper_trade_id=paper_trade_id,
+                    preview_hash=preview_hash,
+                    legs=[],
+                    notes=[],
+                ),
+                pair_status=ExecutionPairStatus(
+                    execution_entry_id=execution.entry_id,
+                    paper_trade_id=paper_trade_id,
+                    preview_hash=preview_hash,
+                    derived_state="hedged",
+                    recommended_action="monitor_open_hedge",
+                    order_state=ExecutionOrderState(
+                        execution_entry_id=execution.entry_id,
+                        paper_trade_id=paper_trade_id,
+                        preview_hash=preview_hash,
+                        legs=[],
+                        notes=[],
+                    ),
+                    reconciliation=ExecutionReconciliation(
+                        execution_entry_id=execution.entry_id,
+                        paper_trade_id=paper_trade_id,
+                        preview_hash=preview_hash,
+                        status="accepted",
+                        recommended_action="monitor",
+                        matched_all_leg_symbols=True,
+                        venues=[],
+                        notes=[],
+                    ),
+                    notes=[],
+                ),
+            )
+        )
+
+    app.dependency_overrides[get_approved_canary_store] = lambda: approved_store
+    app.dependency_overrides[get_launch_ready_canary_store] = lambda: launch_ready_store
+    app.dependency_overrides[get_stable_canary_launch_store] = lambda: stable_launch_store
+    app.dependency_overrides[get_execution_journal_store] = lambda: execution_store
+    app.dependency_overrides[get_execution_observation_store] = lambda: observation_store
+    app.dependency_overrides[get_automation_readiness_checked_at] = (
+        lambda: datetime(2026, 3, 29, 16, 1, 10, tzinfo=UTC)
+    )
+    try:
+        client = TestClient(app)
+        response = client.get("/v1/automation/readiness")
+    finally:
+        app.dependency_overrides.clear()
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["ready"] is False
+    assert payload["active_live_execution_count"] == 2
 
 
 def _build_api_test_launch_ready_snapshot(
@@ -2324,13 +2492,19 @@ def _build_api_test_launch_ready_snapshot(
     )
 
 
-def _build_api_test_paper_trade() -> PaperTradeEntry:
+def _build_api_test_paper_trade(
+    *,
+    entry_id: int = 7,
+    label: str = "arb_extended_paradex",
+    created_at: datetime | None = None,
+) -> PaperTradeEntry:
+    created_at = created_at or datetime(2026, 3, 29, 16, 1, tzinfo=UTC)
     return PaperTradeEntry(
-        entry_id=7,
-        created_at=datetime(2026, 3, 29, 16, 1, tzinfo=UTC),
+        entry_id=entry_id,
+        created_at=created_at,
         note="approved canary",
         intent=FundingPairTradeIntent(
-            label="arb_extended_paradex",
+            label=label,
             canonical_symbol="ARB-USD-PERP",
             source_recorded_at=datetime(2026, 3, 29, 16, 0, tzinfo=UTC),
             one_day_net_edge_after_entry=0.00355,

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -13,6 +13,8 @@ from carryme_api.app import (
     get_approved_canary_store,
     get_balance_accounting_service,
     get_execution_accounting_service,
+    get_execution_journal_store,
+    get_execution_observation_store,
     get_execution_quality_service,
     get_history_store,
     get_launch_ready_canary_store,
@@ -20,6 +22,7 @@ from carryme_api.app import (
     get_opportunity_universe_service,
     get_route_approval_service,
     get_route_stability_service,
+    get_stable_canary_launch_store,
     get_stable_launch_ready_alert_store,
     get_system_state_service,
 )
@@ -92,6 +95,7 @@ from carryme_storage import (
     PairClosePreviewConfirmationStore,
     PaperTradeStore,
     PreviewConfirmationStore,
+    StableCanaryLaunchStore,
     StableLaunchReadyAlertStore,
     SystemStateAlertStore,
     WatchlistStore,
@@ -2026,6 +2030,331 @@ def test_stable_launch_ready_alerts_endpoint_lists_recent(tmp_path: Path) -> Non
     assert len(payload) == 1
     assert payload[0]["alert_type"] == "stable_launch_ready_available"
     assert payload[0]["current_stability"]["snapshot"]["label"] == "arb_extended_paradex"
+
+
+def test_production_automation_readiness_endpoint_reports_missing_pipeline_data(
+    tmp_path: Path,
+) -> None:
+    database_path = tmp_path / "readiness.sqlite3"
+    stable_launch_store = StableCanaryLaunchStore(database_path)
+    execution_store = ExecutionJournalStore(database_path)
+    observation_store = ExecutionObservationStore(database_path)
+    app.dependency_overrides[get_approved_canary_store] = lambda: ApprovedCanaryStore(
+        database_path
+    )
+    app.dependency_overrides[get_launch_ready_canary_store] = lambda: LaunchReadyCanaryStore(
+        database_path
+    )
+    app.dependency_overrides[get_stable_canary_launch_store] = lambda: stable_launch_store
+    app.dependency_overrides[get_execution_journal_store] = lambda: execution_store
+    app.dependency_overrides[get_execution_observation_store] = lambda: observation_store
+    try:
+        client = TestClient(app)
+        response = client.get("/v1/automation/readiness")
+    finally:
+        app.dependency_overrides.clear()
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["ready"] is False
+    assert payload["status"] == "blocked"
+    assert payload["approved_snapshot"] is None
+    assert payload["launch_ready_snapshot"] is None
+    assert "No approved canary snapshot found" in payload["blocking_reasons"]
+    assert "No launch-ready canary snapshot found" in payload["blocking_reasons"]
+
+
+def test_production_automation_readiness_endpoint_reports_stable_launch_ready(
+    tmp_path: Path,
+) -> None:
+    database_path = tmp_path / "readiness-ready.sqlite3"
+    approved_store = ApprovedCanaryStore(database_path)
+    launch_ready_store = LaunchReadyCanaryStore(database_path)
+    stable_launch_store = StableCanaryLaunchStore(database_path)
+    execution_store = ExecutionJournalStore(database_path)
+    observation_store = ExecutionObservationStore(database_path)
+    first_snapshot = _build_api_test_launch_ready_snapshot(
+        captured_at=datetime(2026, 3, 29, 16, 0, tzinfo=UTC),
+    )
+    second_snapshot = _build_api_test_launch_ready_snapshot(
+        captured_at=datetime(2026, 3, 29, 16, 1, tzinfo=UTC),
+    )
+    approved_store.append(second_snapshot.approved_snapshot)
+    launch_ready_store.append(first_snapshot)
+    launch_ready_store.append(second_snapshot)
+
+    app.dependency_overrides[get_approved_canary_store] = lambda: approved_store
+    app.dependency_overrides[get_launch_ready_canary_store] = lambda: launch_ready_store
+    app.dependency_overrides[get_stable_canary_launch_store] = lambda: stable_launch_store
+    app.dependency_overrides[get_execution_journal_store] = lambda: execution_store
+    app.dependency_overrides[get_execution_observation_store] = lambda: observation_store
+    try:
+        client = TestClient(app)
+        response = client.get(
+            "/v1/automation/readiness",
+            params={
+                "now": "2026-03-29T16:01:10Z",
+                "min_snapshot_count": "2",
+                "min_stable_seconds": "30",
+                "max_snapshot_age_seconds": "300",
+            },
+        )
+    finally:
+        app.dependency_overrides.clear()
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["ready"] is True
+    assert payload["status"] == "ready"
+    assert payload["blocking_reasons"] == []
+    assert payload["approved_snapshot"]["snapshot_id"] == 1
+    assert payload["launch_ready_snapshot"]["snapshot_id"] == 2
+    assert payload["stable_launch_ready"] is True
+    assert payload["stable_launch_consecutive_snapshots"] == 2
+    assert payload["active_live_execution_count"] == 0
+
+
+def test_production_automation_readiness_endpoint_blocks_active_live_execution(
+    tmp_path: Path,
+) -> None:
+    database_path = tmp_path / "readiness-active.sqlite3"
+    approved_store = ApprovedCanaryStore(database_path)
+    launch_ready_store = LaunchReadyCanaryStore(database_path)
+    stable_launch_store = StableCanaryLaunchStore(database_path)
+    execution_store = ExecutionJournalStore(database_path)
+    observation_store = ExecutionObservationStore(database_path)
+    first_snapshot = _build_api_test_launch_ready_snapshot(
+        captured_at=datetime(2026, 3, 29, 16, 0, tzinfo=UTC),
+    )
+    second_snapshot = _build_api_test_launch_ready_snapshot(
+        captured_at=datetime(2026, 3, 29, 16, 1, tzinfo=UTC),
+    )
+    approved_store.append(second_snapshot.approved_snapshot)
+    launch_ready_store.append(first_snapshot)
+    launch_ready_store.append(second_snapshot)
+    paper_trade = _build_api_test_paper_trade()
+    execution = execution_store.append(
+        ExecutionJournalEntry(
+            executed_at=datetime(2026, 3, 29, 16, 1, 2, tzinfo=UTC),
+            adapter="paired_live:extended_then_paradex",
+            mode="live",
+            status="accepted",
+            paper_trade_id=paper_trade.entry_id,
+            preview_hash="preview-hash",
+            confirmation_entry_id=9,
+            paper_trade=paper_trade,
+            legs=[
+                ExecutionLegResult(
+                    venue="extended",
+                    symbol="ARB-USD",
+                    fee_profile="default",
+                    side="sell",
+                    target_notional=11.0,
+                    status="accepted",
+                    simulated=False,
+                    external_reference="extended-order",
+                ),
+                ExecutionLegResult(
+                    venue="paradex",
+                    symbol="ARB-USD-PERP",
+                    fee_profile="pro_fastfills",
+                    side="buy",
+                    target_notional=11.0,
+                    status="accepted",
+                    simulated=False,
+                    external_reference="paradex-order",
+                ),
+            ],
+        )
+    )
+    order_state = ExecutionOrderState(
+        execution_entry_id=execution.entry_id,
+        paper_trade_id=paper_trade.entry_id,
+        preview_hash="preview-hash",
+        legs=[],
+        notes=[],
+    )
+    reconciliation = ExecutionReconciliation(
+        execution_entry_id=execution.entry_id,
+        paper_trade_id=paper_trade.entry_id,
+        preview_hash="preview-hash",
+        status="accepted",
+        recommended_action="monitor",
+        matched_all_leg_symbols=True,
+        venues=[],
+        notes=[],
+    )
+    observation_store.append(
+        ExecutionObservationEntry(
+            observed_at=datetime(2026, 3, 29, 16, 1, 8, tzinfo=UTC),
+            context="execution_monitor",
+            execution_entry_id=execution.entry_id,
+            paper_trade_id=paper_trade.entry_id,
+            preview_hash="preview-hash",
+            order_state=order_state,
+            pair_status=ExecutionPairStatus(
+                execution_entry_id=execution.entry_id,
+                paper_trade_id=paper_trade.entry_id,
+                preview_hash="preview-hash",
+                derived_state="hedged",
+                recommended_action="no_action",
+                order_state=order_state,
+                reconciliation=reconciliation,
+                notes=[],
+            ),
+        )
+    )
+
+    app.dependency_overrides[get_approved_canary_store] = lambda: approved_store
+    app.dependency_overrides[get_launch_ready_canary_store] = lambda: launch_ready_store
+    app.dependency_overrides[get_stable_canary_launch_store] = lambda: stable_launch_store
+    app.dependency_overrides[get_execution_journal_store] = lambda: execution_store
+    app.dependency_overrides[get_execution_observation_store] = lambda: observation_store
+    try:
+        client = TestClient(app)
+        response = client.get(
+            "/v1/automation/readiness",
+            params={
+                "now": "2026-03-29T16:01:10Z",
+                "min_snapshot_count": "2",
+                "min_stable_seconds": "30",
+                "max_snapshot_age_seconds": "300",
+            },
+        )
+    finally:
+        app.dependency_overrides.clear()
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["ready"] is False
+    assert payload["status"] == "blocked"
+    assert payload["stable_launch_ready"] is True
+    assert payload["active_live_execution_count"] == 1
+    assert any(
+        "Active live executions still require monitoring" in reason
+        for reason in payload["blocking_reasons"]
+    )
+
+
+def _build_api_test_launch_ready_snapshot(
+    *,
+    captured_at: datetime,
+) -> LaunchReadyCanarySnapshot:
+    candidate = FundingUniverseCanaryCandidate(
+        opportunity=FundingUniverseOpportunity(
+            opportunity=FundingArbOpportunity(
+                canonical_symbol="ARB-USD-PERP",
+                long_venue="paradex",
+                short_venue="extended",
+                long_fee_profile="pro_fastfills",
+                short_fee_profile="default",
+                gross_daily_edge=0.004,
+                entry_cost_rate=0.00045,
+                round_trip_cost_rate=0.0009,
+                one_day_net_edge_after_entry=0.00355,
+                one_day_net_edge_after_round_trip=0.0031,
+                break_even_days_entry=0.2,
+                break_even_days_round_trip=0.3,
+                capacity=CapacityEstimate(
+                    short_bid_notional=1400.0,
+                    long_ask_notional=900.0,
+                    max_entry_notional=900.0,
+                    limiting_venue="paradex",
+                ),
+            ),
+            venue_markets={
+                "extended": FundingUniverseVenueMarket(
+                    venue="extended",
+                    symbol="ARB-USD",
+                ),
+                "paradex": FundingUniverseVenueMarket(
+                    venue="paradex",
+                    symbol="ARB-USD-PERP",
+                ),
+            },
+            deployable_notional=900.0,
+            estimated_one_day_pnl_after_round_trip=2.79,
+        ),
+        suggested_canary_notional=11.0,
+    )
+    approved_snapshot = ApprovedCanarySnapshot(
+        snapshot_id=1,
+        captured_at=captured_at,
+        label="arb_extended_paradex",
+        candidate=candidate,
+        approval=RouteApprovalEntry(
+            updated_at=datetime(2026, 3, 29, 15, 59, tzinfo=UTC),
+            label="arb_extended_paradex",
+            canonical_symbol="ARB-USD-PERP",
+            short_venue="extended",
+            long_venue="paradex",
+            short_fee_profile="default",
+            long_fee_profile="pro_fastfills",
+            approved=True,
+            max_live_notional=11.0,
+            note="approved canary",
+        ),
+    )
+    return LaunchReadyCanarySnapshot(
+        captured_at=captured_at,
+        label="arb_extended_paradex",
+        max_snapshot_age_seconds=300,
+        approved_snapshot=approved_snapshot,
+        system_state=PaperTradeSystemState(
+            paper_trade_id=0,
+            label="arb_extended_paradex",
+            ready=True,
+            venues=[
+                VenueSystemState(
+                    venue="extended",
+                    enabled=True,
+                    checked=True,
+                    healthy=True,
+                    status="ok",
+                ),
+                VenueSystemState(
+                    venue="paradex",
+                    enabled=True,
+                    checked=True,
+                    healthy=True,
+                    status="ok",
+                ),
+            ],
+        ),
+    )
+
+
+def _build_api_test_paper_trade() -> PaperTradeEntry:
+    return PaperTradeEntry(
+        entry_id=7,
+        created_at=datetime(2026, 3, 29, 16, 1, tzinfo=UTC),
+        note="approved canary",
+        intent=FundingPairTradeIntent(
+            label="arb_extended_paradex",
+            canonical_symbol="ARB-USD-PERP",
+            source_recorded_at=datetime(2026, 3, 29, 16, 0, tzinfo=UTC),
+            one_day_net_edge_after_entry=0.00355,
+            break_even_days_entry=0.2,
+            capacity_limit_notional=900.0,
+            target_notional=11.0,
+            capacity_fraction=1.0,
+            max_target_notional=11.0,
+            long_leg=TradeLegIntent(
+                venue="paradex",
+                symbol="ARB-USD-PERP",
+                fee_profile="pro_fastfills",
+                side="buy",
+                target_notional=11.0,
+            ),
+            short_leg=TradeLegIntent(
+                venue="extended",
+                symbol="ARB-USD",
+                fee_profile="default",
+                side="sell",
+                target_notional=11.0,
+            ),
+        ),
+    )
 
 
 def test_system_state_alerts_endpoint_lists_recent(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- add `GET /v1/automation/readiness` as a bounded, read-only production status endpoint
- summarize latest approved and launch-ready snapshots with age, stability, and blocking reasons
- include fail-closed blockers for missing/stale/unstable snapshots, already-consumed stable launch snapshots, and active live executions that still require monitoring

## Safety
- read-only API change only; it does not approve, launch, close, or change notional limits
- defaults to blocked unless the approved snapshot, launch-ready snapshot, stability window, stable-launch history, and active live execution state are all clean
- active live execution checks treat missing/stale observations, missing pair status, hedged/cleanup/review states, and non-`no_action` recommendations as blocking

## Validation
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run pytest -q tests/test_api.py -k 'production_automation_readiness'`
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run pytest -q tests/test_api.py -k 'automation_readiness or stable_launch_ready'`
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run pytest -q tests/test_api.py`
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run ruff check .`
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run mypy src apps packages tests`
