### PR TITLE
fix: reserve stable launch snapshots before live submit

### DIFF
--- a/packages/storage/src/carryme_storage/schema.py
+++ b/packages/storage/src/carryme_storage/schema.py
@@ -53,6 +53,7 @@ SCHEMA_TABLES: Sequence[str] = (
     "preview_confirmation_entries",
     "route_approval_entries",
     "stable_canary_launch_records",
+    "stable_canary_launch_reservations",
     "stable_launch_ready_alert_events",
     "system_state_alert_events",
 )

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -3206,6 +3206,38 @@ def test_stable_canary_launch_store_reserves_snapshot_launch_once(
     assert second_reserved is False
 
 
+def test_stable_canary_launch_store_prunes_expired_snapshot_reservations(
+    tmp_path: Path,
+) -> None:
+    store = StableCanaryLaunchStore(tmp_path / "history.sqlite3")
+    first_reserved_at = datetime(2026, 4, 4, 10, 0, tzinfo=UTC)
+    second_reserved_at = datetime(2026, 4, 4, 10, 5, tzinfo=UTC)
+
+    assert store.reserve_snapshot_launch(
+        launch_ready_snapshot_id=9,
+        label="arb_extended_paradex",
+        reserved_at=first_reserved_at,
+        retention_seconds=60,
+    )
+    assert store.reserve_snapshot_launch(
+        launch_ready_snapshot_id=10,
+        label="bera_extended_paradex",
+        reserved_at=second_reserved_at,
+        retention_seconds=60,
+    )
+
+    with store.database.begin() as connection:
+        rows = connection.execute(
+            """
+            SELECT launch_ready_snapshot_id
+            FROM stable_canary_launch_reservations
+            ORDER BY launch_ready_snapshot_id
+            """
+        ).fetchall()
+
+    assert [int(row[0]) for row in rows] == [10]
+
+
 def test_stable_canary_launch_store_reclaims_stale_snapshot_launch_reservation(
     tmp_path: Path,
 ) -> None:
@@ -3636,12 +3668,17 @@ def test_initialize_database_schema_accepts_sqlite_url(tmp_path: Path) -> None:
     initialize_database_schema(database_url)
 
     with Database(database_url).begin() as connection:
-        row = connection.fetchone(
+        history_row = connection.fetchone(
             "SELECT name FROM sqlite_master WHERE type = ? AND name = ?",
             ("table", "opportunity_history"),
         )
+        reservation_row = connection.fetchone(
+            "SELECT name FROM sqlite_master WHERE type = ? AND name = ?",
+            ("table", "stable_canary_launch_reservations"),
+        )
 
-    assert row is not None
+    assert history_row is not None
+    assert reservation_row is not None
 
 
 def test_history_store_accepts_sqlite_url(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- reserve each launch-ready snapshot before stable launch enters the live canary lifecycle
- add an idempotent `stable_canary_launch_reservations` table keyed by `launch_ready_snapshot_id`
- make the launcher fall through to the next ranked candidate when a snapshot is already reserved by another worker

## Why
During Render redeploys or accidental parallel stable-launch workers, two processes can pass the existing `latest_for_snapshot` check before either one appends the final launch record. That can duplicate a live hedge for the same launch-ready snapshot. This PR adds a pre-submit reservation so only one worker can launch a snapshot.

The reservation is intentionally fail-closed: once a worker reaches the live lifecycle boundary for a snapshot, later workers skip that snapshot and may use another ranked candidate instead.

## Validation
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run pytest -q tests/test_storage.py::test_stable_canary_launch_store_reserves_snapshot_launch_once tests/test_worker.py::test_launch_latest_stable_canary_once_falls_through_reserved_snapshot`
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run pytest -q tests/test_worker.py -k 'launch_latest_stable_canary_once'`
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run pytest -q tests/test_storage.py -k 'stable_canary_launch_store'`
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run ruff check .`
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run mypy src apps packages tests`
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run pytest` (`633 passed`)

## Stack
- Stacked on #221 / `codex/stable-launch-fall-through-candidates`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a stable canary launch reservation system with built-in expiration and automatic cleanup of expired records.

* **Tests**
  * Added test coverage to verify reservation expiration and pruning of outdated entries.
  * Enhanced database schema initialization tests to confirm proper setup of the new reservation storage system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->