### PR TITLE
fix: require profit protection for stable hold mode

### DIFF
--- a/apps/worker/src/carryme_worker/poller.py
+++ b/apps/worker/src/carryme_worker/poller.py
@@ -523,6 +523,16 @@ def _build_stable_launch_hold_mode_blocker(settings: WorkerSettings) -> str | No
             "Stable launch hold mode is blocked because "
             "execution_auto_pair_close_shadow_mode is true"
         )
+    if settings.execution_auto_pair_close_min_profit_total_collateral is None:
+        return (
+            "Stable launch hold mode is blocked because "
+            "execution_auto_pair_close_min_profit_total_collateral is unset"
+        )
+    if settings.execution_auto_pair_close_max_profit_giveback_ratio is None:
+        return (
+            "Stable launch hold mode is blocked because "
+            "execution_auto_pair_close_max_profit_giveback_ratio is unset"
+        )
     return None
 
 

--- a/apps/worker/src/carryme_worker/poller.py
+++ b/apps/worker/src/carryme_worker/poller.py
@@ -533,6 +533,11 @@ def _build_stable_launch_hold_mode_blocker(settings: WorkerSettings) -> str | No
             "Stable launch hold mode is blocked because "
             "execution_auto_pair_close_max_profit_giveback_ratio is unset"
         )
+    if not 0 < settings.execution_auto_pair_close_max_profit_giveback_ratio < 1:
+        return (
+            "Stable launch hold mode is blocked because "
+            "execution_auto_pair_close_max_profit_giveback_ratio must be between 0 and 1"
+        )
     if not settings.execution_balance_checkpoint_enabled:
         return (
             "Stable launch hold mode is blocked because "

--- a/apps/worker/src/carryme_worker/poller.py
+++ b/apps/worker/src/carryme_worker/poller.py
@@ -536,7 +536,7 @@ def _build_stable_launch_hold_mode_blocker(settings: WorkerSettings) -> str | No
     if not 0 < settings.execution_auto_pair_close_max_profit_giveback_ratio < 1:
         return (
             "Stable launch hold mode is blocked because "
-            "execution_auto_pair_close_max_profit_giveback_ratio must be between 0 and 1"
+            "execution_auto_pair_close_max_profit_giveback_ratio must satisfy 0 < ratio < 1"
         )
     if not settings.execution_balance_checkpoint_enabled:
         return (

--- a/apps/worker/src/carryme_worker/poller.py
+++ b/apps/worker/src/carryme_worker/poller.py
@@ -533,6 +533,11 @@ def _build_stable_launch_hold_mode_blocker(settings: WorkerSettings) -> str | No
             "Stable launch hold mode is blocked because "
             "execution_auto_pair_close_max_profit_giveback_ratio is unset"
         )
+    if not settings.execution_balance_checkpoint_enabled:
+        return (
+            "Stable launch hold mode is blocked because "
+            "execution_balance_checkpoint_enabled is false"
+        )
     return None
 
 

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -8110,6 +8110,23 @@ def test_launch_latest_stable_canary_once_returns_launched_summary(
             "Stable launch hold mode is blocked because "
             "execution_auto_pair_close_shadow_mode is true",
         ),
+        (
+            {
+                "execution_auto_pair_close_enabled": True,
+                "execution_auto_pair_close_shadow_mode": False,
+            },
+            "Stable launch hold mode is blocked because "
+            "execution_auto_pair_close_min_profit_total_collateral is unset",
+        ),
+        (
+            {
+                "execution_auto_pair_close_enabled": True,
+                "execution_auto_pair_close_shadow_mode": False,
+                "execution_auto_pair_close_min_profit_total_collateral": 0.5,
+            },
+            "Stable launch hold mode is blocked because "
+            "execution_auto_pair_close_max_profit_giveback_ratio is unset",
+        ),
     ),
 )
 def test_launch_latest_stable_canary_once_blocks_hold_mode_without_live_auto_close(
@@ -8166,6 +8183,8 @@ def test_launch_latest_stable_canary_once_can_hold_when_auto_close_is_live(
         stable_canary_launch_close_position=False,
         execution_auto_pair_close_enabled=True,
         execution_auto_pair_close_shadow_mode=False,
+        execution_auto_pair_close_min_profit_total_collateral=0.5,
+        execution_auto_pair_close_max_profit_giveback_ratio=0.4,
         extended_live_enabled=True,
         extended_api_key="extended-key",
         extended_stark_private_key="extended-secret",

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -8147,7 +8147,7 @@ def test_launch_latest_stable_canary_once_returns_launched_summary(
                 "execution_balance_checkpoint_enabled": True,
             },
             "Stable launch hold mode is blocked because "
-            "execution_auto_pair_close_max_profit_giveback_ratio must be between 0 and 1",
+            "execution_auto_pair_close_max_profit_giveback_ratio must satisfy 0 < ratio < 1",
         ),
     ),
 )

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -8138,6 +8138,17 @@ def test_launch_latest_stable_canary_once_returns_launched_summary(
             "Stable launch hold mode is blocked because "
             "execution_balance_checkpoint_enabled is false",
         ),
+        (
+            {
+                "execution_auto_pair_close_enabled": True,
+                "execution_auto_pair_close_shadow_mode": False,
+                "execution_auto_pair_close_min_profit_total_collateral": 0.5,
+                "execution_auto_pair_close_max_profit_giveback_ratio": 1.0,
+                "execution_balance_checkpoint_enabled": True,
+            },
+            "Stable launch hold mode is blocked because "
+            "execution_auto_pair_close_max_profit_giveback_ratio must be between 0 and 1",
+        ),
     ),
 )
 def test_launch_latest_stable_canary_once_blocks_hold_mode_without_live_auto_close(

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -8127,6 +8127,17 @@ def test_launch_latest_stable_canary_once_returns_launched_summary(
             "Stable launch hold mode is blocked because "
             "execution_auto_pair_close_max_profit_giveback_ratio is unset",
         ),
+        (
+            {
+                "execution_auto_pair_close_enabled": True,
+                "execution_auto_pair_close_shadow_mode": False,
+                "execution_auto_pair_close_min_profit_total_collateral": 0.5,
+                "execution_auto_pair_close_max_profit_giveback_ratio": 0.4,
+                "execution_balance_checkpoint_enabled": False,
+            },
+            "Stable launch hold mode is blocked because "
+            "execution_balance_checkpoint_enabled is false",
+        ),
     ),
 )
 def test_launch_latest_stable_canary_once_blocks_hold_mode_without_live_auto_close(


### PR DESCRIPTION
## Summary
- require profit-giveback thresholds before stable launch can enter hold mode
- keep immediate-close execution-test mode unchanged
- extend hold-mode tests for missing auto-close, shadow auto-close, missing min profit, missing giveback ratio, and the fully configured path

## Why
For funding capture, `close_position=false` leaves a live hedge open. That should only happen when auto-close is live and profit-protection is configured, otherwise the system can hold through a profit giveback and only exit on the older edge/hold-window checks.

## Safety
- fail-closed only; this blocks unsafe hold-mode launches rather than enabling new launch paths
- does not change canary caps, approvals, or execution behavior when `close_position=true`

## Validation
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run pytest -q tests/test_worker.py -k 'hold_mode_without_live_auto_close or can_hold_when_auto_close_is_live'`
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run ruff check .`
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run mypy src apps packages tests`
