### PR TITLE
fix: rank stable launch-ready labels

### DIFF
--- a/apps/worker/src/carryme_worker/config.py
+++ b/apps/worker/src/carryme_worker/config.py
@@ -6,6 +6,7 @@ from typing import Literal
 from carryme_models import SUPPORTED_UNIVERSE_VENUES
 from carryme_normalizers import get_fee_profile
 from carryme_storage.db import redact_database_url
+from carryme_storage.launch_ready_canaries import MAX_RECENT_LABEL_LIMIT
 from pydantic import AliasChoices, Field, ValidationInfo, field_validator, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
@@ -35,7 +36,11 @@ class WorkerSettings(BaseSettings):
     stable_canary_launch_max_active_live_executions: int = Field(default=0, ge=0)
     # Fetch enough rows to decide whether the blocking threshold is exceeded.
     stable_canary_launch_active_execution_limit: int = Field(default=20, gt=0)
-    stable_canary_launch_candidate_scan_limit: int = Field(default=100, gt=0)
+    stable_canary_launch_candidate_scan_limit: int = Field(
+        default=100,
+        gt=0,
+        le=MAX_RECENT_LABEL_LIMIT,
+    )
     stable_canary_launch_max_total_live_notional: float | None = Field(
         default=None,
         ge=0,

--- a/apps/worker/src/carryme_worker/config.py
+++ b/apps/worker/src/carryme_worker/config.py
@@ -35,6 +35,7 @@ class WorkerSettings(BaseSettings):
     stable_canary_launch_max_active_live_executions: int = Field(default=0, ge=0)
     # Fetch enough rows to decide whether the blocking threshold is exceeded.
     stable_canary_launch_active_execution_limit: int = Field(default=20, gt=0)
+    stable_canary_launch_candidate_scan_limit: int = Field(default=100, gt=0)
     stable_canary_launch_max_total_live_notional: float | None = Field(
         default=None,
         ge=0,

--- a/apps/worker/src/carryme_worker/poller.py
+++ b/apps/worker/src/carryme_worker/poller.py
@@ -2932,6 +2932,40 @@ async def launch_latest_stable_canary_once(
     selected: FundingUniverseCanaryCandidate | None = None
     approval: RouteApprovalEntry | None = None
     candidate_skip_details: list[str] = []
+    single_candidate = len(stable_candidates) == 1
+
+    def _single_candidate_skip(
+        *,
+        candidate_snapshot: LaunchReadyCanarySnapshot | None,
+        detail: str,
+        approved_snapshot_id: int | None = None,
+        paper_trade_id: int | None = None,
+        final_pair_state: str | None = None,
+    ) -> StableCanaryLaunchSummary | None:
+        if not single_candidate:
+            return None
+        return StableCanaryLaunchSummary(
+            status="skipped",
+            database_path=settings.database_target,
+            label=candidate_snapshot.label if candidate_snapshot is not None else None,
+            launch_ready_snapshot_id=(
+                candidate_snapshot.launch_ready_snapshot_id
+                if candidate_snapshot is not None
+                else None
+            ),
+            approved_snapshot_id=(
+                approved_snapshot_id
+                if approved_snapshot_id is not None
+                else (
+                    candidate_snapshot.approved_snapshot.snapshot_id
+                    if candidate_snapshot is not None
+                    else None
+                )
+            ),
+            paper_trade_id=paper_trade_id,
+            final_pair_state=final_pair_state,
+            detail=detail,
+        )
 
     for candidate_stability in stable_candidates:
         try:
@@ -2946,6 +2980,12 @@ async def launch_latest_stable_canary_once(
             )
         except HTTPException as exc:
             if exc.status_code in {404, 409}:
+                summary = _single_candidate_skip(
+                    candidate_snapshot=None,
+                    detail=str(exc.detail),
+                )
+                if summary is not None:
+                    return summary
                 candidate_skip_details.append(
                     f"{candidate_stability.snapshot.label}: {exc.detail}"
                 )
@@ -2959,6 +2999,12 @@ async def launch_latest_stable_canary_once(
             label=candidate_snapshot.label,
         )
         if label_cooldown_reason is not None:
+            summary = _single_candidate_skip(
+                candidate_snapshot=candidate_snapshot,
+                detail=label_cooldown_reason,
+            )
+            if summary is not None:
+                return summary
             candidate_skip_details.append(
                 f"{candidate_snapshot.label}: {label_cooldown_reason}"
             )
@@ -2971,6 +3017,12 @@ async def launch_latest_stable_canary_once(
             label=candidate_snapshot.label,
         )
         if label_rate_cap_reason is not None:
+            summary = _single_candidate_skip(
+                candidate_snapshot=candidate_snapshot,
+                detail=label_rate_cap_reason,
+            )
+            if summary is not None:
+                return summary
             candidate_skip_details.append(
                 f"{candidate_snapshot.label}: {label_rate_cap_reason}"
             )
@@ -2980,6 +3032,12 @@ async def launch_latest_stable_canary_once(
             label=candidate_snapshot.label
         )
         if candidate_latest_approved_snapshot is None:
+            summary = _single_candidate_skip(
+                candidate_snapshot=candidate_snapshot,
+                detail="Latest approved canary snapshot is missing for the selected label",
+            )
+            if summary is not None:
+                return summary
             candidate_skip_details.append(
                 f"{candidate_snapshot.label}: latest approved canary snapshot is missing"
             )
@@ -2988,6 +3046,15 @@ async def launch_latest_stable_canary_once(
             candidate_latest_approved_snapshot.snapshot_id
             != candidate_snapshot.approved_snapshot.snapshot_id
         ):
+            summary = _single_candidate_skip(
+                candidate_snapshot=candidate_snapshot,
+                detail=(
+                    "Launch-ready canary snapshot is stale relative to the latest "
+                    "approved snapshot"
+                ),
+            )
+            if summary is not None:
+                return summary
             candidate_skip_details.append(
                 f"{candidate_snapshot.label}: launch-ready canary snapshot is stale relative "
                 "to the latest approved snapshot"
@@ -3005,6 +3072,12 @@ async def launch_latest_stable_canary_once(
                     candidate_snapshot.label,
                     execution_maturity_reason,
                 )
+            summary = _single_candidate_skip(
+                candidate_snapshot=candidate_snapshot,
+                detail=execution_maturity_reason,
+            )
+            if summary is not None:
+                return summary
             candidate_skip_details.append(
                 f"{candidate_snapshot.label}: {execution_maturity_reason}"
             )
@@ -3021,6 +3094,12 @@ async def launch_latest_stable_canary_once(
                     candidate_snapshot.label,
                     latest_outcome_reason,
                 )
+            summary = _single_candidate_skip(
+                candidate_snapshot=candidate_snapshot,
+                detail=latest_outcome_reason,
+            )
+            if summary is not None:
+                return summary
             candidate_skip_details.append(
                 f"{candidate_snapshot.label}: {latest_outcome_reason}"
             )
@@ -3037,6 +3116,12 @@ async def launch_latest_stable_canary_once(
                     candidate_snapshot.label,
                     liquidity_and_value_reason,
                 )
+            summary = _single_candidate_skip(
+                candidate_snapshot=candidate_snapshot,
+                detail=liquidity_and_value_reason,
+            )
+            if summary is not None:
+                return summary
             candidate_skip_details.append(
                 f"{candidate_snapshot.label}: {liquidity_and_value_reason}"
             )
@@ -3059,6 +3144,15 @@ async def launch_latest_stable_canary_once(
                     candidate_snapshot.label,
                     automation_gate_reason,
                 )
+            summary = _single_candidate_skip(
+                candidate_snapshot=candidate_snapshot,
+                detail=(
+                    "Latest approved snapshot no longer satisfies automated launch "
+                    f"gates: {automation_gate_reason}"
+                ),
+            )
+            if summary is not None:
+                return summary
             candidate_skip_details.append(
                 f"{candidate_snapshot.label}: latest approved snapshot no longer "
                 f"satisfies automated launch gates: {automation_gate_reason}"
@@ -3072,6 +3166,16 @@ async def launch_latest_stable_canary_once(
             if previous_launch is not None:
                 if previous_launch.status == "shadowed":
                     if settings.stable_canary_launch_shadow_mode:
+                        summary = _single_candidate_skip(
+                            candidate_snapshot=candidate_snapshot,
+                            detail=(
+                                "Launch-ready canary snapshot already evaluated in shadow mode "
+                                "by worker"
+                            ),
+                            final_pair_state=previous_launch.final_pair_state,
+                        )
+                        if summary is not None:
+                            return summary
                         candidate_skip_details.append(
                             f"{candidate_snapshot.label}: launch-ready canary snapshot "
                             "already evaluated in shadow mode by worker"
@@ -3079,6 +3183,17 @@ async def launch_latest_stable_canary_once(
                         continue
                     # Shadow mode is off but was previously on: allow a real launch now.
                 else:
+                    summary = _single_candidate_skip(
+                        candidate_snapshot=candidate_snapshot,
+                        detail=(
+                            "Launch-ready canary snapshot already launched by worker as "
+                            f"paper trade {previous_launch.paper_trade_id}"
+                        ),
+                        paper_trade_id=previous_launch.paper_trade_id,
+                        final_pair_state=previous_launch.final_pair_state,
+                    )
+                    if summary is not None:
+                        return summary
                     candidate_skip_details.append(
                         f"{candidate_snapshot.label}: launch-ready canary snapshot already "
                         f"launched by worker as paper trade {previous_launch.paper_trade_id}"
@@ -3097,29 +3212,14 @@ async def launch_latest_stable_canary_once(
                     candidate_snapshot.label,
                     risk_budget_reason,
                 )
+            summary = _single_candidate_skip(
+                candidate_snapshot=candidate_snapshot,
+                detail=risk_budget_reason,
+            )
+            if summary is not None:
+                return summary
             candidate_skip_details.append(
                 f"{candidate_snapshot.label}: {risk_budget_reason}"
-            )
-            continue
-
-        execution_preflight = _build_candidate_live_execution_preflight(
-            settings=runtime_settings,
-            candidate=candidate_selected,
-            label=candidate_snapshot.label,
-        )
-        if not execution_preflight.ready:
-            try:
-                launch_ready_store.delete_label(candidate_snapshot.label)
-            except Exception:
-                logging.getLogger("carryme.worker").exception(
-                    "failed to invalidate launch-ready snapshots for label=%s "
-                    "during stable launch preflight",
-                    candidate_snapshot.label,
-                )
-            candidate_skip_details.append(
-                f"{candidate_snapshot.label}: latest launch-ready snapshot no longer "
-                "satisfies live execution readiness: "
-                f"{'; '.join(execution_preflight.blocking_reasons)}"
             )
             continue
 
@@ -3180,6 +3280,32 @@ async def launch_latest_stable_canary_once(
             launch_ready_snapshot_id=snapshot.launch_ready_snapshot_id,
             approved_snapshot_id=snapshot.approved_snapshot.snapshot_id,
             detail=hold_mode_blocker,
+        )
+
+    execution_preflight = _build_candidate_live_execution_preflight(
+        settings=runtime_settings,
+        candidate=selected,
+        label=snapshot.label,
+    )
+    if not execution_preflight.ready:
+        try:
+            launch_ready_store.delete_label(snapshot.label)
+        except Exception:
+            logging.getLogger("carryme.worker").exception(
+                "failed to invalidate launch-ready snapshots for label=%s "
+                "during stable launch preflight",
+                snapshot.label,
+            )
+        return StableCanaryLaunchSummary(
+            status="skipped",
+            database_path=settings.database_target,
+            label=snapshot.label,
+            launch_ready_snapshot_id=snapshot.launch_ready_snapshot_id,
+            approved_snapshot_id=snapshot.approved_snapshot.snapshot_id,
+            detail=(
+                "Latest launch-ready snapshot no longer satisfies live execution "
+                f"readiness: {'; '.join(execution_preflight.blocking_reasons)}"
+            ),
         )
 
     try:

--- a/apps/worker/src/carryme_worker/poller.py
+++ b/apps/worker/src/carryme_worker/poller.py
@@ -2111,6 +2111,70 @@ def _build_latest_launch_ready_stability(
     )
 
 
+def _rank_launch_ready_stability(
+    stability: LaunchReadyCanaryStability,
+) -> tuple[float, float, float, datetime, int]:
+    """Return the deterministic launch ranking for one stable launch-ready label."""
+
+    snapshot_id = stability.snapshot.launch_ready_snapshot_id or 0
+    return (
+        *_rank_approved_canary_candidate(stability.snapshot.approved_snapshot.candidate),
+        stability.snapshot.captured_at,
+        snapshot_id,
+    )
+
+
+def _list_ranked_stable_launch_ready_stabilities(
+    *,
+    store: LaunchReadyCanaryStore,
+    max_snapshot_age_seconds: int,
+    min_snapshot_count: int,
+    min_stable_seconds: float,
+    now: datetime,
+    scan_limit: int,
+) -> list[LaunchReadyCanaryStability]:
+    """Return stable launch-ready labels ranked by route quality, then freshness."""
+
+    if scan_limit < 1:
+        raise ValueError("scan_limit must be positive")
+
+    recent_snapshots = store.list_recent(limit=scan_limit)
+    if not recent_snapshots:
+        return [
+            _build_launch_ready_canary_stability(
+                store=store,
+                label=None,
+                max_snapshot_age_seconds=max_snapshot_age_seconds,
+                min_snapshot_count=min_snapshot_count,
+                min_stable_seconds=min_stable_seconds,
+                now=now,
+            )
+        ]
+
+    labels: list[str] = []
+    seen_labels: set[str] = set()
+    for snapshot in recent_snapshots:
+        if snapshot.label in seen_labels:
+            continue
+        seen_labels.add(snapshot.label)
+        labels.append(snapshot.label)
+
+    stabilities: list[LaunchReadyCanaryStability] = []
+    for label in labels:
+        stability = _build_latest_launch_ready_stability(
+            store=store,
+            label=label,
+            max_snapshot_age_seconds=max_snapshot_age_seconds,
+            min_snapshot_count=min_snapshot_count,
+            min_stable_seconds=min_stable_seconds,
+            now=now,
+        )
+        if stability is not None:
+            stabilities.append(stability)
+
+    return sorted(stabilities, key=_rank_launch_ready_stability, reverse=True)
+
+
 async def scan_approved_canary_once(
     settings: WorkerSettings,
     *,
@@ -2764,14 +2828,20 @@ async def launch_latest_stable_canary_once(
         )
 
     try:
-        stability = _build_launch_ready_canary_stability(
+        stable_candidates = _list_ranked_stable_launch_ready_stabilities(
             store=launch_ready_store,
-            label=None,
             max_snapshot_age_seconds=settings.launch_ready_canary_max_snapshot_age_seconds,
             min_snapshot_count=settings.stable_launch_ready_min_snapshot_count,
             min_stable_seconds=settings.stable_launch_ready_min_stable_seconds,
             now=timestamp,
+            scan_limit=settings.stable_canary_launch_candidate_scan_limit,
         )
+        if not stable_candidates:
+            raise HTTPException(
+                status_code=409,
+                detail="No stable launch-ready canary snapshot found",
+            )
+        stability = stable_candidates[0]
         snapshot, selected, approval = _select_latest_launch_ready_canary_snapshot(
             store=launch_ready_store,
             approval_service=route_approval_service,

--- a/apps/worker/src/carryme_worker/poller.py
+++ b/apps/worker/src/carryme_worker/poller.py
@@ -2106,10 +2106,9 @@ def _evaluate_latest_launch_ready_stability(
         return None, f"label={label}: no launch-ready canary snapshot found"
 
     latest_snapshot = snapshots[0]
-    snapshot_age_seconds = max(
-        0.0,
-        (now - latest_snapshot.captured_at).total_seconds(),
-    )
+    snapshot_age_seconds = (now - latest_snapshot.captured_at).total_seconds()
+    if snapshot_age_seconds < 0:
+        return None, f"label={label}: snapshot timestamp is in the future"
     effective_max_age_seconds = min(
         max_snapshot_age_seconds,
         latest_snapshot.max_snapshot_age_seconds,
@@ -2992,6 +2991,44 @@ async def launch_latest_stable_canary_once(
                 continue
             raise
 
+        try:
+            revalidated_stability = _build_launch_ready_canary_stability(
+                store=launch_ready_store,
+                label=candidate_snapshot.label,
+                max_snapshot_age_seconds=settings.launch_ready_canary_max_snapshot_age_seconds,
+                min_snapshot_count=settings.stable_launch_ready_min_snapshot_count,
+                min_stable_seconds=settings.stable_launch_ready_min_stable_seconds,
+                now=timestamp,
+            )
+        except HTTPException as exc:
+            detail = str(exc.detail) or (
+                "Launch-ready canary snapshot no longer satisfies stability requirements"
+            )
+            summary = _single_candidate_skip(
+                candidate_snapshot=candidate_snapshot,
+                detail=detail,
+            )
+            if summary is not None:
+                return summary
+            candidate_skip_details.append(f"{candidate_snapshot.label}: {detail}")
+            continue
+        if (
+            revalidated_stability.snapshot.launch_ready_snapshot_id
+            != candidate_snapshot.launch_ready_snapshot_id
+        ):
+            detail = (
+                "Launch-ready canary snapshot changed before stability could be revalidated"
+            )
+            summary = _single_candidate_skip(
+                candidate_snapshot=candidate_snapshot,
+                detail=detail,
+            )
+            if summary is not None:
+                return summary
+            candidate_skip_details.append(f"{candidate_snapshot.label}: {detail}")
+            continue
+        candidate_stability = revalidated_stability
+
         label_cooldown_reason = _build_stable_launch_cooldown_reason(
             settings=settings,
             launch_store=stable_launch_store,
@@ -3316,7 +3353,7 @@ async def launch_latest_stable_canary_once(
             note="worker stable launch-ready canary",
             lifecycle_note=(
                 "Launched by carryme-worker from stable launch-ready snapshot "
-                f"{stability.snapshot.launch_ready_snapshot_id} after "
+                f"{snapshot.launch_ready_snapshot_id} after "
                 f"{stability.consecutive_snapshots} stable snapshots over "
                 f"{stability.stable_seconds:.1f}s."
             ),

--- a/apps/worker/src/carryme_worker/poller.py
+++ b/apps/worker/src/carryme_worker/poller.py
@@ -17,7 +17,6 @@ from carryme_api.app import (
     _append_pair_close_confirmation_for_preview,
     _build_cleanup_live_execution_router_for_candidate,
     _build_cleanup_preview_router_for_candidate,
-    _build_launch_ready_canary_stability,
     _build_pair_close_context_for_paper_trade,
     _build_pair_close_live_execution_coordinator_for_candidate,
     _build_pair_close_preview_service_for_candidate,
@@ -25,6 +24,9 @@ from carryme_api.app import (
     _execute_guarded_pair_close_from_confirmation,
     _run_guarded_canary_lifecycle,
     _select_latest_launch_ready_canary_snapshot,
+)
+from carryme_api.app import (
+    _build_launch_ready_canary_stability as _api_build_launch_ready_canary_stability,
 )
 from carryme_api.config import ApiSettings
 from carryme_models import (
@@ -125,6 +127,12 @@ FUNDING_WINDOW_HOURS_BY_VENUE: dict[str, float] = {
     "paradex": 8.0,
     "hyperliquid": 8.0,
 }
+
+
+def _build_launch_ready_canary_stability(**kwargs: Any) -> LaunchReadyCanaryStability:
+    """Delegate to the API-layer stability helper for legacy worker call sites and tests."""
+
+    return _api_build_launch_ready_canary_stability(**kwargs)
 
 
 def _rank_approved_canary_candidate(
@@ -2071,9 +2079,33 @@ def _build_latest_launch_ready_stability(
 ) -> LaunchReadyCanaryStability | None:
     """Return the latest stable launch-ready snapshot for one label, if any."""
 
-    latest_snapshot = store.latest(label=label)
-    if latest_snapshot is None:
-        return None
+    stability, _ = _evaluate_latest_launch_ready_stability(
+        store=store,
+        label=label,
+        max_snapshot_age_seconds=max_snapshot_age_seconds,
+        min_snapshot_count=min_snapshot_count,
+        min_stable_seconds=min_stable_seconds,
+        now=now,
+    )
+    return stability
+
+
+def _evaluate_latest_launch_ready_stability(
+    *,
+    store: LaunchReadyCanaryStore,
+    label: str,
+    max_snapshot_age_seconds: int,
+    min_snapshot_count: int,
+    min_stable_seconds: float,
+    now: datetime,
+) -> tuple[LaunchReadyCanaryStability | None, str | None]:
+    """Return the latest stable launch-ready snapshot and failure detail for one label."""
+
+    snapshots = store.list_recent(limit=max(min_snapshot_count + 5, 20), label=label)
+    if not snapshots:
+        return None, f"label={label}: no launch-ready canary snapshot found"
+
+    latest_snapshot = snapshots[0]
     snapshot_age_seconds = max(
         0.0,
         (now - latest_snapshot.captured_at).total_seconds(),
@@ -2083,14 +2115,20 @@ def _build_latest_launch_ready_stability(
         latest_snapshot.max_snapshot_age_seconds,
     )
     if snapshot_age_seconds > effective_max_age_seconds:
-        return None
+        return (
+            None,
+            "label="
+            f"{label}: snapshot stale ({snapshot_age_seconds:.1f}s > {effective_max_age_seconds}s)",
+        )
 
-    snapshots = store.list_recent(limit=max(min_snapshot_count + 5, 20), label=label)
     chain: list[LaunchReadyCanarySnapshot] = []
     for snapshot in snapshots:
         if _launch_ready_snapshot_payload_changed(snapshot, latest_snapshot):
             break
         chain.append(snapshot)
+
+    if not chain:
+        return None, f"label={label}: stability chain missing current snapshot"
 
     consecutive_snapshots = len(chain)
     oldest_snapshot = chain[-1]
@@ -2099,15 +2137,27 @@ def _build_latest_launch_ready_stability(
         (latest_snapshot.captured_at - oldest_snapshot.captured_at).total_seconds(),
     )
     if consecutive_snapshots < min_snapshot_count:
-        return None
+        return (
+            None,
+            "label="
+            f"{label}: not yet stable ({consecutive_snapshots} < {min_snapshot_count} "
+            "consecutive snapshots)",
+        )
     if stable_seconds < min_stable_seconds:
-        return None
-    return LaunchReadyCanaryStability(
-        snapshot=latest_snapshot,
-        consecutive_snapshots=consecutive_snapshots,
-        stable_seconds=stable_seconds,
-        min_snapshot_count=min_snapshot_count,
-        min_stable_seconds=min_stable_seconds,
+        return (
+            None,
+            "label="
+            f"{label}: stable time too short ({stable_seconds:.1f}s < {min_stable_seconds:.1f}s)",
+        )
+    return (
+        LaunchReadyCanaryStability(
+            snapshot=latest_snapshot,
+            consecutive_snapshots=consecutive_snapshots,
+            stable_seconds=stable_seconds,
+            min_snapshot_count=min_snapshot_count,
+            min_stable_seconds=min_stable_seconds,
+        ),
+        None,
     )
 
 
@@ -2132,36 +2182,34 @@ def _list_ranked_stable_launch_ready_stabilities(
     min_stable_seconds: float,
     now: datetime,
     scan_limit: int,
-) -> list[LaunchReadyCanaryStability]:
+) -> tuple[list[LaunchReadyCanaryStability], str | None]:
     """Return stable launch-ready labels ranked by route quality, then freshness."""
 
     if scan_limit < 1:
         raise ValueError("scan_limit must be positive")
 
-    recent_snapshots = store.list_recent(limit=scan_limit)
-    if not recent_snapshots:
-        return [
-            _build_launch_ready_canary_stability(
-                store=store,
-                label=None,
-                max_snapshot_age_seconds=max_snapshot_age_seconds,
-                min_snapshot_count=min_snapshot_count,
-                min_stable_seconds=min_stable_seconds,
-                now=now,
-            )
-        ]
-
-    labels: list[str] = []
-    seen_labels: set[str] = set()
-    for snapshot in recent_snapshots:
-        if snapshot.label in seen_labels:
-            continue
-        seen_labels.add(snapshot.label)
-        labels.append(snapshot.label)
+    labels = store.list_recent_labels(limit=scan_limit)
+    if not labels:
+        try:
+            return [
+                _build_launch_ready_canary_stability(
+                    store=store,
+                    label=None,
+                    max_snapshot_age_seconds=max_snapshot_age_seconds,
+                    min_snapshot_count=min_snapshot_count,
+                    min_stable_seconds=min_stable_seconds,
+                    now=now,
+                )
+            ], None
+        except HTTPException as exc:
+            if exc.status_code in {404, 409}:
+                return [], str(exc.detail)
+            raise
 
     stabilities: list[LaunchReadyCanaryStability] = []
+    failure_details: list[str] = []
     for label in labels:
-        stability = _build_latest_launch_ready_stability(
+        stability, failure_detail = _evaluate_latest_launch_ready_stability(
             store=store,
             label=label,
             max_snapshot_age_seconds=max_snapshot_age_seconds,
@@ -2171,8 +2219,21 @@ def _list_ranked_stable_launch_ready_stabilities(
         )
         if stability is not None:
             stabilities.append(stability)
+            continue
+        if failure_detail is not None:
+            failure_details.append(failure_detail)
 
-    return sorted(stabilities, key=_rank_launch_ready_stability, reverse=True)
+    ranked = sorted(stabilities, key=_rank_launch_ready_stability, reverse=True)
+    if ranked:
+        return ranked, None
+
+    detail = "No stable launch-ready canary snapshot found"
+    if failure_details:
+        summarized_failures = "; ".join(failure_details[:3])
+        if len(failure_details) > 3:
+            summarized_failures += f"; +{len(failure_details) - 3} more labels"
+        detail = f"{detail}: {summarized_failures}"
+    return [], detail
 
 
 async def scan_approved_canary_once(
@@ -2827,214 +2888,6 @@ async def launch_latest_stable_canary_once(
             detail=global_rate_cap_reason,
         )
 
-    try:
-        stable_candidates = _list_ranked_stable_launch_ready_stabilities(
-            store=launch_ready_store,
-            max_snapshot_age_seconds=settings.launch_ready_canary_max_snapshot_age_seconds,
-            min_snapshot_count=settings.stable_launch_ready_min_snapshot_count,
-            min_stable_seconds=settings.stable_launch_ready_min_stable_seconds,
-            now=timestamp,
-            scan_limit=settings.stable_canary_launch_candidate_scan_limit,
-        )
-        if not stable_candidates:
-            raise HTTPException(
-                status_code=409,
-                detail="No stable launch-ready canary snapshot found",
-            )
-        stability = stable_candidates[0]
-        snapshot, selected, approval = _select_latest_launch_ready_canary_snapshot(
-            store=launch_ready_store,
-            approval_service=route_approval_service,
-            label=stability.snapshot.label,
-            max_snapshot_age_seconds=settings.launch_ready_canary_max_snapshot_age_seconds,
-            now=timestamp,
-        )
-    except HTTPException as exc:
-        if exc.status_code in {404, 409}:
-            return StableCanaryLaunchSummary(
-                status="skipped",
-                database_path=settings.database_target,
-                detail=exc.detail,
-            )
-        raise
-
-    label_cooldown_reason = _build_stable_launch_cooldown_reason(
-        settings=settings,
-        launch_store=stable_launch_store,
-        now=timestamp,
-        label=snapshot.label,
-    )
-    if label_cooldown_reason is not None:
-        return StableCanaryLaunchSummary(
-            status="skipped",
-            database_path=settings.database_target,
-            label=snapshot.label,
-            launch_ready_snapshot_id=snapshot.launch_ready_snapshot_id,
-            approved_snapshot_id=snapshot.approved_snapshot.snapshot_id,
-            detail=label_cooldown_reason,
-        )
-
-    label_rate_cap_reason = _build_stable_launch_rate_cap_reason(
-        settings=settings,
-        launch_store=stable_launch_store,
-        now=timestamp,
-        label=snapshot.label,
-    )
-    if label_rate_cap_reason is not None:
-        return StableCanaryLaunchSummary(
-            status="skipped",
-            database_path=settings.database_target,
-            label=snapshot.label,
-            launch_ready_snapshot_id=snapshot.launch_ready_snapshot_id,
-            approved_snapshot_id=snapshot.approved_snapshot.snapshot_id,
-            detail=label_rate_cap_reason,
-        )
-
-    latest_approved_snapshot = source_approved_store.latest(label=snapshot.label)
-    if latest_approved_snapshot is None:
-        return StableCanaryLaunchSummary(
-            status="skipped",
-            database_path=settings.database_target,
-            label=snapshot.label,
-            launch_ready_snapshot_id=snapshot.launch_ready_snapshot_id,
-            approved_snapshot_id=snapshot.approved_snapshot.snapshot_id,
-            detail="Latest approved canary snapshot is missing for the selected label",
-        )
-    if latest_approved_snapshot.snapshot_id != snapshot.approved_snapshot.snapshot_id:
-        return StableCanaryLaunchSummary(
-            status="skipped",
-            database_path=settings.database_target,
-            label=snapshot.label,
-            launch_ready_snapshot_id=snapshot.launch_ready_snapshot_id,
-            approved_snapshot_id=snapshot.approved_snapshot.snapshot_id,
-            detail=(
-                "Launch-ready canary snapshot is stale relative to the latest "
-                "approved snapshot"
-            ),
-        )
-
-    execution_maturity_reason = _build_stable_launch_execution_maturity_reason(
-        settings=settings,
-        candidate=latest_approved_snapshot.candidate,
-    )
-    if execution_maturity_reason is not None:
-        if settings.stable_canary_launch_shadow_mode:
-            logging.getLogger("carryme.worker").info(
-                "shadow launch maturity blocked label=%s because %s",
-                snapshot.label,
-                execution_maturity_reason,
-            )
-        return StableCanaryLaunchSummary(
-            status="skipped",
-            database_path=settings.database_target,
-            label=snapshot.label,
-            launch_ready_snapshot_id=snapshot.launch_ready_snapshot_id,
-            approved_snapshot_id=snapshot.approved_snapshot.snapshot_id,
-            detail=execution_maturity_reason,
-        )
-
-    latest_outcome_reason = _build_stable_launch_latest_outcome_reason(
-        settings=settings,
-        candidate=latest_approved_snapshot.candidate,
-    )
-    if latest_outcome_reason is not None:
-        if settings.stable_canary_launch_shadow_mode:
-            logging.getLogger("carryme.worker").info(
-                "shadow launch latest-outcome blocked label=%s because %s",
-                snapshot.label,
-                latest_outcome_reason,
-            )
-        return StableCanaryLaunchSummary(
-            status="skipped",
-            database_path=settings.database_target,
-            label=snapshot.label,
-            launch_ready_snapshot_id=snapshot.launch_ready_snapshot_id,
-            approved_snapshot_id=snapshot.approved_snapshot.snapshot_id,
-            detail=latest_outcome_reason,
-        )
-
-    liquidity_and_value_reason = _build_stable_launch_liquidity_and_value_reason(
-        settings=settings,
-        candidate=latest_approved_snapshot.candidate,
-    )
-    if liquidity_and_value_reason is not None:
-        if settings.stable_canary_launch_shadow_mode:
-            logging.getLogger("carryme.worker").info(
-                "shadow launch liquidity/value blocked label=%s because %s",
-                snapshot.label,
-                liquidity_and_value_reason,
-            )
-        return StableCanaryLaunchSummary(
-            status="skipped",
-            database_path=settings.database_target,
-            label=snapshot.label,
-            launch_ready_snapshot_id=snapshot.launch_ready_snapshot_id,
-            approved_snapshot_id=snapshot.approved_snapshot.snapshot_id,
-            detail=liquidity_and_value_reason,
-        )
-
-    recent_approved_chain = _list_recent_approved_snapshot_chain(
-        store=source_approved_store,
-        snapshot=latest_approved_snapshot,
-        max_snapshot_age_seconds=settings.launch_ready_canary_max_snapshot_age_seconds,
-    )
-    automation_gate_reason = _build_approved_snapshot_automation_gate_reason(
-        snapshot=latest_approved_snapshot,
-        recent_chain=recent_approved_chain or [latest_approved_snapshot],
-        settings=settings,
-    )
-    if automation_gate_reason is not None:
-        if settings.stable_canary_launch_shadow_mode:
-            logging.getLogger("carryme.worker").info(
-                "shadow launch gate blocked label=%s because %s",
-                snapshot.label,
-                automation_gate_reason,
-            )
-        return StableCanaryLaunchSummary(
-            status="skipped",
-            database_path=settings.database_target,
-            label=snapshot.label,
-            launch_ready_snapshot_id=snapshot.launch_ready_snapshot_id,
-            approved_snapshot_id=snapshot.approved_snapshot.snapshot_id,
-            detail=(
-                "Latest approved snapshot no longer satisfies automated launch "
-                f"gates: {automation_gate_reason}"
-            ),
-        )
-
-    if snapshot.launch_ready_snapshot_id is not None:
-        previous_launch = stable_launch_store.latest_for_snapshot(snapshot.launch_ready_snapshot_id)
-        if previous_launch is not None:
-            if previous_launch.status == "shadowed":
-                if settings.stable_canary_launch_shadow_mode:
-                    return StableCanaryLaunchSummary(
-                        status="skipped",
-                        database_path=settings.database_target,
-                        label=snapshot.label,
-                        launch_ready_snapshot_id=snapshot.launch_ready_snapshot_id,
-                        approved_snapshot_id=snapshot.approved_snapshot.snapshot_id,
-                        final_pair_state=previous_launch.final_pair_state,
-                        detail=(
-                            "Launch-ready canary snapshot already evaluated in shadow mode by "
-                            "worker"
-                        ),
-                    )
-                # Shadow mode is off but was previously on: allow a real launch now.
-            else:
-                return StableCanaryLaunchSummary(
-                    status="skipped",
-                    database_path=settings.database_target,
-                    label=snapshot.label,
-                    launch_ready_snapshot_id=snapshot.launch_ready_snapshot_id,
-                    approved_snapshot_id=snapshot.approved_snapshot.snapshot_id,
-                    paper_trade_id=previous_launch.paper_trade_id,
-                    final_pair_state=previous_launch.final_pair_state,
-                    detail=(
-                        "Launch-ready canary snapshot already launched by worker as "
-                        f"paper trade {previous_launch.paper_trade_id}"
-                    ),
-                )
-
     risk_budget_scan_limit = settings.stable_canary_launch_active_execution_limit
     active_executions_for_budget = _list_recent_live_executions(
         execution_store,
@@ -3053,34 +2906,239 @@ async def launch_latest_stable_canary_once(
         return StableCanaryLaunchSummary(
             status="skipped",
             database_path=settings.database_target,
-            label=snapshot.label,
-            launch_ready_snapshot_id=snapshot.launch_ready_snapshot_id,
-            approved_snapshot_id=snapshot.approved_snapshot.snapshot_id,
             detail=(
                 "Stable launch risk-budget check truncated by "
                 "stable_canary_launch_active_execution_limit; increase limit"
             ),
         )
 
-    risk_budget_reason = _build_stable_launch_risk_budget_reason(
-        settings=settings,
-        active_executions=active_executions_for_budget,
-        candidate=selected,
+    stable_candidates, no_candidate_detail = _list_ranked_stable_launch_ready_stabilities(
+        store=launch_ready_store,
+        max_snapshot_age_seconds=settings.launch_ready_canary_max_snapshot_age_seconds,
+        min_snapshot_count=settings.stable_launch_ready_min_snapshot_count,
+        min_stable_seconds=settings.stable_launch_ready_min_stable_seconds,
+        now=timestamp,
+        scan_limit=settings.stable_canary_launch_candidate_scan_limit,
     )
-    if risk_budget_reason is not None:
-        if settings.stable_canary_launch_shadow_mode:
-            logging.getLogger("carryme.worker").info(
-                "shadow launch budget blocked label=%s because %s",
-                snapshot.label,
-                risk_budget_reason,
-            )
+    if not stable_candidates:
         return StableCanaryLaunchSummary(
             status="skipped",
             database_path=settings.database_target,
-            label=snapshot.label,
-            launch_ready_snapshot_id=snapshot.launch_ready_snapshot_id,
-            approved_snapshot_id=snapshot.approved_snapshot.snapshot_id,
-            detail=risk_budget_reason,
+            detail=no_candidate_detail or "No stable launch-ready canary snapshot found",
+        )
+
+    stability: LaunchReadyCanaryStability | None = None
+    snapshot: LaunchReadyCanarySnapshot | None = None
+    selected: FundingUniverseCanaryCandidate | None = None
+    approval: RouteApprovalEntry | None = None
+    candidate_skip_details: list[str] = []
+
+    for candidate_stability in stable_candidates:
+        try:
+            candidate_snapshot, candidate_selected, candidate_approval = (
+                _select_latest_launch_ready_canary_snapshot(
+                    store=launch_ready_store,
+                    approval_service=route_approval_service,
+                    label=candidate_stability.snapshot.label,
+                    max_snapshot_age_seconds=settings.launch_ready_canary_max_snapshot_age_seconds,
+                    now=timestamp,
+                )
+            )
+        except HTTPException as exc:
+            if exc.status_code in {404, 409}:
+                candidate_skip_details.append(
+                    f"{candidate_stability.snapshot.label}: {exc.detail}"
+                )
+                continue
+            raise
+
+        label_cooldown_reason = _build_stable_launch_cooldown_reason(
+            settings=settings,
+            launch_store=stable_launch_store,
+            now=timestamp,
+            label=candidate_snapshot.label,
+        )
+        if label_cooldown_reason is not None:
+            candidate_skip_details.append(
+                f"{candidate_snapshot.label}: {label_cooldown_reason}"
+            )
+            continue
+
+        label_rate_cap_reason = _build_stable_launch_rate_cap_reason(
+            settings=settings,
+            launch_store=stable_launch_store,
+            now=timestamp,
+            label=candidate_snapshot.label,
+        )
+        if label_rate_cap_reason is not None:
+            candidate_skip_details.append(
+                f"{candidate_snapshot.label}: {label_rate_cap_reason}"
+            )
+            continue
+
+        candidate_latest_approved_snapshot = source_approved_store.latest(
+            label=candidate_snapshot.label
+        )
+        if candidate_latest_approved_snapshot is None:
+            candidate_skip_details.append(
+                f"{candidate_snapshot.label}: latest approved canary snapshot is missing"
+            )
+            continue
+        if (
+            candidate_latest_approved_snapshot.snapshot_id
+            != candidate_snapshot.approved_snapshot.snapshot_id
+        ):
+            candidate_skip_details.append(
+                f"{candidate_snapshot.label}: launch-ready canary snapshot is stale relative "
+                "to the latest approved snapshot"
+            )
+            continue
+
+        execution_maturity_reason = _build_stable_launch_execution_maturity_reason(
+            settings=settings,
+            candidate=candidate_latest_approved_snapshot.candidate,
+        )
+        if execution_maturity_reason is not None:
+            if settings.stable_canary_launch_shadow_mode:
+                logging.getLogger("carryme.worker").info(
+                    "shadow launch maturity blocked label=%s because %s",
+                    candidate_snapshot.label,
+                    execution_maturity_reason,
+                )
+            candidate_skip_details.append(
+                f"{candidate_snapshot.label}: {execution_maturity_reason}"
+            )
+            continue
+
+        latest_outcome_reason = _build_stable_launch_latest_outcome_reason(
+            settings=settings,
+            candidate=candidate_latest_approved_snapshot.candidate,
+        )
+        if latest_outcome_reason is not None:
+            if settings.stable_canary_launch_shadow_mode:
+                logging.getLogger("carryme.worker").info(
+                    "shadow launch latest-outcome blocked label=%s because %s",
+                    candidate_snapshot.label,
+                    latest_outcome_reason,
+                )
+            candidate_skip_details.append(
+                f"{candidate_snapshot.label}: {latest_outcome_reason}"
+            )
+            continue
+
+        liquidity_and_value_reason = _build_stable_launch_liquidity_and_value_reason(
+            settings=settings,
+            candidate=candidate_latest_approved_snapshot.candidate,
+        )
+        if liquidity_and_value_reason is not None:
+            if settings.stable_canary_launch_shadow_mode:
+                logging.getLogger("carryme.worker").info(
+                    "shadow launch liquidity/value blocked label=%s because %s",
+                    candidate_snapshot.label,
+                    liquidity_and_value_reason,
+                )
+            candidate_skip_details.append(
+                f"{candidate_snapshot.label}: {liquidity_and_value_reason}"
+            )
+            continue
+
+        recent_approved_chain = _list_recent_approved_snapshot_chain(
+            store=source_approved_store,
+            snapshot=candidate_latest_approved_snapshot,
+            max_snapshot_age_seconds=settings.launch_ready_canary_max_snapshot_age_seconds,
+        )
+        automation_gate_reason = _build_approved_snapshot_automation_gate_reason(
+            snapshot=candidate_latest_approved_snapshot,
+            recent_chain=recent_approved_chain or [candidate_latest_approved_snapshot],
+            settings=settings,
+        )
+        if automation_gate_reason is not None:
+            if settings.stable_canary_launch_shadow_mode:
+                logging.getLogger("carryme.worker").info(
+                    "shadow launch gate blocked label=%s because %s",
+                    candidate_snapshot.label,
+                    automation_gate_reason,
+                )
+            candidate_skip_details.append(
+                f"{candidate_snapshot.label}: latest approved snapshot no longer "
+                f"satisfies automated launch gates: {automation_gate_reason}"
+            )
+            continue
+
+        if candidate_snapshot.launch_ready_snapshot_id is not None:
+            previous_launch = stable_launch_store.latest_for_snapshot(
+                candidate_snapshot.launch_ready_snapshot_id
+            )
+            if previous_launch is not None:
+                if previous_launch.status == "shadowed":
+                    if settings.stable_canary_launch_shadow_mode:
+                        candidate_skip_details.append(
+                            f"{candidate_snapshot.label}: launch-ready canary snapshot "
+                            "already evaluated in shadow mode by worker"
+                        )
+                        continue
+                    # Shadow mode is off but was previously on: allow a real launch now.
+                else:
+                    candidate_skip_details.append(
+                        f"{candidate_snapshot.label}: launch-ready canary snapshot already "
+                        f"launched by worker as paper trade {previous_launch.paper_trade_id}"
+                    )
+                    continue
+
+        risk_budget_reason = _build_stable_launch_risk_budget_reason(
+            settings=settings,
+            active_executions=active_executions_for_budget,
+            candidate=candidate_selected,
+        )
+        if risk_budget_reason is not None:
+            if settings.stable_canary_launch_shadow_mode:
+                logging.getLogger("carryme.worker").info(
+                    "shadow launch budget blocked label=%s because %s",
+                    candidate_snapshot.label,
+                    risk_budget_reason,
+                )
+            candidate_skip_details.append(
+                f"{candidate_snapshot.label}: {risk_budget_reason}"
+            )
+            continue
+
+        execution_preflight = _build_candidate_live_execution_preflight(
+            settings=runtime_settings,
+            candidate=candidate_selected,
+            label=candidate_snapshot.label,
+        )
+        if not execution_preflight.ready:
+            try:
+                launch_ready_store.delete_label(candidate_snapshot.label)
+            except Exception:
+                logging.getLogger("carryme.worker").exception(
+                    "failed to invalidate launch-ready snapshots for label=%s "
+                    "during stable launch preflight",
+                    candidate_snapshot.label,
+                )
+            candidate_skip_details.append(
+                f"{candidate_snapshot.label}: latest launch-ready snapshot no longer "
+                "satisfies live execution readiness: "
+                f"{'; '.join(execution_preflight.blocking_reasons)}"
+            )
+            continue
+
+        stability = candidate_stability
+        snapshot = candidate_snapshot
+        selected = candidate_selected
+        approval = candidate_approval
+        break
+
+    if stability is None or snapshot is None or selected is None or approval is None:
+        detail = "No stable launch-ready canary snapshot passed launch gating"
+        if candidate_skip_details:
+            detail = f"{detail}: {'; '.join(candidate_skip_details[:3])}"
+            if len(candidate_skip_details) > 3:
+                detail += f"; +{len(candidate_skip_details) - 3} more labels"
+        return StableCanaryLaunchSummary(
+            status="skipped",
+            database_path=settings.database_target,
+            detail=detail,
         )
 
     if settings.stable_canary_launch_shadow_mode:
@@ -3122,32 +3180,6 @@ async def launch_latest_stable_canary_once(
             launch_ready_snapshot_id=snapshot.launch_ready_snapshot_id,
             approved_snapshot_id=snapshot.approved_snapshot.snapshot_id,
             detail=hold_mode_blocker,
-        )
-
-    execution_preflight = _build_candidate_live_execution_preflight(
-        settings=runtime_settings,
-        candidate=selected,
-        label=snapshot.label,
-    )
-    if not execution_preflight.ready:
-        try:
-            launch_ready_store.delete_label(snapshot.label)
-        except Exception:
-            logging.getLogger("carryme.worker").exception(
-                "failed to invalidate launch-ready snapshots for label=%s "
-                "during stable launch preflight",
-                snapshot.label,
-            )
-        return StableCanaryLaunchSummary(
-            status="skipped",
-            database_path=settings.database_target,
-            label=snapshot.label,
-            launch_ready_snapshot_id=snapshot.launch_ready_snapshot_id,
-            approved_snapshot_id=snapshot.approved_snapshot.snapshot_id,
-            detail=(
-                "Latest launch-ready snapshot no longer satisfies live execution "
-                f"readiness: {'; '.join(execution_preflight.blocking_reasons)}"
-            ),
         )
 
     try:

--- a/packages/storage/src/carryme_storage/launch_ready_canaries.py
+++ b/packages/storage/src/carryme_storage/launch_ready_canaries.py
@@ -43,6 +43,12 @@ class LaunchReadyCanaryStore:
             )
             connection.execute(
                 """
+                CREATE INDEX IF NOT EXISTS idx_launch_ready_canary_snapshots_captured_at_id
+                ON launch_ready_canary_snapshots(captured_at DESC, id DESC)
+                """
+            )
+            connection.execute(
+                """
                 CREATE INDEX IF NOT EXISTS idx_launch_ready_canary_snapshots_label
                 ON launch_ready_canary_snapshots(label)
                 """
@@ -131,30 +137,51 @@ class LaunchReadyCanaryStore:
         """Return recent distinct labels ordered by latest snapshot timestamp."""
 
         self.initialize()
-        with self.database.begin() as connection:
-            rows = connection.execute(
-                """
-                WITH ranked_snapshots AS (
-                    SELECT
-                        label,
-                        captured_at,
-                        id,
-                        ROW_NUMBER() OVER (
-                            PARTITION BY label
-                            ORDER BY captured_at DESC, id DESC
-                        ) AS row_number
-                    FROM launch_ready_canary_snapshots
-                )
-                SELECT label, captured_at AS latest_captured_at, id AS latest_id
-                FROM ranked_snapshots
-                WHERE row_number = 1
-                ORDER BY latest_captured_at DESC, latest_id DESC
-                LIMIT ?
-                """,
-                (limit,),
-            ).fetchall()
+        labels: list[str] = []
+        seen_labels: set[str] = set()
+        batch_size = max(limit * 4, 50)
+        cursor: tuple[str, int] | None = None
 
-        return [label for label, _, _ in rows]
+        with self.database.begin() as connection:
+            while len(labels) < limit:
+                if cursor is None:
+                    rows = connection.execute(
+                        """
+                        SELECT label, captured_at, id
+                        FROM launch_ready_canary_snapshots
+                        ORDER BY captured_at DESC, id DESC
+                        LIMIT ?
+                        """,
+                        (batch_size,),
+                    ).fetchall()
+                else:
+                    rows = connection.execute(
+                        """
+                        SELECT label, captured_at, id
+                        FROM launch_ready_canary_snapshots
+                        WHERE captured_at < ? OR (captured_at = ? AND id < ?)
+                        ORDER BY captured_at DESC, id DESC
+                        LIMIT ?
+                        """,
+                        (cursor[0], cursor[0], cursor[1], batch_size),
+                    ).fetchall()
+
+                if not rows:
+                    break
+
+                for label, _captured_at, _row_id in rows:
+                    if label in seen_labels:
+                        continue
+                    seen_labels.add(label)
+                    labels.append(label)
+                    if len(labels) >= limit:
+                        break
+
+                last_label, last_captured_at, last_row_id = rows[-1]
+                _ = last_label
+                cursor = (last_captured_at, last_row_id)
+
+        return labels
 
     def delete_label(self, label: str) -> int:
         """Delete all launch-ready canary snapshots for one label."""

--- a/packages/storage/src/carryme_storage/launch_ready_canaries.py
+++ b/packages/storage/src/carryme_storage/launch_ready_canaries.py
@@ -10,6 +10,8 @@ from carryme_models import LaunchReadyCanarySnapshot
 
 from carryme_storage.db import Database
 
+MAX_RECENT_LABEL_LIMIT = 250
+
 
 class LaunchReadyCanaryStore:
     """Persist and query launch-ready canary snapshots."""
@@ -137,13 +139,14 @@ class LaunchReadyCanaryStore:
         """Return recent distinct labels ordered by latest snapshot timestamp."""
 
         self.initialize()
+        bounded_limit = max(1, min(limit, MAX_RECENT_LABEL_LIMIT))
         labels: list[str] = []
         seen_labels: set[str] = set()
-        batch_size = max(limit * 4, 50)
+        batch_size = min(max(bounded_limit * 4, 50), MAX_RECENT_LABEL_LIMIT * 4)
         cursor: tuple[str, int] | None = None
 
         with self.database.begin() as connection:
-            while len(labels) < limit:
+            while len(labels) < bounded_limit:
                 if cursor is None:
                     rows = connection.execute(
                         """
@@ -174,7 +177,7 @@ class LaunchReadyCanaryStore:
                         continue
                     seen_labels.add(label)
                     labels.append(label)
-                    if len(labels) >= limit:
+                    if len(labels) >= bounded_limit:
                         break
 
                 last_label, last_captured_at, last_row_id = rows[-1]

--- a/packages/storage/src/carryme_storage/launch_ready_canaries.py
+++ b/packages/storage/src/carryme_storage/launch_ready_canaries.py
@@ -127,6 +127,24 @@ class LaunchReadyCanaryStore:
         snapshots = self.list_recent(limit=1, label=label)
         return snapshots[0] if snapshots else None
 
+    def list_recent_labels(self, *, limit: int = 50) -> list[str]:
+        """Return recent distinct labels ordered by latest snapshot timestamp."""
+
+        self.initialize()
+        with self.database.begin() as connection:
+            rows = connection.execute(
+                """
+                SELECT label, MAX(captured_at) AS latest_captured_at, MAX(id) AS latest_id
+                FROM launch_ready_canary_snapshots
+                GROUP BY label
+                ORDER BY latest_captured_at DESC, latest_id DESC
+                LIMIT ?
+                """,
+                (limit,),
+            ).fetchall()
+
+        return [label for label, _, _ in rows]
+
     def delete_label(self, label: str) -> int:
         """Delete all launch-ready canary snapshots for one label."""
 

--- a/packages/storage/src/carryme_storage/launch_ready_canaries.py
+++ b/packages/storage/src/carryme_storage/launch_ready_canaries.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import logging
 from pathlib import Path
 from typing import Any
 
@@ -10,7 +11,9 @@ from carryme_models import LaunchReadyCanarySnapshot
 
 from carryme_storage.db import Database
 
+logger = logging.getLogger(__name__)
 MAX_RECENT_LABEL_LIMIT = 250
+MAX_RECENT_LABEL_SCAN_ROWS = MAX_RECENT_LABEL_LIMIT * 20
 
 
 class LaunchReadyCanaryStore:
@@ -138,15 +141,20 @@ class LaunchReadyCanaryStore:
     def list_recent_labels(self, *, limit: int = 50) -> list[str]:
         """Return recent distinct labels ordered by latest snapshot timestamp."""
 
+        if limit < 1:
+            raise ValueError("limit must be at least 1")
+        if limit > MAX_RECENT_LABEL_LIMIT:
+            raise ValueError(f"limit must be at most {MAX_RECENT_LABEL_LIMIT}")
+
         self.initialize()
-        bounded_limit = max(1, min(limit, MAX_RECENT_LABEL_LIMIT))
         labels: list[str] = []
         seen_labels: set[str] = set()
-        batch_size = min(max(bounded_limit * 4, 50), MAX_RECENT_LABEL_LIMIT * 4)
+        batch_size = min(max(limit * 4, 50), MAX_RECENT_LABEL_LIMIT * 4)
         cursor: tuple[str, int] | None = None
+        scanned_rows = 0
 
         with self.database.begin() as connection:
-            while len(labels) < bounded_limit:
+            while len(labels) < limit and scanned_rows < MAX_RECENT_LABEL_SCAN_ROWS:
                 if cursor is None:
                     rows = connection.execute(
                         """
@@ -171,18 +179,29 @@ class LaunchReadyCanaryStore:
 
                 if not rows:
                     break
+                scanned_rows += len(rows)
 
                 for label, _captured_at, _row_id in rows:
                     if label in seen_labels:
                         continue
                     seen_labels.add(label)
                     labels.append(label)
-                    if len(labels) >= bounded_limit:
+                    if len(labels) >= limit:
                         break
 
                 last_label, last_captured_at, last_row_id = rows[-1]
                 _ = last_label
                 cursor = (last_captured_at, last_row_id)
+
+        if len(labels) < limit and scanned_rows >= MAX_RECENT_LABEL_SCAN_ROWS:
+            logger.warning(
+                "list_recent_labels scan capped before collecting requested labels: "
+                "requested_limit=%s collected_labels=%s scanned_rows=%s scan_row_cap=%s",
+                limit,
+                len(labels),
+                scanned_rows,
+                MAX_RECENT_LABEL_SCAN_ROWS,
+            )
 
         return labels
 

--- a/packages/storage/src/carryme_storage/launch_ready_canaries.py
+++ b/packages/storage/src/carryme_storage/launch_ready_canaries.py
@@ -134,9 +134,20 @@ class LaunchReadyCanaryStore:
         with self.database.begin() as connection:
             rows = connection.execute(
                 """
-                SELECT label, MAX(captured_at) AS latest_captured_at, MAX(id) AS latest_id
-                FROM launch_ready_canary_snapshots
-                GROUP BY label
+                WITH ranked_snapshots AS (
+                    SELECT
+                        label,
+                        captured_at,
+                        id,
+                        ROW_NUMBER() OVER (
+                            PARTITION BY label
+                            ORDER BY captured_at DESC, id DESC
+                        ) AS row_number
+                    FROM launch_ready_canary_snapshots
+                )
+                SELECT label, captured_at AS latest_captured_at, id AS latest_id
+                FROM ranked_snapshots
+                WHERE row_number = 1
                 ORDER BY latest_captured_at DESC, latest_id DESC
                 LIMIT ?
                 """,

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -2842,6 +2842,111 @@ def test_launch_ready_canary_store_lists_recent_labels_by_true_latest_row(
     ]
 
 
+def test_launch_ready_canary_store_list_recent_labels_paginates_duplicate_rows(
+    tmp_path: Path,
+) -> None:
+    approved_snapshot = ApprovedCanarySnapshot(
+        snapshot_id=7,
+        captured_at=datetime(2026, 3, 29, 14, 10, tzinfo=UTC),
+        label="arb_extended_paradex",
+        candidate=FundingUniverseCanaryCandidate(
+            opportunity=FundingUniverseOpportunity(
+                opportunity=FundingArbOpportunity(
+                    canonical_symbol="ARB-USD-PERP",
+                    long_venue="paradex",
+                    short_venue="extended",
+                    long_fee_profile="pro_fastfills",
+                    short_fee_profile="default",
+                    gross_daily_edge=0.004,
+                    entry_cost_rate=0.00045,
+                    round_trip_cost_rate=0.0009,
+                    one_day_net_edge_after_entry=0.00355,
+                    one_day_net_edge_after_round_trip=0.0031,
+                    break_even_days_entry=0.2,
+                    break_even_days_round_trip=0.3,
+                    capacity=CapacityEstimate(
+                        short_bid_notional=1400.0,
+                        long_ask_notional=900.0,
+                        max_entry_notional=900.0,
+                        limiting_venue="paradex",
+                    ),
+                ),
+                venue_markets={
+                    "extended": FundingUniverseVenueMarket(
+                        venue="extended",
+                        symbol="ARB-USD",
+                    ),
+                    "paradex": FundingUniverseVenueMarket(
+                        venue="paradex",
+                        symbol="ARB-USD-PERP",
+                    ),
+                },
+                deployable_notional=900.0,
+                estimated_one_day_pnl_after_round_trip=2.79,
+            ),
+            suggested_canary_notional=11.0,
+        ),
+        approval=RouteApprovalEntry(
+            updated_at=datetime(2026, 3, 29, 14, 9, tzinfo=UTC),
+            label="arb_extended_paradex",
+            canonical_symbol="ARB-USD-PERP",
+            short_venue="extended",
+            long_venue="paradex",
+            short_fee_profile="default",
+            long_fee_profile="pro_fastfills",
+            approved=True,
+            max_live_notional=11.0,
+            note="approved canary",
+        ),
+    )
+    store = LaunchReadyCanaryStore(tmp_path / "history.sqlite3")
+
+    def append(label: str, captured_at: datetime) -> None:
+        store.append(
+            LaunchReadyCanarySnapshot(
+                captured_at=captured_at,
+                label=label,
+                max_snapshot_age_seconds=300,
+                approved_snapshot=approved_snapshot.model_copy(update={"label": label}),
+                system_state=PaperTradeSystemState(
+                    paper_trade_id=0,
+                    label=label,
+                    ready=True,
+                    venues=[
+                        VenueSystemState(
+                            venue="extended",
+                            enabled=True,
+                            checked=False,
+                            healthy=True,
+                            status=None,
+                        ),
+                        VenueSystemState(
+                            venue="paradex",
+                            enabled=True,
+                            checked=True,
+                            healthy=True,
+                            status="ok",
+                        ),
+                    ],
+                    blocking_reasons=[],
+                ),
+            )
+        )
+
+    base_time = datetime(2026, 3, 29, 14, 11, tzinfo=UTC)
+    for offset in range(60):
+        append(
+            "arb_extended_paradex",
+            base_time - timedelta(seconds=offset),
+        )
+    append("bera_extended_paradex", base_time - timedelta(seconds=61))
+
+    assert store.list_recent_labels(limit=2) == [
+        "arb_extended_paradex",
+        "bera_extended_paradex",
+    ]
+
+
 def test_stable_canary_launch_store_appends_and_filters(tmp_path: Path) -> None:
     store = StableCanaryLaunchStore(tmp_path / "history.sqlite3")
     record = store.append(

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -66,6 +66,7 @@ from carryme_storage import (
     save_watchlist,
 )
 from carryme_storage.db import Database, normalize_database_url, redact_database_url
+from carryme_storage.launch_ready_canaries import MAX_RECENT_LABEL_LIMIT
 from carryme_storage.watchlist import _parse_watchlist_payload
 
 
@@ -2945,6 +2946,105 @@ def test_launch_ready_canary_store_list_recent_labels_paginates_duplicate_rows(
         "arb_extended_paradex",
         "bera_extended_paradex",
     ]
+
+
+def test_launch_ready_canary_store_list_recent_labels_enforces_hard_max(
+    tmp_path: Path,
+) -> None:
+    approved_snapshot = ApprovedCanarySnapshot(
+        snapshot_id=7,
+        captured_at=datetime(2026, 3, 29, 14, 10, tzinfo=UTC),
+        label="arb_extended_paradex",
+        candidate=FundingUniverseCanaryCandidate(
+            opportunity=FundingUniverseOpportunity(
+                opportunity=FundingArbOpportunity(
+                    canonical_symbol="ARB-USD-PERP",
+                    long_venue="paradex",
+                    short_venue="extended",
+                    long_fee_profile="pro_fastfills",
+                    short_fee_profile="default",
+                    gross_daily_edge=0.004,
+                    entry_cost_rate=0.00045,
+                    round_trip_cost_rate=0.0009,
+                    one_day_net_edge_after_entry=0.00355,
+                    one_day_net_edge_after_round_trip=0.0031,
+                    break_even_days_entry=0.2,
+                    break_even_days_round_trip=0.3,
+                    capacity=CapacityEstimate(
+                        short_bid_notional=1400.0,
+                        long_ask_notional=900.0,
+                        max_entry_notional=900.0,
+                        limiting_venue="paradex",
+                    ),
+                ),
+                venue_markets={
+                    "extended": FundingUniverseVenueMarket(
+                        venue="extended",
+                        symbol="ARB-USD",
+                    ),
+                    "paradex": FundingUniverseVenueMarket(
+                        venue="paradex",
+                        symbol="ARB-USD-PERP",
+                    ),
+                },
+                deployable_notional=900.0,
+                estimated_one_day_pnl_after_round_trip=2.79,
+            ),
+            suggested_canary_notional=11.0,
+        ),
+        approval=RouteApprovalEntry(
+            updated_at=datetime(2026, 3, 29, 14, 9, tzinfo=UTC),
+            label="arb_extended_paradex",
+            canonical_symbol="ARB-USD-PERP",
+            short_venue="extended",
+            long_venue="paradex",
+            short_fee_profile="default",
+            long_fee_profile="pro_fastfills",
+            approved=True,
+            max_live_notional=11.0,
+            note="approved canary",
+        ),
+    )
+    store = LaunchReadyCanaryStore(tmp_path / "history.sqlite3")
+
+    for index in range(MAX_RECENT_LABEL_LIMIT + 5):
+        label = f"label-{index:03d}"
+        store.append(
+            LaunchReadyCanarySnapshot(
+                captured_at=datetime(2026, 3, 29, 14, 11, tzinfo=UTC) - timedelta(seconds=index),
+                label=label,
+                max_snapshot_age_seconds=300,
+                approved_snapshot=approved_snapshot.model_copy(update={"label": label}),
+                system_state=PaperTradeSystemState(
+                    paper_trade_id=0,
+                    label=label,
+                    ready=True,
+                    venues=[
+                        VenueSystemState(
+                            venue="extended",
+                            enabled=True,
+                            checked=False,
+                            healthy=True,
+                            status=None,
+                        ),
+                        VenueSystemState(
+                            venue="paradex",
+                            enabled=True,
+                            checked=True,
+                            healthy=True,
+                            status="ok",
+                        ),
+                    ],
+                    blocking_reasons=[],
+                ),
+            )
+        )
+
+    labels = store.list_recent_labels(limit=MAX_RECENT_LABEL_LIMIT + 25)
+
+    assert len(labels) == MAX_RECENT_LABEL_LIMIT
+    assert labels[0] == "label-000"
+    assert labels[-1] == f"label-{MAX_RECENT_LABEL_LIMIT - 1:03d}"
 
 
 def test_stable_canary_launch_store_appends_and_filters(tmp_path: Path) -> None:

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -2741,6 +2741,107 @@ def test_launch_ready_canary_store_appends_and_lists_recent(tmp_path: Path) -> N
     assert latest.launch_ready_snapshot_id == results[0].launch_ready_snapshot_id
 
 
+def test_launch_ready_canary_store_lists_recent_labels_by_true_latest_row(
+    tmp_path: Path,
+) -> None:
+    approved_snapshot = ApprovedCanarySnapshot(
+        snapshot_id=7,
+        captured_at=datetime(2026, 3, 29, 14, 10, tzinfo=UTC),
+        label="arb_extended_paradex",
+        candidate=FundingUniverseCanaryCandidate(
+            opportunity=FundingUniverseOpportunity(
+                opportunity=FundingArbOpportunity(
+                    canonical_symbol="ARB-USD-PERP",
+                    long_venue="paradex",
+                    short_venue="extended",
+                    long_fee_profile="pro_fastfills",
+                    short_fee_profile="default",
+                    gross_daily_edge=0.004,
+                    entry_cost_rate=0.00045,
+                    round_trip_cost_rate=0.0009,
+                    one_day_net_edge_after_entry=0.00355,
+                    one_day_net_edge_after_round_trip=0.0031,
+                    break_even_days_entry=0.2,
+                    break_even_days_round_trip=0.3,
+                    capacity=CapacityEstimate(
+                        short_bid_notional=1400.0,
+                        long_ask_notional=900.0,
+                        max_entry_notional=900.0,
+                        limiting_venue="paradex",
+                    ),
+                ),
+                venue_markets={
+                    "extended": FundingUniverseVenueMarket(
+                        venue="extended",
+                        symbol="ARB-USD",
+                    ),
+                    "paradex": FundingUniverseVenueMarket(
+                        venue="paradex",
+                        symbol="ARB-USD-PERP",
+                    ),
+                },
+                deployable_notional=900.0,
+                estimated_one_day_pnl_after_round_trip=2.79,
+            ),
+            suggested_canary_notional=11.0,
+        ),
+        approval=RouteApprovalEntry(
+            updated_at=datetime(2026, 3, 29, 14, 9, tzinfo=UTC),
+            label="arb_extended_paradex",
+            canonical_symbol="ARB-USD-PERP",
+            short_venue="extended",
+            long_venue="paradex",
+            short_fee_profile="default",
+            long_fee_profile="pro_fastfills",
+            approved=True,
+            max_live_notional=11.0,
+            note="approved canary",
+        ),
+    )
+    store = LaunchReadyCanaryStore(tmp_path / "history.sqlite3")
+
+    def append(label: str, captured_at: datetime) -> None:
+        store.append(
+            LaunchReadyCanarySnapshot(
+                captured_at=captured_at,
+                label=label,
+                max_snapshot_age_seconds=300,
+                approved_snapshot=approved_snapshot.model_copy(update={"label": label}),
+                system_state=PaperTradeSystemState(
+                    paper_trade_id=0,
+                    label=label,
+                    ready=True,
+                    venues=[
+                        VenueSystemState(
+                            venue="extended",
+                            enabled=True,
+                            checked=False,
+                            healthy=True,
+                            status=None,
+                        ),
+                        VenueSystemState(
+                            venue="paradex",
+                            enabled=True,
+                            checked=True,
+                            healthy=True,
+                            status="ok",
+                        ),
+                    ],
+                    blocking_reasons=[],
+                ),
+            )
+        )
+
+    append("arb_extended_paradex", datetime(2026, 3, 29, 14, 11, tzinfo=UTC))
+    append("bera_extended_paradex", datetime(2026, 3, 29, 14, 11, tzinfo=UTC))
+    append("arb_extended_paradex", datetime(2026, 3, 29, 14, 10, tzinfo=UTC))
+
+    assert store.list_recent_labels(limit=2) == [
+        "bera_extended_paradex",
+        "arb_extended_paradex",
+    ]
+
+
 def test_stable_canary_launch_store_appends_and_filters(tmp_path: Path) -> None:
     store = StableCanaryLaunchStore(tmp_path / "history.sqlite3")
     record = store.append(

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -2948,7 +2948,7 @@ def test_launch_ready_canary_store_list_recent_labels_paginates_duplicate_rows(
     ]
 
 
-def test_launch_ready_canary_store_list_recent_labels_enforces_hard_max(
+def test_launch_ready_canary_store_list_recent_labels_rejects_invalid_limits(
     tmp_path: Path,
 ) -> None:
     approved_snapshot = ApprovedCanarySnapshot(
@@ -3040,11 +3040,11 @@ def test_launch_ready_canary_store_list_recent_labels_enforces_hard_max(
             )
         )
 
-    labels = store.list_recent_labels(limit=MAX_RECENT_LABEL_LIMIT + 25)
+    with pytest.raises(ValueError, match="limit must be at least 1"):
+        store.list_recent_labels(limit=0)
 
-    assert len(labels) == MAX_RECENT_LABEL_LIMIT
-    assert labels[0] == "label-000"
-    assert labels[-1] == f"label-{MAX_RECENT_LABEL_LIMIT - 1:03d}"
+    with pytest.raises(ValueError, match=f"limit must be at most {MAX_RECENT_LABEL_LIMIT}"):
+        store.list_recent_labels(limit=MAX_RECENT_LABEL_LIMIT + 25)
 
 
 def test_stable_canary_launch_store_appends_and_filters(tmp_path: Path) -> None:

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -121,10 +121,12 @@ from carryme_worker.poller import (
     UniverseScanLoopSummary,
     UniverseScanSummary,
     _build_api_settings_from_worker_settings,
+    _build_latest_launch_ready_stability,
     _build_open_hedge_auto_close_reason,
     _build_open_hedge_profit_protection_reason,
     _build_order_state_observers,
     _execution_requires_continued_monitoring,
+    _list_ranked_stable_launch_ready_stabilities,
     _maybe_auto_close_open_hedged_execution,
     _probe_candidate_system_state,
     cache_launch_ready_canaries_once,
@@ -4634,7 +4636,7 @@ def test_launch_latest_stable_canary_once_ranks_stable_labels_independently(
             )
         )
 
-    append_launch_ready_pair(
+    high_launch_ready = append_launch_ready_pair(
         high_snapshot,
         high_approved,
         datetime(2026, 4, 4, 10, 0, 0, tzinfo=UTC),
@@ -4739,7 +4741,307 @@ def test_launch_latest_stable_canary_once_ranks_stable_labels_independently(
     assert latest_low.label == "arb_extended_paradex"
     assert summary.status == "launched"
     assert summary.label == "bera_extended_paradex"
+    assert summary.launch_ready_snapshot_id == high_launch_ready.launch_ready_snapshot_id
+    assert summary.approved_snapshot_id == high_approved.snapshot_id
     assert captured_labels == ["bera_extended_paradex"]
+
+
+def test_launch_latest_stable_canary_once_falls_through_blocked_top_candidate(
+    tmp_path: Path,
+) -> None:
+    settings = WorkerSettings(
+        database_path=str(tmp_path / "history.sqlite3"),
+        stable_canary_launch_label_cooldown_seconds=300,
+    )
+    launch_ready_store = LaunchReadyCanaryStore(settings.database_path)
+    approved_store = ApprovedCanaryStore(settings.database_path)
+    route_approval_store = RouteApprovalStore(settings.database_path)
+    stable_launch_store = StableCanaryLaunchStore(settings.database_path)
+
+    top_approval, _, top_snapshot, _ = _build_stable_launch_test_snapshot(
+        label="bera_extended_paradex",
+        canonical_symbol="BERA-USD-PERP",
+        short_symbol="BERA-USD",
+        long_symbol="BERA-USD-PERP",
+        launch_ready_snapshot_id=40,
+        approved_snapshot_id=39,
+        suggested_canary_notional=20.0,
+        min_daily_volume=120_000.0,
+        deployable_notional=1000.0,
+        estimated_one_day_pnl_after_round_trip=3.0,
+    )
+    fallback_approval, fallback_candidate, fallback_snapshot, _ = (
+        _build_stable_launch_test_snapshot(
+            label="arb_extended_paradex",
+            launch_ready_snapshot_id=20,
+            approved_snapshot_id=19,
+        )
+    )
+    top_approved = approved_store.append(top_snapshot.approved_snapshot)
+    fallback_approved = approved_store.append(fallback_snapshot.approved_snapshot)
+    route_approval_store.upsert(top_approval)
+    route_approval_store.upsert(fallback_approval)
+
+    def append_launch_ready_pair(
+        snapshot: LaunchReadyCanarySnapshot,
+        approved_snapshot: ApprovedCanarySnapshot,
+        first_captured_at: datetime,
+        second_captured_at: datetime,
+    ) -> LaunchReadyCanarySnapshot:
+        launch_ready_store.append(
+            snapshot.model_copy(
+                update={
+                    "launch_ready_snapshot_id": None,
+                    "captured_at": first_captured_at,
+                    "approved_snapshot": approved_snapshot,
+                }
+            )
+        )
+        return launch_ready_store.append(
+            snapshot.model_copy(
+                update={
+                    "launch_ready_snapshot_id": None,
+                    "captured_at": second_captured_at,
+                    "approved_snapshot": approved_snapshot,
+                }
+            )
+        )
+
+    top_launch_ready = append_launch_ready_pair(
+        top_snapshot,
+        top_approved,
+        datetime(2026, 4, 4, 10, 0, 0, tzinfo=UTC),
+        datetime(2026, 4, 4, 10, 1, 0, tzinfo=UTC),
+    )
+    fallback_launch_ready = append_launch_ready_pair(
+        fallback_snapshot,
+        fallback_approved,
+        datetime(2026, 4, 4, 10, 0, 10, tzinfo=UTC),
+        datetime(2026, 4, 4, 10, 1, 10, tzinfo=UTC),
+    )
+    stable_launch_store.append(
+        StableCanaryLaunchRecord(
+            launched_at=datetime(2026, 4, 4, 10, 1, 5, tzinfo=UTC),
+            status="launched",
+            label=top_launch_ready.label,
+            launch_ready_snapshot_id=top_launch_ready.launch_ready_snapshot_id or 0,
+            approved_snapshot_id=top_approved.snapshot_id or 0,
+            paper_trade_id=7,
+            final_pair_state="closed",
+        )
+    )
+
+    captured_labels: list[str] = []
+
+    class StubLifecycleResult:
+        def __init__(self, label: str) -> None:
+            self.paper_trade = PaperTradeEntry(
+                entry_id=17,
+                created_at=datetime(2026, 4, 4, 10, 1, 20, tzinfo=UTC),
+                intent=FundingPairTradeIntent(
+                    label=label,
+                    canonical_symbol=fallback_candidate.opportunity.opportunity.canonical_symbol,
+                    source_recorded_at=datetime(2026, 4, 4, 10, 1, tzinfo=UTC),
+                    one_day_net_edge_after_entry=0.00355,
+                    break_even_days_entry=0.2,
+                    capacity_limit_notional=900.0,
+                    target_notional=20.0,
+                    capacity_fraction=20.0 / 900.0,
+                    max_target_notional=20.0,
+                    long_leg=TradeLegIntent(
+                        venue="paradex",
+                        symbol=fallback_candidate.opportunity.venue_markets["paradex"].symbol,
+                        fee_profile="pro_fastfills",
+                        side="buy",
+                        target_notional=20.0,
+                    ),
+                    short_leg=TradeLegIntent(
+                        venue="extended",
+                        symbol=fallback_candidate.opportunity.venue_markets["extended"].symbol,
+                        fee_profile="default",
+                        side="sell",
+                        target_notional=20.0,
+                    ),
+                ),
+                note="worker launch",
+            )
+            self.final_pair_status = ExecutionPairStatus(
+                execution_entry_id=31,
+                paper_trade_id=17,
+                preview_hash="preview",
+                derived_state="closed",
+                recommended_action="no_action",
+                order_state=ExecutionOrderState(
+                    execution_entry_id=31,
+                    paper_trade_id=17,
+                    preview_hash="preview",
+                    legs=[],
+                    notes=[],
+                ),
+                reconciliation=ExecutionReconciliation(
+                    execution_entry_id=31,
+                    paper_trade_id=17,
+                    preview_hash="preview",
+                    status="accepted",
+                    recommended_action="no_action",
+                    matched_all_leg_symbols=True,
+                    venues=[],
+                    notes=[],
+                ),
+                notes=[],
+            )
+
+    async def run_stub_lifecycle(**kwargs: object) -> StubLifecycleResult:
+        approval = cast(RouteApprovalEntry, kwargs["approval"])
+        captured_labels.append(approval.label)
+        return StubLifecycleResult(approval.label)
+
+    api_settings = ApiSettings(
+        database_path=settings.database_path,
+        watchlist_path=settings.watchlist_path,
+        environment=settings.environment,
+        extended_live_enabled=True,
+        extended_api_key="extended-key",
+        extended_stark_private_key="extended-secret",
+        paradex_live_enabled=True,
+        paradex_account_address="0x123",
+        paradex_private_key="0x456",
+    )
+    with pytest.MonkeyPatch.context() as monkeypatch:
+        monkeypatch.setattr(
+            "carryme_worker.poller._run_guarded_canary_lifecycle",
+            run_stub_lifecycle,
+        )
+        summary = asyncio.run(
+            launch_latest_stable_canary_once(
+                settings,
+                api_settings=api_settings,
+                launch_store=stable_launch_store,
+                approved_store=approved_store,
+                now=datetime(2026, 4, 4, 10, 1, 20, tzinfo=UTC),
+            )
+        )
+
+    assert summary.status == "launched"
+    assert summary.label == fallback_launch_ready.label
+    assert summary.launch_ready_snapshot_id == fallback_launch_ready.launch_ready_snapshot_id
+    assert summary.approved_snapshot_id == fallback_approved.snapshot_id
+    assert captured_labels == [fallback_approval.label]
+
+
+def test_list_ranked_stable_launch_ready_stabilities_uses_distinct_label_scan_limit(
+    tmp_path: Path,
+) -> None:
+    settings = WorkerSettings(database_path=str(tmp_path / "history.sqlite3"))
+    launch_ready_store = LaunchReadyCanaryStore(settings.database_path)
+    approved_store = ApprovedCanaryStore(settings.database_path)
+    _, _, first_snapshot, _ = _build_stable_launch_test_snapshot(
+        label="bera_extended_paradex",
+        canonical_symbol="BERA-USD-PERP",
+        short_symbol="BERA-USD",
+        long_symbol="BERA-USD-PERP",
+        launch_ready_snapshot_id=41,
+        approved_snapshot_id=40,
+    )
+    _, _, second_snapshot, _ = _build_stable_launch_test_snapshot(
+        label="arb_extended_paradex",
+        launch_ready_snapshot_id=21,
+        approved_snapshot_id=20,
+    )
+    first_approved = approved_store.append(first_snapshot.approved_snapshot)
+    second_approved = approved_store.append(second_snapshot.approved_snapshot)
+
+    def append_snapshot(
+        snapshot: LaunchReadyCanarySnapshot,
+        approved_snapshot: ApprovedCanarySnapshot,
+        captured_at: datetime,
+    ) -> None:
+        launch_ready_store.append(
+            snapshot.model_copy(
+                update={
+                    "launch_ready_snapshot_id": None,
+                    "captured_at": captured_at,
+                    "approved_snapshot": approved_snapshot,
+                }
+            )
+        )
+
+    append_snapshot(first_snapshot, first_approved, datetime(2026, 4, 4, 10, 1, 40, tzinfo=UTC))
+    append_snapshot(first_snapshot, first_approved, datetime(2026, 4, 4, 10, 1, 20, tzinfo=UTC))
+    append_snapshot(first_snapshot, first_approved, datetime(2026, 4, 4, 10, 1, 0, tzinfo=UTC))
+    append_snapshot(second_snapshot, second_approved, datetime(2026, 4, 4, 10, 0, 50, tzinfo=UTC))
+    append_snapshot(second_snapshot, second_approved, datetime(2026, 4, 4, 10, 0, 20, tzinfo=UTC))
+
+    stabilities, detail = _list_ranked_stable_launch_ready_stabilities(
+        store=launch_ready_store,
+        max_snapshot_age_seconds=300,
+        min_snapshot_count=2,
+        min_stable_seconds=20.0,
+        now=datetime(2026, 4, 4, 10, 1, 50, tzinfo=UTC),
+        scan_limit=2,
+    )
+
+    assert detail is None
+    assert {stability.snapshot.label for stability in stabilities} == {
+        "bera_extended_paradex",
+        "arb_extended_paradex",
+    }
+
+
+def test_build_latest_launch_ready_stability_handles_empty_snapshot_chain() -> None:
+    class EmptyChainStore:
+        def list_recent(
+            self,
+            *,
+            limit: int = 50,
+            label: str | None = None,
+        ) -> list[LaunchReadyCanarySnapshot]:
+            _ = limit, label
+            return []
+
+    stability = _build_latest_launch_ready_stability(
+        store=cast(Any, EmptyChainStore()),
+        label="arb_extended_paradex",
+        max_snapshot_age_seconds=300,
+        min_snapshot_count=2,
+        min_stable_seconds=20.0,
+        now=datetime(2026, 4, 4, 10, 1, 50, tzinfo=UTC),
+    )
+
+    assert stability is None
+
+
+def test_list_ranked_stable_launch_ready_stabilities_reports_failure_detail_when_none_stable(
+    tmp_path: Path,
+) -> None:
+    settings = WorkerSettings(database_path=str(tmp_path / "history.sqlite3"))
+    launch_ready_store = LaunchReadyCanaryStore(settings.database_path)
+    approved_store = ApprovedCanaryStore(settings.database_path)
+    _, _, snapshot, _ = _build_stable_launch_test_snapshot(label="arb_extended_paradex")
+    approved_snapshot = approved_store.append(snapshot.approved_snapshot)
+    launch_ready_store.append(
+        snapshot.model_copy(
+            update={
+                "launch_ready_snapshot_id": None,
+                "captured_at": datetime(2026, 4, 4, 9, 50, 0, tzinfo=UTC),
+                "approved_snapshot": approved_snapshot,
+            }
+        )
+    )
+
+    stabilities, detail = _list_ranked_stable_launch_ready_stabilities(
+        store=launch_ready_store,
+        max_snapshot_age_seconds=300,
+        min_snapshot_count=2,
+        min_stable_seconds=20.0,
+        now=datetime(2026, 4, 4, 10, 1, 50, tzinfo=UTC),
+        scan_limit=2,
+    )
+
+    assert stabilities == []
+    assert detail is not None
+    assert "arb_extended_paradex" in detail
+    assert "stale" in detail
 
 
 def test_launch_latest_stable_canary_once_skips_when_global_cooldown_active(

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -4649,35 +4649,43 @@ def test_launch_latest_stable_canary_once_ranks_stable_labels_independently(
         datetime(2026, 4, 4, 10, 1, 10, tzinfo=UTC),
     )
     captured_labels: list[str] = []
+    captured_leg_symbols: list[tuple[str, str]] = []
 
     class StubLifecycleResult:
-        def __init__(self, label: str) -> None:
+        def __init__(
+            self,
+            approval: RouteApprovalEntry,
+            candidate: FundingUniverseCanaryCandidate,
+        ) -> None:
+            route = candidate.opportunity.opportunity
+            venue_markets = candidate.opportunity.venue_markets
+            target_notional = candidate.suggested_canary_notional
             self.paper_trade = PaperTradeEntry(
                 entry_id=17,
                 created_at=datetime(2026, 4, 4, 10, 1, 20, tzinfo=UTC),
                 intent=FundingPairTradeIntent(
-                    label=label,
-                    canonical_symbol="BERA-USD-PERP",
+                    label=approval.label,
+                    canonical_symbol=approval.canonical_symbol,
                     source_recorded_at=datetime(2026, 4, 4, 10, 1, tzinfo=UTC),
                     one_day_net_edge_after_entry=0.00355,
                     break_even_days_entry=0.2,
                     capacity_limit_notional=900.0,
-                    target_notional=20.0,
-                    capacity_fraction=20.0 / 900.0,
-                    max_target_notional=20.0,
+                    target_notional=target_notional,
+                    capacity_fraction=target_notional / 900.0,
+                    max_target_notional=target_notional,
                     long_leg=TradeLegIntent(
-                        venue="paradex",
-                        symbol="BERA-USD-PERP",
-                        fee_profile="pro_fastfills",
+                        venue=approval.long_venue,
+                        symbol=venue_markets[route.long_venue].symbol,
+                        fee_profile=approval.long_fee_profile,
                         side="buy",
-                        target_notional=20.0,
+                        target_notional=target_notional,
                     ),
                     short_leg=TradeLegIntent(
-                        venue="extended",
-                        symbol="BERA-USD",
-                        fee_profile="default",
+                        venue=approval.short_venue,
+                        symbol=venue_markets[route.short_venue].symbol,
+                        fee_profile=approval.short_fee_profile,
                         side="sell",
-                        target_notional=20.0,
+                        target_notional=target_notional,
                     ),
                 ),
                 note="worker launch",
@@ -4710,8 +4718,16 @@ def test_launch_latest_stable_canary_once_ranks_stable_labels_independently(
 
     async def run_stub_lifecycle(**kwargs: object) -> StubLifecycleResult:
         approval = cast(RouteApprovalEntry, kwargs["approval"])
+        candidate = cast(FundingUniverseCanaryCandidate, kwargs["candidate"])
         captured_labels.append(approval.label)
-        return StubLifecycleResult(approval.label)
+        result = StubLifecycleResult(approval, candidate)
+        captured_leg_symbols.append(
+            (
+                result.paper_trade.intent.long_leg.symbol,
+                result.paper_trade.intent.short_leg.symbol,
+            )
+        )
+        return result
 
     api_settings = ApiSettings(
         database_path=settings.database_path,
@@ -4744,6 +4760,7 @@ def test_launch_latest_stable_canary_once_ranks_stable_labels_independently(
     assert summary.launch_ready_snapshot_id == high_launch_ready.launch_ready_snapshot_id
     assert summary.approved_snapshot_id == high_approved.snapshot_id
     assert captured_labels == ["bera_extended_paradex"]
+    assert captured_leg_symbols == [("BERA-USD-PERP", "BERA-USD")]
 
 
 def test_launch_latest_stable_canary_once_falls_through_blocked_top_candidate(
@@ -4988,6 +5005,107 @@ def test_list_ranked_stable_launch_ready_stabilities_uses_distinct_label_scan_li
     }
 
 
+def test_launch_latest_stable_canary_once_honors_candidate_scan_limit(
+    tmp_path: Path,
+) -> None:
+    settings = WorkerSettings(
+        database_path=str(tmp_path / "history.sqlite3"),
+        stable_canary_launch_label_cooldown_seconds=300,
+        stable_canary_launch_candidate_scan_limit=1,
+    )
+    launch_ready_store = LaunchReadyCanaryStore(settings.database_path)
+    approved_store = ApprovedCanaryStore(settings.database_path)
+    route_approval_store = RouteApprovalStore(settings.database_path)
+    stable_launch_store = StableCanaryLaunchStore(settings.database_path)
+
+    top_approval, _, top_snapshot, _ = _build_stable_launch_test_snapshot(
+        label="bera_extended_paradex",
+        canonical_symbol="BERA-USD-PERP",
+        short_symbol="BERA-USD",
+        long_symbol="BERA-USD-PERP",
+        launch_ready_snapshot_id=40,
+        approved_snapshot_id=39,
+        suggested_canary_notional=20.0,
+        estimated_one_day_pnl_after_round_trip=3.0,
+    )
+    fallback_approval, _, fallback_snapshot, _ = _build_stable_launch_test_snapshot(
+        label="arb_extended_paradex",
+        launch_ready_snapshot_id=20,
+        approved_snapshot_id=19,
+        estimated_one_day_pnl_after_round_trip=1.0,
+    )
+    top_approved = approved_store.append(top_snapshot.approved_snapshot)
+    fallback_approved = approved_store.append(fallback_snapshot.approved_snapshot)
+    route_approval_store.upsert(top_approval)
+    route_approval_store.upsert(fallback_approval)
+
+    def append_launch_ready_pair(
+        snapshot: LaunchReadyCanarySnapshot,
+        approved_snapshot: ApprovedCanarySnapshot,
+        first_captured_at: datetime,
+        second_captured_at: datetime,
+    ) -> LaunchReadyCanarySnapshot:
+        launch_ready_store.append(
+            snapshot.model_copy(
+                update={
+                    "launch_ready_snapshot_id": None,
+                    "captured_at": first_captured_at,
+                    "approved_snapshot": approved_snapshot,
+                }
+            )
+        )
+        return launch_ready_store.append(
+            snapshot.model_copy(
+                update={
+                    "launch_ready_snapshot_id": None,
+                    "captured_at": second_captured_at,
+                    "approved_snapshot": approved_snapshot,
+                }
+            )
+        )
+
+    top_launch_ready = append_launch_ready_pair(
+        top_snapshot,
+        top_approved,
+        datetime(2026, 4, 4, 10, 0, 0, tzinfo=UTC),
+        datetime(2026, 4, 4, 10, 1, 0, tzinfo=UTC),
+    )
+    append_launch_ready_pair(
+        fallback_snapshot,
+        fallback_approved,
+        datetime(2026, 4, 4, 10, 0, 10, tzinfo=UTC),
+        datetime(2026, 4, 4, 10, 0, 50, tzinfo=UTC),
+    )
+    stable_launch_store.append(
+        StableCanaryLaunchRecord(
+            launched_at=datetime(2026, 4, 4, 10, 0, 30, tzinfo=UTC),
+            status="launched",
+            label=top_launch_ready.label,
+            launch_ready_snapshot_id=top_launch_ready.launch_ready_snapshot_id or 0,
+            approved_snapshot_id=top_approved.snapshot_id or 0,
+            paper_trade_id=77,
+            final_pair_state="closed",
+        )
+    )
+
+    summary = asyncio.run(
+        launch_latest_stable_canary_once(
+            settings,
+            launch_store=stable_launch_store,
+            approved_store=approved_store,
+            now=datetime(2026, 4, 4, 10, 1, 20, tzinfo=UTC),
+        )
+    )
+
+    assert summary.status == "skipped"
+    assert summary.label == "bera_extended_paradex"
+    assert summary.launch_ready_snapshot_id == top_launch_ready.launch_ready_snapshot_id
+    assert summary.detail == (
+        "Stable launch label cooldown active: "
+        "label=bera_extended_paradex remaining_seconds=250"
+    )
+
+
 def test_build_latest_launch_ready_stability_handles_empty_snapshot_chain() -> None:
     class EmptyChainStore:
         def list_recent(
@@ -5042,6 +5160,104 @@ def test_list_ranked_stable_launch_ready_stabilities_reports_failure_detail_when
     assert detail is not None
     assert "arb_extended_paradex" in detail
     assert "stale" in detail
+
+
+def test_list_ranked_stable_launch_ready_stabilities_reports_future_snapshot_detail(
+    tmp_path: Path,
+) -> None:
+    settings = WorkerSettings(database_path=str(tmp_path / "history.sqlite3"))
+    launch_ready_store = LaunchReadyCanaryStore(settings.database_path)
+    approved_store = ApprovedCanaryStore(settings.database_path)
+    _, _, snapshot, _ = _build_stable_launch_test_snapshot(label="arb_extended_paradex")
+    approved_snapshot = approved_store.append(snapshot.approved_snapshot)
+    launch_ready_store.append(
+        snapshot.model_copy(
+            update={
+                "launch_ready_snapshot_id": None,
+                "captured_at": datetime(2026, 4, 4, 10, 2, 0, tzinfo=UTC),
+                "approved_snapshot": approved_snapshot,
+            }
+        )
+    )
+
+    stabilities, detail = _list_ranked_stable_launch_ready_stabilities(
+        store=launch_ready_store,
+        max_snapshot_age_seconds=300,
+        min_snapshot_count=2,
+        min_stable_seconds=20.0,
+        now=datetime(2026, 4, 4, 10, 1, 50, tzinfo=UTC),
+        scan_limit=2,
+    )
+
+    assert stabilities == []
+    assert detail is not None
+    assert "future" in detail
+
+
+def test_launch_latest_stable_canary_once_skips_when_selected_snapshot_lacks_revalidated_stability(
+    tmp_path: Path,
+) -> None:
+    settings = WorkerSettings(database_path=str(tmp_path / "history.sqlite3"))
+    launch_ready_store = LaunchReadyCanaryStore(settings.database_path)
+    approved_store = ApprovedCanaryStore(settings.database_path)
+    route_approval_store = RouteApprovalStore(settings.database_path)
+    approval, candidate, snapshot, _ = _build_stable_launch_test_snapshot(
+        label="arb_extended_paradex",
+        launch_ready_snapshot_id=9,
+        approved_snapshot_id=8,
+    )
+    approved_snapshot = approved_store.append(snapshot.approved_snapshot)
+    route_approval_store.upsert(approval)
+    stable_snapshot = launch_ready_store.append(
+        snapshot.model_copy(
+            update={
+                "launch_ready_snapshot_id": None,
+                "captured_at": datetime(2026, 4, 4, 10, 0, 30, tzinfo=UTC),
+                "approved_snapshot": approved_snapshot,
+            }
+        )
+    )
+    launch_ready_store.append(
+        snapshot.model_copy(
+            update={
+                "launch_ready_snapshot_id": None,
+                "captured_at": datetime(2026, 4, 4, 10, 1, 0, tzinfo=UTC),
+                "approved_snapshot": approved_snapshot,
+            }
+        )
+    )
+    selected_snapshot = stable_snapshot.model_copy(
+        update={
+            "launch_ready_snapshot_id": 999,
+            "captured_at": datetime(2026, 4, 4, 10, 1, 20, tzinfo=UTC),
+        }
+    )
+
+    with pytest.MonkeyPatch.context() as monkeypatch:
+        monkeypatch.setattr(
+            "carryme_worker.poller._select_latest_launch_ready_canary_snapshot",
+            lambda **_: (selected_snapshot, candidate, approval),
+        )
+        monkeypatch.setattr(
+            "carryme_worker.poller._run_guarded_canary_lifecycle",
+            lambda **_: (_ for _ in ()).throw(
+                AssertionError("launch should skip before lifecycle when stability changed")
+            ),
+        )
+        summary = asyncio.run(
+            launch_latest_stable_canary_once(
+                settings,
+                approved_store=approved_store,
+                now=datetime(2026, 4, 4, 10, 1, 40, tzinfo=UTC),
+            )
+        )
+
+    assert summary.status == "skipped"
+    assert summary.label == "arb_extended_paradex"
+    assert summary.launch_ready_snapshot_id == 999
+    assert summary.detail == (
+        "Launch-ready canary snapshot changed before stability could be revalidated"
+    )
 
 
 def test_launch_latest_stable_canary_once_skips_when_global_cooldown_active(

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -236,6 +236,10 @@ def _clear_worker_env(monkeypatch: pytest.MonkeyPatch) -> None:
         raising=False,
     )
     monkeypatch.delenv(
+        "CARRYME_WORKER_STABLE_CANARY_LAUNCH_CANDIDATE_SCAN_LIMIT",
+        raising=False,
+    )
+    monkeypatch.delenv(
         "CARRYME_WORKER_STABLE_CANARY_LAUNCH_MAX_TOTAL_LIVE_NOTIONAL",
         raising=False,
     )
@@ -322,6 +326,7 @@ def test_worker_defaults(monkeypatch: pytest.MonkeyPatch) -> None:
     assert settings.execution_observation_max_backoff_seconds == 60
     assert settings.stable_canary_launch_max_active_live_executions == 0
     assert settings.stable_canary_launch_active_execution_limit == 20
+    assert settings.stable_canary_launch_candidate_scan_limit == 100
     assert settings.stable_canary_launch_max_total_live_notional is None
     assert settings.stable_canary_launch_max_live_notional_per_venue is None
     assert settings.stable_canary_launch_recent_closed_trade_limit == 10
@@ -4453,6 +4458,9 @@ def test_cache_launch_ready_canaries_once_emits_stable_launch_ready_available_al
 def _build_stable_launch_test_snapshot(
     *,
     label: str,
+    canonical_symbol: str = "ARB-USD-PERP",
+    short_symbol: str = "ARB-USD",
+    long_symbol: str = "ARB-USD-PERP",
     launch_ready_snapshot_id: int = 19,
     approved_snapshot_id: int = 18,
     suggested_canary_notional: float = 20.0,
@@ -4470,7 +4478,7 @@ def _build_stable_launch_test_snapshot(
     approval = RouteApprovalEntry(
         updated_at=datetime(2026, 4, 4, 10, 0, tzinfo=UTC),
         label=label,
-        canonical_symbol="ARB-USD-PERP",
+        canonical_symbol=canonical_symbol,
         short_venue="extended",
         long_venue="paradex",
         short_fee_profile="default",
@@ -4482,7 +4490,7 @@ def _build_stable_launch_test_snapshot(
     candidate = FundingUniverseCanaryCandidate(
         opportunity=FundingUniverseOpportunity(
             opportunity=FundingArbOpportunity(
-                canonical_symbol="ARB-USD-PERP",
+                canonical_symbol=canonical_symbol,
                 long_venue="paradex",
                 short_venue="extended",
                 long_fee_profile="pro_fastfills",
@@ -4502,10 +4510,10 @@ def _build_stable_launch_test_snapshot(
                 ),
             ),
             venue_markets={
-                "extended": FundingUniverseVenueMarket(venue="extended", symbol="ARB-USD"),
+                "extended": FundingUniverseVenueMarket(venue="extended", symbol=short_symbol),
                 "paradex": FundingUniverseVenueMarket(
                     venue="paradex",
-                    symbol="ARB-USD-PERP",
+                    symbol=long_symbol,
                 ),
             },
             min_daily_volume=min_daily_volume,
@@ -4568,18 +4576,170 @@ def test_launch_latest_stable_canary_once_skips_when_no_stable_snapshot(
 ) -> None:
     settings = WorkerSettings(database_path=str(tmp_path / "history.sqlite3"))
 
-    with pytest.MonkeyPatch.context() as monkeypatch:
-        monkeypatch.setattr(
-            "carryme_worker.poller._build_launch_ready_canary_stability",
-            lambda **_: (_ for _ in ()).throw(
-                HTTPException(status_code=404, detail="No launch-ready canary snapshot found")
-            ),
-        )
-        summary = asyncio.run(launch_latest_stable_canary_once(settings))
+    summary = asyncio.run(launch_latest_stable_canary_once(settings))
 
     assert summary.status == "skipped"
     assert summary.detail == "No launch-ready canary snapshot found"
     assert summary.paper_trade_id is None
+
+
+def test_launch_latest_stable_canary_once_ranks_stable_labels_independently(
+    tmp_path: Path,
+) -> None:
+    settings = WorkerSettings(database_path=str(tmp_path / "history.sqlite3"))
+    approved_store = ApprovedCanaryStore(settings.database_path)
+    launch_ready_store = LaunchReadyCanaryStore(settings.database_path)
+    route_approval_store = RouteApprovalStore(settings.database_path)
+    low_approval, _, low_snapshot, _ = _build_stable_launch_test_snapshot(
+        label="arb_extended_paradex",
+        canonical_symbol="ARB-USD-PERP",
+        short_symbol="ARB-USD",
+        long_symbol="ARB-USD-PERP",
+        estimated_one_day_pnl_after_round_trip=0.5,
+    )
+    high_approval, _, high_snapshot, _ = _build_stable_launch_test_snapshot(
+        label="bera_extended_paradex",
+        canonical_symbol="BERA-USD-PERP",
+        short_symbol="BERA-USD",
+        long_symbol="BERA-USD-PERP",
+        estimated_one_day_pnl_after_round_trip=3.0,
+    )
+    low_approved = approved_store.append(low_snapshot.approved_snapshot)
+    high_approved = approved_store.append(high_snapshot.approved_snapshot)
+    route_approval_store.upsert(low_approval)
+    route_approval_store.upsert(high_approval)
+
+    def append_launch_ready_pair(
+        snapshot: LaunchReadyCanarySnapshot,
+        approved_snapshot: ApprovedCanarySnapshot,
+        first_captured_at: datetime,
+        second_captured_at: datetime,
+    ) -> LaunchReadyCanarySnapshot:
+        launch_ready_store.append(
+            snapshot.model_copy(
+                update={
+                    "launch_ready_snapshot_id": None,
+                    "captured_at": first_captured_at,
+                    "approved_snapshot": approved_snapshot,
+                }
+            )
+        )
+        return launch_ready_store.append(
+            snapshot.model_copy(
+                update={
+                    "launch_ready_snapshot_id": None,
+                    "captured_at": second_captured_at,
+                    "approved_snapshot": approved_snapshot,
+                }
+            )
+        )
+
+    append_launch_ready_pair(
+        high_snapshot,
+        high_approved,
+        datetime(2026, 4, 4, 10, 0, 0, tzinfo=UTC),
+        datetime(2026, 4, 4, 10, 1, 0, tzinfo=UTC),
+    )
+    latest_low = append_launch_ready_pair(
+        low_snapshot,
+        low_approved,
+        datetime(2026, 4, 4, 10, 0, 10, tzinfo=UTC),
+        datetime(2026, 4, 4, 10, 1, 10, tzinfo=UTC),
+    )
+    captured_labels: list[str] = []
+
+    class StubLifecycleResult:
+        def __init__(self, label: str) -> None:
+            self.paper_trade = PaperTradeEntry(
+                entry_id=17,
+                created_at=datetime(2026, 4, 4, 10, 1, 20, tzinfo=UTC),
+                intent=FundingPairTradeIntent(
+                    label=label,
+                    canonical_symbol="BERA-USD-PERP",
+                    source_recorded_at=datetime(2026, 4, 4, 10, 1, tzinfo=UTC),
+                    one_day_net_edge_after_entry=0.00355,
+                    break_even_days_entry=0.2,
+                    capacity_limit_notional=900.0,
+                    target_notional=20.0,
+                    capacity_fraction=20.0 / 900.0,
+                    max_target_notional=20.0,
+                    long_leg=TradeLegIntent(
+                        venue="paradex",
+                        symbol="BERA-USD-PERP",
+                        fee_profile="pro_fastfills",
+                        side="buy",
+                        target_notional=20.0,
+                    ),
+                    short_leg=TradeLegIntent(
+                        venue="extended",
+                        symbol="BERA-USD",
+                        fee_profile="default",
+                        side="sell",
+                        target_notional=20.0,
+                    ),
+                ),
+                note="worker launch",
+            )
+            self.final_pair_status = ExecutionPairStatus(
+                execution_entry_id=31,
+                paper_trade_id=17,
+                preview_hash="preview",
+                derived_state="closed",
+                recommended_action="no_action",
+                order_state=ExecutionOrderState(
+                    execution_entry_id=31,
+                    paper_trade_id=17,
+                    preview_hash="preview",
+                    legs=[],
+                    notes=[],
+                ),
+                reconciliation=ExecutionReconciliation(
+                    execution_entry_id=31,
+                    paper_trade_id=17,
+                    preview_hash="preview",
+                    status="accepted",
+                    recommended_action="no_action",
+                    matched_all_leg_symbols=True,
+                    venues=[],
+                    notes=[],
+                ),
+                notes=[],
+            )
+
+    async def run_stub_lifecycle(**kwargs: object) -> StubLifecycleResult:
+        approval = cast(RouteApprovalEntry, kwargs["approval"])
+        captured_labels.append(approval.label)
+        return StubLifecycleResult(approval.label)
+
+    api_settings = ApiSettings(
+        database_path=settings.database_path,
+        watchlist_path=settings.watchlist_path,
+        environment=settings.environment,
+        extended_live_enabled=True,
+        extended_api_key="extended-key",
+        extended_stark_private_key="extended-secret",
+        paradex_live_enabled=True,
+        paradex_account_address="0x123",
+        paradex_private_key="0x456",
+    )
+    with pytest.MonkeyPatch.context() as monkeypatch:
+        monkeypatch.setattr(
+            "carryme_worker.poller._run_guarded_canary_lifecycle",
+            run_stub_lifecycle,
+        )
+        summary = asyncio.run(
+            launch_latest_stable_canary_once(
+                settings,
+                api_settings=api_settings,
+                approved_store=approved_store,
+                now=datetime(2026, 4, 4, 10, 1, 20, tzinfo=UTC),
+            )
+        )
+
+    assert latest_low.label == "arb_extended_paradex"
+    assert summary.status == "launched"
+    assert summary.label == "bera_extended_paradex"
+    assert captured_labels == ["bera_extended_paradex"]
 
 
 def test_launch_latest_stable_canary_once_skips_when_global_cooldown_active(
@@ -8874,7 +9034,24 @@ def test_launch_latest_stable_canary_once_rechecks_live_execution_readiness(
     persisted_snapshot = approved_store.append(snapshot.approved_snapshot)
     snapshot = snapshot.model_copy(update={"approved_snapshot": persisted_snapshot})
     stability = stability.model_copy(update={"snapshot": snapshot})
-    LaunchReadyCanaryStore(settings.database_path).append(snapshot)
+    launch_ready_store = LaunchReadyCanaryStore(settings.database_path)
+    launch_ready_store.append(
+        snapshot.model_copy(
+            update={
+                "launch_ready_snapshot_id": None,
+                "captured_at": datetime(2026, 3, 30, 10, 1, tzinfo=UTC),
+            }
+        )
+    )
+    snapshot = launch_ready_store.append(
+        snapshot.model_copy(
+            update={
+                "launch_ready_snapshot_id": None,
+                "captured_at": datetime(2026, 3, 30, 10, 2, tzinfo=UTC),
+            }
+        )
+    )
+    stability = stability.model_copy(update={"snapshot": snapshot})
 
     async def run_unexpected_lifecycle(**_: object) -> object:
         pytest.fail("stable launch should not submit when live execution credentials are missing")

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -69,6 +69,7 @@ from carryme_storage import (
     SystemStateAlertStore,
 )
 from carryme_storage.db import DatabaseConnection, redact_database_url
+from carryme_storage.launch_ready_canaries import MAX_RECENT_LABEL_LIMIT
 from carryme_worker.config import WorkerSettings
 from carryme_worker.main import (
     build_approved_canary_scan_loop_payload,
@@ -390,6 +391,19 @@ def test_worker_defaults(monkeypatch: pytest.MonkeyPatch) -> None:
     assert settings.database_path == "data/carryme.sqlite3"
     assert Path(settings.watchlist_path).is_file()
     assert settings.watchlist_path.endswith("config/watchlists/default.json")
+
+
+def test_worker_rejects_stable_canary_launch_candidate_scan_limit_above_max(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _clear_worker_env(monkeypatch)
+    monkeypatch.setenv(
+        "CARRYME_WORKER_STABLE_CANARY_LAUNCH_CANDIDATE_SCAN_LIMIT",
+        str(MAX_RECENT_LABEL_LIMIT + 1),
+    )
+
+    with pytest.raises(ValidationError, match="stable_canary_launch_candidate_scan_limit"):
+        WorkerSettings()
 
 
 def test_worker_env_can_disable_stable_launch_immediate_close(


### PR DESCRIPTION
## Summary
- make stable launch evaluate launch-ready stability per label instead of across globally interleaved snapshots
- rank stable launch-ready labels by route quality/PnL and freshness before selecting one to launch
- add a bounded `stable_canary_launch_candidate_scan_limit` worker setting for the candidate scan
- cover the regression where the latest global snapshot belongs to a lower-PnL label while a better label is independently stable

## Why
After approved scans cover multiple labels, launch-ready snapshots can interleave by label. The old stable-launch path asked for stability with `label=None`, so a different label immediately before the latest snapshot could make the latest route look unstable. That can skip valid opportunities or pick based on chronology instead of expected route quality.

## Safety
- does not widen approvals, live notional caps, or live credential gates
- still revalidates the selected latest snapshot, approval, freshness, system state, active live execution limits, cooldowns, and downstream launch gates
- keeps the legacy no-snapshot path behavior for existing operator/debug flows

## Validation
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run pytest -q tests/test_worker.py -k 'ranks_stable_labels_independently or worker_defaults or skips_when_no_stable_snapshot'`
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run pytest -q tests/test_worker.py -k 'launch_latest_stable_canary_once'`
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run ruff check .`
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run mypy src apps packages tests`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable limit for stable canary candidate scanning (default 100)
  * Improved stable-canary selection: evaluates and ranks multiple label candidates before launching
  * Recent-label listing to surface most-recent canary labels

* **Bug Fixes**
  * Launch runs now skip cleanly with an aggregated, per-candidate skip summary when no candidates pass

* **Tests**
  * Added and updated tests covering ranking, selection, validation, and defaults
<!-- end of auto-generated comment: release notes by coderabbit.ai -->