### PR TITLE
fix: auto-close max-hold with stale route snapshot

### DIFF
--- a/apps/worker/src/carryme_worker/poller.py
+++ b/apps/worker/src/carryme_worker/poller.py
@@ -1621,6 +1621,28 @@ def _build_open_hedge_auto_close_reason(
     return None
 
 
+def _build_open_hedge_stale_snapshot_auto_close_reason(
+    *,
+    opened_at: datetime,
+    snapshot: ApprovedCanarySnapshot,
+    settings: WorkerSettings,
+    now: datetime,
+) -> str | None:
+    """Return the protective stale-snapshot close reason, if any."""
+
+    hold_window_hours = _hold_window_hours(snapshot)
+    hold_age_seconds = max(0.0, (now - opened_at).total_seconds())
+    hold_age_windows = hold_age_seconds / (hold_window_hours * 3600.0)
+    if hold_age_windows >= settings.execution_auto_pair_close_max_hold_windows:
+        return (
+            "hold age windows "
+            f"{hold_age_windows:.2f} reached maximum "
+            f"{settings.execution_auto_pair_close_max_hold_windows:.2f}"
+        )
+
+    return None
+
+
 def _approved_snapshot_is_fresh(
     *,
     snapshot: ApprovedCanarySnapshot,
@@ -1640,25 +1662,27 @@ async def _resolve_auto_close_snapshot(
     scanner: OpportunityUniverseService | None,
     logger: logging.Logger,
     now: datetime,
-) -> tuple[ApprovedCanarySnapshot | None, Literal["approved_snapshot", "live_revalidation"] | None]:
+) -> tuple[
+    ApprovedCanarySnapshot | None,
+    Literal["approved_snapshot", "live_revalidation", "stale_approved_snapshot"] | None,
+]:
     paper_trade = execution.paper_trade
     if paper_trade is None:
         return None, None
 
     latest_snapshot = approved_store.latest(label=paper_trade.intent.label)
-    if (
-        latest_snapshot is not None
-        and _approved_snapshot_matches_paper_trade(
-            snapshot=latest_snapshot,
-            paper_trade=paper_trade,
-        )
-        and _approved_snapshot_is_fresh(
+    stale_matching_snapshot: ApprovedCanarySnapshot | None = None
+    if latest_snapshot is not None and _approved_snapshot_matches_paper_trade(
+        snapshot=latest_snapshot,
+        paper_trade=paper_trade,
+    ):
+        if _approved_snapshot_is_fresh(
             snapshot=latest_snapshot,
             settings=settings,
             now=now,
-        )
-    ):
-        return latest_snapshot, "approved_snapshot"
+        ):
+            return latest_snapshot, "approved_snapshot"
+        stale_matching_snapshot = latest_snapshot
 
     fallback_reason = "no approved snapshot exists"
     if latest_snapshot is not None:
@@ -1735,6 +1759,13 @@ async def _resolve_auto_close_snapshot(
             paper_trade.entry_id,
             approval.label,
         )
+        if stale_matching_snapshot is not None:
+            logger.warning(
+                "auto-close falling back to stale approved snapshot for paper_trade_id=%s label=%s",
+                paper_trade.entry_id,
+                approval.label,
+            )
+            return stale_matching_snapshot, "stale_approved_snapshot"
         return None, None
     except (ConnectorError, UpstreamDataError, httpx.HTTPError, ValueError) as exc:
         logger.warning(
@@ -1743,9 +1774,26 @@ async def _resolve_auto_close_snapshot(
             approval.label,
             exc,
         )
+        if stale_matching_snapshot is not None:
+            logger.warning(
+                "auto-close falling back to stale approved snapshot for paper_trade_id=%s label=%s",
+                paper_trade.entry_id,
+                approval.label,
+            )
+            return stale_matching_snapshot, "stale_approved_snapshot"
         return None, None
 
     if live_candidate is None:
+        if stale_matching_snapshot is not None:
+            logger.debug(
+                (
+                    "live revalidation found no exact match for paper_trade_id=%s; "
+                    "falling back to stale approved snapshot because %s"
+                ),
+                paper_trade.entry_id,
+                fallback_reason,
+            )
+            return stale_matching_snapshot, "stale_approved_snapshot"
         logger.debug(
             (
                 "skipping auto-close for paper_trade_id=%s because %s and live "
@@ -1766,6 +1814,15 @@ async def _resolve_auto_close_snapshot(
         snapshot=live_snapshot,
         paper_trade=paper_trade,
     ):
+        if stale_matching_snapshot is not None:
+            logger.debug(
+                (
+                    "live revalidation returned a mismatched route for paper_trade_id=%s; "
+                    "falling back to stale approved snapshot"
+                ),
+                paper_trade.entry_id,
+            )
+            return stale_matching_snapshot, "stale_approved_snapshot"
         logger.debug(
             (
                 "skipping auto-close for paper_trade_id=%s because live route "
@@ -1987,13 +2044,21 @@ async def _maybe_auto_close_open_hedged_execution(
         attribution=latest_attribution,
     )
     if close_reason is None:
-        close_reason = _build_open_hedge_auto_close_reason(
-            paper_trade=paper_trade,
-            opened_at=execution.executed_at,
-            snapshot=latest_snapshot,
-            settings=settings,
-            now=now,
-        )
+        if snapshot_source == "stale_approved_snapshot":
+            close_reason = _build_open_hedge_stale_snapshot_auto_close_reason(
+                opened_at=execution.executed_at,
+                snapshot=latest_snapshot,
+                settings=settings,
+                now=now,
+            )
+        else:
+            close_reason = _build_open_hedge_auto_close_reason(
+                paper_trade=paper_trade,
+                opened_at=execution.executed_at,
+                snapshot=latest_snapshot,
+                settings=settings,
+                now=now,
+            )
     if close_reason is None:
         return None
 

--- a/apps/worker/src/carryme_worker/poller.py
+++ b/apps/worker/src/carryme_worker/poller.py
@@ -403,6 +403,7 @@ def _list_blocking_live_executions_for_stable_launch(
         limit=scan_limit,
         now=now,
         max_age_seconds=settings.execution_observation_max_age_seconds,
+        unobserved_requires_monitoring=True,
     )
     for execution in recent_live_executions:
         paper_trade_id = execution.paper_trade_id
@@ -4464,6 +4465,7 @@ async def observe_live_executions_once(
         limit=settings.execution_observation_limit,
         now=timestamp,
         max_age_seconds=settings.execution_observation_max_age_seconds,
+        unobserved_requires_monitoring=True,
     )
 
     scanned_executions = 0

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -14141,6 +14141,152 @@ def test_maybe_auto_close_open_hedged_execution_skips_non_hedged_pair_status(
     assert result is None
 
 
+def test_maybe_auto_close_open_hedged_execution_uses_stale_snapshot_for_max_hold(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    settings = WorkerSettings(
+        database_path=str(tmp_path / "history.sqlite3"),
+        execution_auto_pair_close_shadow_mode=True,
+        execution_auto_pair_close_max_snapshot_age_seconds=300,
+        execution_auto_pair_close_max_hold_windows=0.01,
+    )
+    approval_store = ApprovedCanaryStore(settings.database_path)
+    approval_store.append(
+        _build_auto_close_snapshot(
+            captured_at=datetime(2026, 4, 4, 8, 0, tzinfo=UTC),
+            round_trip_edge=0.0009,
+        )
+    )
+    execution = ExecutionJournalEntry(
+        executed_at=datetime(2026, 4, 4, 9, 0, tzinfo=UTC),
+        adapter="paired_live:extended_then_paradex",
+        mode="live",
+        status="submitted",
+        paper_trade_id=27,
+        preview_hash="stale-max-hold-preview",
+        confirmation_entry_id=27,
+        paper_trade=_build_auto_close_paper_trade(
+            entry_id=27,
+            created_at=datetime(2026, 4, 4, 8, 58, tzinfo=UTC),
+        ),
+        legs=[_build_auto_close_execution_leg()],
+    )
+
+    with pytest.MonkeyPatch.context() as monkeypatch:
+        async def missing_live_revalidation(
+            **_: object,
+        ) -> tuple[FundingUniverseCanaryCandidate | None, int]:
+            return None, 0
+
+        monkeypatch.setattr(
+            "carryme_worker.poller.scan_live_route_candidate_for_approval",
+            missing_live_revalidation,
+        )
+        monkeypatch.setattr(
+            "carryme_worker.poller._build_pair_close_context_for_paper_trade",
+            lambda **_: (_ for _ in ()).throw(
+                AssertionError("shadow mode should not build a close context")
+            ),
+        )
+        caplog.set_level(logging.INFO)
+        result = asyncio.run(
+            _maybe_auto_close_open_hedged_execution(
+                settings=settings,
+                execution=execution,
+                pair_status=_build_auto_close_pair_status(execution=execution),
+                approved_store=approval_store,
+                execution_store=ExecutionJournalStore(settings.database_path),
+                observation_store=ExecutionObservationStore(settings.database_path),
+                account_service=cast(AccountPreflightService, object()),
+                order_state_service=cast(ExecutionOrderStateService, object()),
+                approval_service=RouteApprovalService(
+                    store=RouteApprovalStore(settings.database_path)
+                ),
+                scanner=cast(Any, object()),
+                logger=logging.getLogger("carryme.worker"),
+                now=datetime(2026, 4, 4, 10, 1, tzinfo=UTC),
+            )
+        )
+
+    assert result is None
+    assert "shadow auto-close for paper_trade_id=27" in caplog.text
+    assert "hold age windows" in caplog.text
+    assert "source=stale_approved_snapshot" in caplog.text
+
+
+def test_maybe_auto_close_open_hedged_execution_does_not_use_stale_edge_decay(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    settings = WorkerSettings(
+        database_path=str(tmp_path / "history.sqlite3"),
+        execution_auto_pair_close_shadow_mode=True,
+        execution_auto_pair_close_max_snapshot_age_seconds=300,
+        execution_auto_pair_close_max_hold_windows=10.0,
+    )
+    approval_store = ApprovedCanaryStore(settings.database_path)
+    approval_store.append(
+        _build_auto_close_snapshot(
+            captured_at=datetime(2026, 4, 4, 8, 0, tzinfo=UTC),
+            round_trip_edge=-0.0001,
+        )
+    )
+    execution = ExecutionJournalEntry(
+        executed_at=datetime(2026, 4, 4, 9, 55, tzinfo=UTC),
+        adapter="paired_live:extended_then_paradex",
+        mode="live",
+        status="submitted",
+        paper_trade_id=28,
+        preview_hash="stale-edge-preview",
+        confirmation_entry_id=28,
+        paper_trade=_build_auto_close_paper_trade(
+            entry_id=28,
+            created_at=datetime(2026, 4, 4, 9, 54, tzinfo=UTC),
+        ),
+        legs=[_build_auto_close_execution_leg()],
+    )
+
+    with pytest.MonkeyPatch.context() as monkeypatch:
+        async def missing_live_revalidation(
+            **_: object,
+        ) -> tuple[FundingUniverseCanaryCandidate | None, int]:
+            return None, 0
+
+        monkeypatch.setattr(
+            "carryme_worker.poller.scan_live_route_candidate_for_approval",
+            missing_live_revalidation,
+        )
+        monkeypatch.setattr(
+            "carryme_worker.poller._build_pair_close_context_for_paper_trade",
+            lambda **_: (_ for _ in ()).throw(
+                AssertionError("stale edge data must not build a close context")
+            ),
+        )
+        caplog.set_level(logging.INFO)
+        result = asyncio.run(
+            _maybe_auto_close_open_hedged_execution(
+                settings=settings,
+                execution=execution,
+                pair_status=_build_auto_close_pair_status(execution=execution),
+                approved_store=approval_store,
+                execution_store=ExecutionJournalStore(settings.database_path),
+                observation_store=ExecutionObservationStore(settings.database_path),
+                account_service=cast(AccountPreflightService, object()),
+                order_state_service=cast(ExecutionOrderStateService, object()),
+                approval_service=RouteApprovalService(
+                    store=RouteApprovalStore(settings.database_path)
+                ),
+                scanner=cast(Any, object()),
+                logger=logging.getLogger("carryme.worker"),
+                now=datetime(2026, 4, 4, 10, 1, tzinfo=UTC),
+            )
+        )
+
+    assert result is None
+    assert "shadow auto-close for paper_trade_id=28" not in caplog.text
+
+
 def test_maybe_auto_close_open_hedged_execution_times_out(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -7332,6 +7332,56 @@ def test_launch_latest_stable_canary_once_skips_when_recent_live_trade_is_unobse
     )
 
 
+def test_launch_latest_stable_canary_once_skips_when_stale_live_trade_is_unobserved(
+    tmp_path: Path,
+) -> None:
+    settings = WorkerSettings(
+        database_path=str(tmp_path / "history.sqlite3"),
+        execution_observation_max_age_seconds=600,
+    )
+    execution_store = ExecutionJournalStore(settings.database_path)
+    execution_store.append(
+        ExecutionJournalEntry(
+            executed_at=datetime(2026, 4, 4, 10, 0, tzinfo=UTC),
+            adapter="paired_live:extended_then_paradex",
+            mode="live",
+            status="submitted",
+            paper_trade_id=33,
+            preview_hash="stale-unobserved-live-preview",
+            confirmation_entry_id=43,
+            paper_trade=_build_auto_close_paper_trade(
+                entry_id=33,
+                created_at=datetime(2026, 4, 4, 9, 58, tzinfo=UTC),
+                label="jup_extended_paradex",
+                canonical_symbol="JUP-USD-PERP",
+            ),
+            legs=[_build_auto_close_execution_leg()],
+        )
+    )
+
+    with pytest.MonkeyPatch.context() as monkeypatch:
+        monkeypatch.setattr(
+            "carryme_worker.poller._build_launch_ready_canary_stability",
+            lambda **_: (_ for _ in ()).throw(
+                AssertionError("stale unobserved live submissions must block launch")
+            ),
+        )
+        summary = asyncio.run(
+            launch_latest_stable_canary_once(
+                settings,
+                now=datetime(2026, 4, 4, 10, 20, 1, tzinfo=UTC),
+            )
+        )
+
+    assert summary.status == "skipped"
+    assert summary.detail == (
+        "Active live executions still require monitoring before unattended launch "
+        "(max_allowed=0, current=1): "
+        "paper_trade_id=33 label=jup_extended_paradex "
+        "state=pending_initial_monitoring"
+    )
+
+
 def test_launch_latest_stable_canary_once_counts_beyond_active_execution_scan_limit(
     tmp_path: Path,
 ) -> None:
@@ -14490,7 +14540,7 @@ def test_observe_live_executions_once_skips_stale_live_entries(tmp_path: Path) -
     )
     execution_store = ExecutionJournalStore(settings.database_path)
     observation_store = ExecutionObservationStore(settings.database_path)
-    execution_store.append(
+    execution = execution_store.append(
         ExecutionJournalEntry(
             executed_at=datetime(2026, 3, 29, 12, 0, tzinfo=UTC),
             adapter="paired_live:extended_then_paradex",
@@ -14543,6 +14593,47 @@ def test_observe_live_executions_once_skips_stale_live_entries(tmp_path: Path) -
             ],
         )
     )
+    observation_store.append(
+        ExecutionObservationEntry(
+            observed_at=datetime(2026, 3, 29, 12, 30, tzinfo=UTC),
+            context="worker_execution_monitor",
+            execution_entry_id=execution.entry_id,
+            paper_trade_id=7,
+            preview_hash="stale-preview",
+            order_state=ExecutionOrderState(
+                execution_entry_id=execution.entry_id,
+                paper_trade_id=7,
+                preview_hash="stale-preview",
+                legs=[],
+                notes=[],
+            ),
+            pair_status=ExecutionPairStatus(
+                execution_entry_id=execution.entry_id,
+                paper_trade_id=7,
+                preview_hash="stale-preview",
+                derived_state="closed",
+                recommended_action="no_action",
+                order_state=ExecutionOrderState(
+                    execution_entry_id=execution.entry_id,
+                    paper_trade_id=7,
+                    preview_hash="stale-preview",
+                    legs=[],
+                    notes=[],
+                ),
+                reconciliation=ExecutionReconciliation(
+                    execution_entry_id=execution.entry_id,
+                    paper_trade_id=7,
+                    preview_hash="stale-preview",
+                    status="accepted",
+                    recommended_action="no_action",
+                    matched_all_leg_symbols=True,
+                    venues=[],
+                    notes=[],
+                ),
+                notes=[],
+            ),
+        )
+    )
 
     class StubAccountService:
         async def probe_paper_trade(
@@ -14570,7 +14661,120 @@ def test_observe_live_executions_once_skips_stale_live_entries(tmp_path: Path) -
     assert summary.scanned_executions == 0
     assert summary.observed_executions == 0
     assert summary.saved_observations == 0
-    assert observation_store.latest_for_paper_trade(7) is None
+    latest = observation_store.latest_for_paper_trade(7)
+    assert latest is not None
+    assert latest.preview_hash == "stale-preview"
+
+
+def test_observe_live_executions_once_backfills_stale_unobserved_live_entries(
+    tmp_path: Path,
+) -> None:
+    watchlist_path = tmp_path / "watchlist.json"
+    watchlist_path.write_text('{"pairs": []}')
+    settings = WorkerSettings(
+        watchlist_path=str(watchlist_path),
+        database_path=str(tmp_path / "history.sqlite3"),
+        execution_observation_limit=5,
+        execution_observation_max_age_seconds=600,
+    )
+    execution_store = ExecutionJournalStore(settings.database_path)
+    observation_store = ExecutionObservationStore(settings.database_path)
+    execution_store.append(
+        ExecutionJournalEntry(
+            executed_at=datetime(2026, 3, 29, 12, 0, tzinfo=UTC),
+            adapter="paired_live:extended_then_paradex",
+            mode="live",
+            status="submitted",
+            paper_trade_id=8,
+            preview_hash="stale-unobserved-preview",
+            confirmation_entry_id=10,
+            paper_trade=PaperTradeEntry(
+                entry_id=8,
+                created_at=datetime(2026, 3, 29, 12, 0, tzinfo=UTC),
+                note="stale unobserved live trade",
+                intent=FundingPairTradeIntent(
+                    label="stale_unobserved_pair",
+                    canonical_symbol="ARB-USD-PERP",
+                    source_recorded_at=datetime(2026, 3, 29, 11, 55, tzinfo=UTC),
+                    one_day_net_edge_after_entry=0.00055,
+                    break_even_days_entry=0.45,
+                    capacity_limit_notional=4500.0,
+                    target_notional=11.0,
+                    capacity_fraction=0.25,
+                    max_target_notional=11.0,
+                    long_leg=TradeLegIntent(
+                        venue="paradex",
+                        symbol="ARB-USD-PERP",
+                        fee_profile="pro",
+                        side="buy",
+                        target_notional=11.0,
+                    ),
+                    short_leg=TradeLegIntent(
+                        venue="extended",
+                        symbol="ARB-USD",
+                        fee_profile="default",
+                        side="sell",
+                        target_notional=11.0,
+                    ),
+                ),
+            ),
+            legs=[
+                ExecutionLegResult(
+                    venue="extended",
+                    symbol="ARB-USD",
+                    fee_profile="default",
+                    side="sell",
+                    target_notional=11.0,
+                    status="submitted",
+                    simulated=False,
+                    external_reference="ext-order-stale-unobserved",
+                )
+            ],
+        )
+    )
+
+    class StubAccountService:
+        async def probe_paper_trade(
+            self,
+            paper_trade: PaperTradeEntry,
+            config_map: object,
+        ) -> PaperTradeAccountPreflight:
+            _ = config_map
+            assert paper_trade.entry_id == 8
+            return PaperTradeAccountPreflight(
+                paper_trade_id=8,
+                label=paper_trade.intent.label,
+                ready=True,
+                venues=[],
+                blocking_reasons=[],
+            )
+
+    class StubOrderStateService:
+        async def observe_execution(self, entry: ExecutionJournalEntry) -> ExecutionOrderState:
+            assert entry.paper_trade_id == 8
+            return ExecutionOrderState(
+                execution_entry_id=entry.entry_id,
+                paper_trade_id=entry.paper_trade_id,
+                preview_hash=entry.preview_hash,
+                legs=[],
+                notes=[],
+            )
+
+    summary = asyncio.run(
+        observe_live_executions_once(
+            settings,
+            execution_store=execution_store,
+            observation_store=observation_store,
+            account_service=cast(AccountPreflightService, StubAccountService()),
+            order_state_service=cast(ExecutionOrderStateService, StubOrderStateService()),
+            now=datetime(2026, 3, 29, 13, 8, tzinfo=UTC),
+        )
+    )
+
+    assert summary.scanned_executions == 1
+    assert summary.observed_executions == 1
+    assert summary.saved_observations == 1
+    assert observation_store.latest_for_paper_trade(8) is not None
 
 
 def test_observe_live_executions_once_keeps_monitoring_stale_open_hedges(


### PR DESCRIPTION
## Summary
- allow max-hold/profit-protection auto-close to use a stale-but-route-matching approved snapshot when live route revalidation fails
- prevent stale approved snapshot edge data from triggering edge-decay/break-even close decisions
- add regressions for max-hold fallback and stale-edge non-use

## Why
Held live hedges must be closable even when market scanners or route revalidation are degraded. Before this change, a stale approved snapshot plus failed live revalidation returned `None`, so max-hold protection could fail to close an old hedge.

This keeps the safety boundary tight: stale snapshots can provide route mechanics for protective close, but only fresh/revalidated data can drive edge-based close decisions.

## Validation
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run pytest -q tests/test_worker.py::test_maybe_auto_close_open_hedged_execution_uses_stale_snapshot_for_max_hold tests/test_worker.py::test_maybe_auto_close_open_hedged_execution_does_not_use_stale_edge_decay tests/test_worker.py::test_maybe_auto_close_open_hedged_execution_skips_when_stale_snapshot_cannot_revalidate`
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run pytest -q tests/test_worker.py -k 'maybe_auto_close_open_hedged_execution or build_open_hedge_auto_close_reason or build_open_hedge_profit_protection_reason'`
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run ruff check .`
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run mypy src apps packages tests`
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run pytest` (`636 passed`)

## Stack
- Stacked on #223 / `codex/block-stale-unobserved-live-executions`
