### PR TITLE
chore: log worker automation mode

### DIFF
--- a/apps/worker/src/carryme_worker/main.py
+++ b/apps/worker/src/carryme_worker/main.py
@@ -88,6 +88,64 @@ def build_readiness_payload(settings: WorkerSettings) -> ServiceReadiness:
     )
 
 
+def build_automation_mode_payload(
+    *,
+    worker_mode: str,
+    settings: WorkerSettings,
+) -> dict[str, bool | float | int | str | None]:
+    """Build a redacted summary of live automation settings for hosted logs."""
+
+    return {
+        "worker_mode": worker_mode,
+        "environment": settings.environment,
+        "database_target": settings.database_target,
+        "stable_canary_launch_close_position": settings.stable_canary_launch_close_position,
+        "stable_canary_launch_hold_mode": not settings.stable_canary_launch_close_position,
+        "stable_canary_launch_shadow_mode": settings.stable_canary_launch_shadow_mode,
+        "stable_canary_launch_max_active_live_executions": (
+            settings.stable_canary_launch_max_active_live_executions
+        ),
+        "stable_canary_launch_active_execution_limit": (
+            settings.stable_canary_launch_active_execution_limit
+        ),
+        "stable_canary_launch_max_total_live_notional": (
+            settings.stable_canary_launch_max_total_live_notional
+        ),
+        "stable_canary_launch_max_live_notional_per_venue": (
+            settings.stable_canary_launch_max_live_notional_per_venue
+        ),
+        "execution_auto_pair_close_enabled": settings.execution_auto_pair_close_enabled,
+        "execution_auto_pair_close_shadow_mode": settings.execution_auto_pair_close_shadow_mode,
+        "execution_auto_pair_close_min_entry_edge_retention_ratio": (
+            settings.execution_auto_pair_close_min_entry_edge_retention_ratio
+        ),
+        "execution_auto_pair_close_max_round_trip_break_even_hold_windows": (
+            settings.execution_auto_pair_close_max_round_trip_break_even_hold_windows
+        ),
+        "execution_auto_pair_close_max_hold_windows": (
+            settings.execution_auto_pair_close_max_hold_windows
+        ),
+        "execution_auto_pair_close_min_profit_total_collateral": (
+            settings.execution_auto_pair_close_min_profit_total_collateral
+        ),
+        "execution_auto_pair_close_max_profit_giveback_ratio": (
+            settings.execution_auto_pair_close_max_profit_giveback_ratio
+        ),
+    }
+
+
+def log_automation_mode(*, worker_mode: str, settings: WorkerSettings) -> None:
+    """Log live automation settings without exposing credentials."""
+
+    logging.getLogger("carryme.worker").info(
+        "worker automation mode %s",
+        json.dumps(
+            build_automation_mode_payload(worker_mode=worker_mode, settings=settings),
+            sort_keys=True,
+        ),
+    )
+
+
 def build_cycle_payload(summary: PollCycleSummary) -> dict[str, int | str]:
     """Build a deterministic summary payload for one poll cycle."""
 
@@ -556,10 +614,17 @@ def main() -> None:
         print(build_launch_ready_canary_cache_loop_payload(supervised_launch_ready_summary))
         return
     if args.launch_latest_stable_canary_once:
+        log_automation_mode(worker_mode="launch_latest_stable_canary_once", settings=settings)
         launch_summary = asyncio.run(launch_latest_stable_canary_once(settings))
         print(build_stable_canary_launch_payload(launch_summary))
         return
     if args.launch_latest_stable_canary_supervise:
