### PR TITLE
fix: block stale unobserved live executions

### DIFF
--- a/apps/worker/src/carryme_worker/poller.py
+++ b/apps/worker/src/carryme_worker/poller.py
@@ -4464,6 +4464,7 @@ async def observe_live_executions_once(
         limit=settings.execution_observation_limit,
         now=timestamp,
         max_age_seconds=settings.execution_observation_max_age_seconds,
+        unobserved_requires_monitoring=True,
     )
 
     scanned_executions = 0

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -14490,7 +14490,7 @@ def test_observe_live_executions_once_skips_stale_live_entries(tmp_path: Path) -
     )
     execution_store = ExecutionJournalStore(settings.database_path)
     observation_store = ExecutionObservationStore(settings.database_path)
-    execution_store.append(
+    execution = execution_store.append(
         ExecutionJournalEntry(
             executed_at=datetime(2026, 3, 29, 12, 0, tzinfo=UTC),
             adapter="paired_live:extended_then_paradex",
@@ -14543,6 +14543,47 @@ def test_observe_live_executions_once_skips_stale_live_entries(tmp_path: Path) -
             ],
         )
     )
+    observation_store.append(
+        ExecutionObservationEntry(
+            observed_at=datetime(2026, 3, 29, 12, 30, tzinfo=UTC),
+            context="worker_execution_monitor",
+            execution_entry_id=execution.entry_id,
+            paper_trade_id=7,
+            preview_hash="stale-preview",
+            order_state=ExecutionOrderState(
+                execution_entry_id=execution.entry_id,
+                paper_trade_id=7,
+                preview_hash="stale-preview",
+                legs=[],
+                notes=[],
+            ),
+            pair_status=ExecutionPairStatus(
+                execution_entry_id=execution.entry_id,
+                paper_trade_id=7,
+                preview_hash="stale-preview",
+                derived_state="closed",
+                recommended_action="no_action",
+                order_state=ExecutionOrderState(
+                    execution_entry_id=execution.entry_id,
+                    paper_trade_id=7,
+                    preview_hash="stale-preview",
+                    legs=[],
+                    notes=[],
+                ),
+                reconciliation=ExecutionReconciliation(
+                    execution_entry_id=execution.entry_id,
+                    paper_trade_id=7,
+                    preview_hash="stale-preview",
+                    status="accepted",
+                    recommended_action="no_action",
+                    matched_all_leg_symbols=True,
+                    venues=[],
+                    notes=[],
+                ),
+                notes=[],
+            ),
+        )
+    )
 
     class StubAccountService:
         async def probe_paper_trade(
@@ -14570,7 +14611,120 @@ def test_observe_live_executions_once_skips_stale_live_entries(tmp_path: Path) -
     assert summary.scanned_executions == 0
     assert summary.observed_executions == 0
     assert summary.saved_observations == 0
-    assert observation_store.latest_for_paper_trade(7) is None
+    latest = observation_store.latest_for_paper_trade(7)
+    assert latest is not None
+    assert latest.preview_hash == "stale-preview"
+
+
+def test_observe_live_executions_once_backfills_stale_unobserved_live_entries(
+    tmp_path: Path,
+) -> None:
+    watchlist_path = tmp_path / "watchlist.json"
+    watchlist_path.write_text('{"pairs": []}')
+    settings = WorkerSettings(
+        watchlist_path=str(watchlist_path),
+        database_path=str(tmp_path / "history.sqlite3"),
+        execution_observation_limit=5,
+        execution_observation_max_age_seconds=600,
+    )
+    execution_store = ExecutionJournalStore(settings.database_path)
+    observation_store = ExecutionObservationStore(settings.database_path)
+    execution_store.append(
+        ExecutionJournalEntry(
+            executed_at=datetime(2026, 3, 29, 12, 0, tzinfo=UTC),
+            adapter="paired_live:extended_then_paradex",
+            mode="live",
+            status="submitted",
+            paper_trade_id=8,
+            preview_hash="stale-unobserved-preview",
+            confirmation_entry_id=10,
+            paper_trade=PaperTradeEntry(
+                entry_id=8,
+                created_at=datetime(2026, 3, 29, 12, 0, tzinfo=UTC),
+                note="stale unobserved live trade",
+                intent=FundingPairTradeIntent(
+                    label="stale_unobserved_pair",
+                    canonical_symbol="ARB-USD-PERP",
+                    source_recorded_at=datetime(2026, 3, 29, 11, 55, tzinfo=UTC),
+                    one_day_net_edge_after_entry=0.00055,
+                    break_even_days_entry=0.45,
+                    capacity_limit_notional=4500.0,
+                    target_notional=11.0,
+                    capacity_fraction=0.25,
+                    max_target_notional=11.0,
+                    long_leg=TradeLegIntent(
+                        venue="paradex",
+                        symbol="ARB-USD-PERP",
+                        fee_profile="pro",
+                        side="buy",
+                        target_notional=11.0,
+                    ),
+                    short_leg=TradeLegIntent(
+                        venue="extended",
+                        symbol="ARB-USD",
+                        fee_profile="default",
+                        side="sell",
+                        target_notional=11.0,
+                    ),
+                ),
+            ),
+            legs=[
+                ExecutionLegResult(
+                    venue="extended",
+                    symbol="ARB-USD",
+                    fee_profile="default",
+                    side="sell",
+                    target_notional=11.0,
+                    status="submitted",
+                    simulated=False,
+                    external_reference="ext-order-stale-unobserved",
+                )
+            ],
+        )
+    )
+
+    class StubAccountService:
+        async def probe_paper_trade(
+            self,
+            paper_trade: PaperTradeEntry,
+            config_map: object,
+        ) -> PaperTradeAccountPreflight:
+            _ = config_map
+            assert paper_trade.entry_id == 8
+            return PaperTradeAccountPreflight(
+                paper_trade_id=8,
+                label=paper_trade.intent.label,
+                ready=True,
+                venues=[],
+                blocking_reasons=[],
+            )
+
+    class StubOrderStateService:
+        async def observe_execution(self, entry: ExecutionJournalEntry) -> ExecutionOrderState:
+            assert entry.paper_trade_id == 8
+            return ExecutionOrderState(
+                execution_entry_id=entry.entry_id,
+                paper_trade_id=entry.paper_trade_id,
+                preview_hash=entry.preview_hash,
+                legs=[],
+                notes=[],
+            )
+
+    summary = asyncio.run(
+        observe_live_executions_once(
+            settings,
+            execution_store=execution_store,
+            observation_store=observation_store,
+            account_service=cast(AccountPreflightService, StubAccountService()),
+            order_state_service=cast(ExecutionOrderStateService, StubOrderStateService()),
+            now=datetime(2026, 3, 29, 13, 8, tzinfo=UTC),
+        )
+    )
+
+    assert summary.scanned_executions == 1
+    assert summary.observed_executions == 1
+    assert summary.saved_observations == 1
+    assert observation_store.latest_for_paper_trade(8) is not None
 
 
 def test_observe_live_executions_once_keeps_monitoring_stale_open_hedges(


### PR DESCRIPTION
## Summary
- keep stale unobserved live submissions blocking stable launch until they are monitored
- preserve execution-monitor behavior that skips old unobserved rows instead of probing them forever
- add a regression test proving stable launch does not age out unknown live state as safe

## Why
Stable launch must fail closed around live-money state. Before this change, a submitted/partial live execution with zero observations could age past `execution_observation_max_age_seconds` and stop blocking unattended launch. That could allow a second live hedge while the first order state is still unknown.

This PR makes the behavior explicit: stable-launch safety checks treat stale unobserved live executions as still monitor-required, while the execution monitor keeps its existing stale-row skip behavior.

## Validation
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run pytest -q tests/test_worker.py::test_launch_latest_stable_canary_once_blocks_stale_unobserved_live_trade tests/test_worker.py::test_observe_live_executions_once_skips_stale_live_entries tests/test_worker.py -k 'execution_requires_continued_monitoring'`
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run pytest -q tests/test_worker.py -k 'launch_latest_stable_canary_once or execution_requires_continued_monitoring or observe_live_executions_once_skips_stale_live_entries'`
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run ruff check .`
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run mypy src apps packages tests`
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run pytest` (`634 passed`)

## Stack
- Stacked on #222 / `codex/stable-launch-snapshot-reservations`