+
+        log_automation_mode(
+            worker_mode="launch_latest_stable_canary_supervise",
+            settings=settings,
+        )
+
         async def run_stable_canary_launch_supervised() -> StableCanaryLaunchLoopSummary:
             stop_event = asyncio.Event()
             install_signal_handlers(
@@ -578,10 +643,17 @@ def main() -> None:
         print(build_stable_canary_launch_loop_payload(supervised_stable_launch_summary))
         return
     if args.run_production_supervisor_once:
+        log_automation_mode(worker_mode="run_production_supervisor_once", settings=settings)
         supervisor_summary = asyncio.run(run_production_supervisor_cycle_once(settings))
         print(build_production_supervisor_cycle_payload(supervisor_summary))
         return
     if args.run_production_supervisor_supervise:
+
+        log_automation_mode(
+            worker_mode="run_production_supervisor_supervise",
+            settings=settings,
+        )
+
         async def run_production_supervisor() -> ProductionSupervisorLoopSummary:
             stop_event = asyncio.Event()
             install_signal_handlers(
@@ -598,10 +670,13 @@ def main() -> None:
         print(build_production_supervisor_loop_payload(supervisor_loop_summary))
         return
     if args.observe_executions_once:
+        log_automation_mode(worker_mode="observe_executions_once", settings=settings)
         observation_summary = asyncio.run(observe_live_executions_once(settings))
         print(json.dumps(build_execution_observation_payload(observation_summary), indent=2))
         return
     if args.observe_executions_supervise:
+
+        log_automation_mode(worker_mode="observe_executions_supervise", settings=settings)
 
         async def run_execution_supervised() -> ExecutionObservationLoopSummary:
             stop_event = asyncio.Event()

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -73,6 +73,7 @@ from carryme_worker.config import WorkerSettings
 from carryme_worker.main import (
     build_approved_canary_scan_loop_payload,
     build_approved_canary_scan_payload,
+    build_automation_mode_payload,
     build_candidate_payload,
     build_cycle_payload,
     build_execution_observation_loop_payload,
@@ -90,6 +91,7 @@ from carryme_worker.main import (
     build_system_state_observation_payload,
     build_universe_scan_loop_payload,
     build_universe_scan_payload,
+    log_automation_mode,
 )
 from carryme_worker.main import (
     main as worker_main,
@@ -520,6 +522,60 @@ def test_worker_database_target_redacts_urls() -> None:
 
     assert settings.database_target == redact_database_url(settings.database_path)
     assert settings.database_target == "postgresql+psycopg://***@db.example.com/carryme"
+
+
+def test_worker_automation_mode_payload_is_redacted_and_shows_hold_controls() -> None:
+    settings = WorkerSettings(
+        environment="production",
+        database_path="postgresql+psycopg://user:secret@db.example.com/carryme",
+        stable_canary_launch_close_position=False,
+        stable_canary_launch_max_active_live_executions=0,
+        stable_canary_launch_max_total_live_notional=25.0,
+        stable_canary_launch_max_live_notional_per_venue=20.0,
+        execution_auto_pair_close_enabled=True,
+        execution_auto_pair_close_shadow_mode=False,
+        execution_auto_pair_close_min_profit_total_collateral=0.5,
+        execution_auto_pair_close_max_profit_giveback_ratio=0.4,
+    )
+
+    payload = build_automation_mode_payload(
+        worker_mode="launch_latest_stable_canary_supervise",
+        settings=settings,
+    )
+
+    assert payload["worker_mode"] == "launch_latest_stable_canary_supervise"
+    assert payload["environment"] == "production"
+    assert payload["database_target"] == "postgresql+psycopg://***@db.example.com/carryme"
+    assert "secret" not in json.dumps(payload)
+    assert payload["stable_canary_launch_close_position"] is False
+    assert payload["stable_canary_launch_hold_mode"] is True
+    assert payload["stable_canary_launch_max_active_live_executions"] == 0
+    assert payload["stable_canary_launch_max_total_live_notional"] == 25.0
+    assert payload["stable_canary_launch_max_live_notional_per_venue"] == 20.0
+    assert payload["execution_auto_pair_close_enabled"] is True
+    assert payload["execution_auto_pair_close_shadow_mode"] is False
+    assert payload["execution_auto_pair_close_min_profit_total_collateral"] == 0.5
+    assert payload["execution_auto_pair_close_max_profit_giveback_ratio"] == 0.4
+
+
+def test_log_automation_mode_emits_json_payload(caplog: pytest.LogCaptureFixture) -> None:
+    settings = WorkerSettings(
+        environment="production",
+        database_path="postgresql+psycopg://user:secret@db.example.com/carryme",
+        execution_auto_pair_close_enabled=True,
+    )
+
+    with caplog.at_level(logging.INFO, logger="carryme.worker"):
+        log_automation_mode(worker_mode="observe_executions_supervise", settings=settings)
+
+    assert len(caplog.records) == 1
+    message = caplog.records[0].getMessage()
+    assert message.startswith("worker automation mode ")
+    payload = json.loads(message.removeprefix("worker automation mode "))
+    assert payload["worker_mode"] == "observe_executions_supervise"
+    assert payload["database_target"] == "postgresql+psycopg://***@db.example.com/carryme"
+    assert payload["execution_auto_pair_close_enabled"] is True
+    assert "secret" not in message
 
 
 def test_build_api_settings_from_worker_settings_keeps_unredacted_database_url() -> None:


### PR DESCRIPTION
## Summary
- add a redacted automation-mode payload for worker startup diagnostics
- log the payload for stable-launch, execution-monitor, and production-supervisor modes
- include hold-mode, stable-launch risk caps, and execution auto-close/profit-giveback settings in the log output

## Why
When Render workers redeploy, we need to know immediately from logs whether the hosted service is still in execution-test mode (`close_position=true`) or real profit-hold mode, and whether auto-close is enabled or shadow-only. This avoids losing opportunity windows while debugging env drift.

## Safety
- no trading behavior changes
- no credentials are logged
- database URLs are redacted through the existing `database_target` path

## Validation
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run pytest -q tests/test_worker.py -k 'automation_mode or worker_defaults'`
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run ruff check .`
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run mypy src apps packages tests`
