### PR TITLE
fix: reserve pair-close submissions per trade

### DIFF
--- a/apps/api/src/carryme_api/app.py
+++ b/apps/api/src/carryme_api/app.py
@@ -3892,6 +3892,7 @@ async def _execute_guarded_pair_close_from_confirmation(
             status_code=500,
             detail="Pair-close confirmation entry_id is required before live submission",
         )
+    confirmation_entry_id = confirmation.entry_id
     paper_trade_id = paper_trade.entry_id or confirmation.paper_trade_id
     if paper_trade_id < 1:
         raise HTTPException(
@@ -3928,7 +3929,7 @@ async def _execute_guarded_pair_close_from_confirmation(
     if not execution_store.reserve_pair_close_live_submission(
         paper_trade_id=paper_trade_id,
         preview_hash=confirmation.preview_hash,
-        confirmation_entry_id=confirmation.entry_id,
+        confirmation_entry_id=confirmation_entry_id,
     ):
         existing_entry = execution_store.find_by_paper_trade_preview_hash(
             paper_trade_id=paper_trade_id,
@@ -3948,7 +3949,7 @@ async def _execute_guarded_pair_close_from_confirmation(
         )
 
     if not execution_store.reserve_live_submission(
-        confirmation_entry_id=confirmation.entry_id,
+        confirmation_entry_id=confirmation_entry_id,
         preview_hash=confirmation.preview_hash,
     ):
         existing_entry = execution_store.find_by_confirmation(
@@ -3967,6 +3968,28 @@ async def _execute_guarded_pair_close_from_confirmation(
                 "manual reconciliation is required before retrying"
             ),
         )
+
+    def _release_pair_close_reservations_or_raise() -> None:
+        released_live = execution_store.release_live_submission(
+            confirmation_entry_id=confirmation_entry_id,
+            preview_hash=confirmation.preview_hash,
+        )
+        released_pair_close = execution_store.release_pair_close_live_submission(
+            paper_trade_id=paper_trade_id,
+            preview_hash=confirmation.preview_hash,
+            confirmation_entry_id=confirmation_entry_id,
+        )
+        if released_live and released_pair_close:
+            return
+        raise HTTPException(
+            status_code=409,
+            detail=(
+                "Pair-close live submission failed before journaling, but its "
+                "reservations could not be safely released; manual reconciliation "
+                "is required before retrying"
+            ),
+        )
+
     try:
         primary_execution = await service.submit_confirmed_preview(
             paper_trade=paper_trade,
@@ -3974,8 +3997,10 @@ async def _execute_guarded_pair_close_from_confirmation(
             first_venue=first_venue,
         )
     except ValueError as exc:
+        _release_pair_close_reservations_or_raise()
         raise HTTPException(status_code=400, detail=str(exc)) from exc
     except (ConnectorError, UpstreamDataError, httpx.HTTPError) as exc:
+        _release_pair_close_reservations_or_raise()
         raise HTTPException(status_code=502, detail=str(exc)) from exc
 
     primary_execution = execution_store.append(primary_execution)
@@ -3985,7 +4010,7 @@ async def _execute_guarded_pair_close_from_confirmation(
             detail="Execution journal append did not return an id",
         )
     execution_store.mark_live_submission_completed(
-        confirmation_entry_id=confirmation.entry_id,
+        confirmation_entry_id=confirmation_entry_id,
         preview_hash=confirmation.preview_hash,
         execution_entry_id=primary_execution.entry_id,
     )

--- a/packages/storage/src/carryme_storage/executions.py
+++ b/packages/storage/src/carryme_storage/executions.py
@@ -315,6 +315,33 @@ class ExecutionJournalStore:
                 (execution_entry_id, confirmation_entry_id, normalized_preview_hash),
             )
 
+    def release_live_submission(
+        self,
+        *,
+        confirmation_entry_id: int,
+        preview_hash: str,
+    ) -> bool:
+        """Release one in-flight live submission reservation that never journaled."""
+
+        self.initialize()
+        if confirmation_entry_id < 1:
+            raise ValueError("confirmation_entry_id must be positive")
+        normalized_preview_hash = preview_hash.strip()
+        if not normalized_preview_hash:
+            raise ValueError("preview_hash must be non-empty")
+        with self.database.begin() as connection:
+            result = connection.execute(
+                """
+                DELETE FROM live_submission_reservations
+                WHERE confirmation_entry_id = ?
+                  AND preview_hash = ?
+                  AND execution_entry_id IS NULL
+                """,
+                (confirmation_entry_id, normalized_preview_hash),
+            )
+        rowcount = getattr(result, "rowcount", None)
+        return isinstance(rowcount, int) and rowcount > 0
+
     def reserve_pair_open_live_submission(
         self,
         *,
@@ -432,6 +459,37 @@ class ExecutionJournalStore:
                 """,
                 (execution_entry_id, paper_trade_id, normalized_preview_hash),
             )
+
+    def release_pair_close_live_submission(
+        self,
+        *,
+        paper_trade_id: int,
+        preview_hash: str,
+        confirmation_entry_id: int,
+    ) -> bool:
+        """Release one pair-close reservation that never reached the journal."""
+
+        self.initialize()
+        if paper_trade_id < 1:
+            raise ValueError("paper_trade_id must be positive")
+        if confirmation_entry_id < 1:
+            raise ValueError("confirmation_entry_id must be positive")
+        normalized_preview_hash = preview_hash.strip()
+        if not normalized_preview_hash:
+            raise ValueError("preview_hash must be non-empty")
+        with self.database.begin() as connection:
+            result = connection.execute(
+                """
+                DELETE FROM pair_close_live_submission_reservations
+                WHERE paper_trade_id = ?
+                  AND preview_hash = ?
+                  AND confirmation_entry_id = ?
+                  AND execution_entry_id IS NULL
+                """,
+                (paper_trade_id, normalized_preview_hash, confirmation_entry_id),
+            )
+        rowcount = getattr(result, "rowcount", None)
+        return isinstance(rowcount, int) and rowcount > 0
 
     def reserve_cleanup_live_submission(
         self,

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -7549,6 +7549,329 @@ def test_guarded_pair_close_endpoint_rejects_duplicate_retry(
     assert len(saved_executions) == 1
 
 
+def test_guarded_pair_close_endpoint_releases_reservations_after_failed_submit(
+    tmp_path: Path,
+) -> None:
+    paper_store = PaperTradeStore(tmp_path / "history.sqlite3")
+    confirmation_store = PairClosePreviewConfirmationStore(tmp_path / "history.sqlite3")
+    execution_store = ExecutionJournalStore(tmp_path / "history.sqlite3")
+    observation_store = ExecutionObservationStore(tmp_path / "history.sqlite3")
+    paper_trade = paper_store.append(
+        PaperTradeEntry(
+            created_at=datetime(2026, 3, 29, 13, 0, tzinfo=UTC),
+            note="operator accepted candidate",
+            intent=FundingPairTradeIntent(
+                label="arb_extended_paradex",
+                canonical_symbol="ARB-USD-PERP",
+                source_recorded_at=datetime(2026, 3, 29, 12, 55, tzinfo=UTC),
+                one_day_net_edge_after_entry=0.00055,
+                break_even_days_entry=0.45,
+                capacity_limit_notional=4500.0,
+                target_notional=11.0,
+                capacity_fraction=0.25,
+                max_target_notional=11.0,
+                long_leg=TradeLegIntent(
+                    venue="paradex",
+                    symbol="ARB-USD-PERP",
+                    fee_profile="pro",
+                    side="buy",
+                    target_notional=11.0,
+                ),
+                short_leg=TradeLegIntent(
+                    venue="extended",
+                    symbol="ARB-USD",
+                    fee_profile="default",
+                    side="sell",
+                    target_notional=11.0,
+                ),
+            ),
+        )
+    )
+    confirmation_store.append(
+        carryme_models_module.PairClosePreviewConfirmationEntry(
+            confirmed_at=datetime(2026, 3, 29, 13, 10, tzinfo=UTC),
+            paper_trade_id=paper_trade.entry_id or 0,
+            label="arb_extended_paradex",
+            preview_hash="pair-close-hash",
+            preview=ExecutionPairClosePreview(
+                execution_entry_id=12,
+                paper_trade_id=paper_trade.entry_id or 0,
+                label="arb_extended_paradex",
+                generated_at=datetime(2026, 3, 29, 13, 5, tzinfo=UTC),
+                slippage_tolerance_bps=10,
+                preview_hash="pair-close-hash",
+                reason="close_pair",
+                legs=[
+                    VenueOrderPreview(
+                        venue="paradex",
+                        symbol="ARB-USD-PERP",
+                        fee_profile="pro",
+                        side="sell",
+                        target_notional=11.0,
+                        effective_notional=10.99,
+                        quantity=123.1,
+                        quantity_text="123.10000000",
+                        quantity_increment=0.1,
+                        minimum_order_size=0.1,
+                        minimum_notional=10.0,
+                        reference_price=0.0892,
+                        reference_price_source="best_bid",
+                        worst_acceptable_price=0.0891,
+                        worst_price_text="0.08910000",
+                        price_increment=0.0001,
+                        max_order_value=1_000_000.0,
+                        reduce_only=True,
+                        endpoint_path_hint="/v1/orders",
+                        auth_scheme="main account address + subkey private key",
+                        payload={"market": "ARB-USD-PERP", "reduce_only": True},
+                        notes=[],
+                    ),
+                    VenueOrderPreview(
+                        venue="extended",
+                        symbol="ARB-USD",
+                        fee_profile="default",
+                        side="buy",
+                        target_notional=11.0,
+                        effective_notional=10.95,
+                        quantity=123.0,
+                        quantity_text="123",
+                        quantity_increment=1.0,
+                        minimum_order_size=10.0,
+                        minimum_notional=0.918,
+                        reference_price=0.0890,
+                        reference_price_source="best_ask",
+                        worst_acceptable_price=0.0891,
+                        worst_price_text="0.0891",
+                        price_increment=0.0001,
+                        max_order_value=1_250_000.0,
+                        reduce_only=True,
+                        endpoint_path_hint="/api/v1/user/order",
+                        auth_scheme="api key + Stark signing key",
+                        payload={"symbol": "ARB-USD", "reduce_only": True},
+                        notes=[],
+                    ),
+                ],
+                notes=[],
+            ),
+            note="operator confirmed",
+        )
+    )
+
+    class StubAccountPreflightService:
+        async def probe_paper_trade(
+            self,
+            paper_trade: PaperTradeEntry,
+            configs: dict[str, object],
+        ) -> PaperTradeAccountPreflight:
+            return PaperTradeAccountPreflight(
+                paper_trade_id=paper_trade.entry_id or 0,
+                label=paper_trade.intent.label,
+                ready=True,
+                venues=[
+                    VenueAccountPreflight(
+                        venue="extended",
+                        enabled=True,
+                        authenticated=True,
+                        ready=True,
+                        credential_mode="api_key",
+                        free_collateral=25.0,
+                        position_symbols=["ARB-USD"],
+                    ),
+                    VenueAccountPreflight(
+                        venue="paradex",
+                        enabled=True,
+                        authenticated=True,
+                        ready=True,
+                        credential_mode="subkey_jwt",
+                        available_to_trade=25.0,
+                        position_symbols=["ARB-USD-PERP"],
+                    ),
+                ],
+                blocking_reasons=[],
+            )
+
+        async def probe_venues(self, configs: object) -> list[VenueAccountPreflight]:
+            return [
+                VenueAccountPreflight(
+                    venue="extended",
+                    enabled=True,
+                    authenticated=True,
+                    ready=True,
+                    credential_mode="api_key",
+                    free_collateral=25.0,
+                ),
+                VenueAccountPreflight(
+                    venue="paradex",
+                    enabled=True,
+                    authenticated=True,
+                    ready=True,
+                    credential_mode="subkey_jwt",
+                    available_to_trade=25.0,
+                ),
+            ]
+
+    class StubExecutionOrderStateService:
+        async def observe_execution(self, entry: ExecutionJournalEntry) -> ExecutionOrderState:
+            return ExecutionOrderState(
+                execution_entry_id=entry.entry_id,
+                paper_trade_id=entry.paper_trade_id,
+                preview_hash=entry.preview_hash,
+                legs=[
+                    ExecutionLegOrderState(
+                        venue="paradex",
+                        supported=True,
+                        external_reference="paradex-close-1",
+                        derived_state="filled",
+                    ),
+                    ExecutionLegOrderState(
+                        venue="extended",
+                        supported=True,
+                        external_reference="extended-close-1",
+                        derived_state="filled",
+                    ),
+                ],
+            )
+
+    class FlakyPairCloseLiveExecutionCoordinator:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        async def submit_confirmed_preview(
+            self,
+            *,
+            paper_trade: PaperTradeEntry,
+            confirmation: carryme_models_module.PairClosePreviewConfirmationEntry,
+            first_venue: str,
+            executed_at: datetime | None = None,
+        ) -> ExecutionJournalEntry:
+            self.calls += 1
+            if self.calls == 1:
+                raise ValueError("submit failed before execution journal append")
+            adapter_first = (
+                confirmation.preview.legs[0].venue if first_venue in {"", "auto"} else first_venue
+            )
+            adapter_second = confirmation.preview.legs[1].venue
+            return ExecutionJournalEntry(
+                executed_at=datetime(2026, 3, 29, 13, 15, tzinfo=UTC),
+                adapter=f"paired_cleanup:{adapter_first}_then_{adapter_second}",
+                mode="live",
+                status="submitted",
+                paper_trade_id=paper_trade.entry_id,
+                preview_hash=confirmation.preview_hash,
+                confirmation_entry_id=confirmation.entry_id,
+                paper_trade=paper_trade,
+                legs=[
+                    ExecutionLegResult(
+                        venue="paradex",
+                        symbol="ARB-USD-PERP",
+                        fee_profile="pro",
+                        side="sell",
+                        target_notional=11.0,
+                        status="submitted",
+                        simulated=False,
+                        external_reference="paradex-close-1",
+                    ),
+                    ExecutionLegResult(
+                        venue="extended",
+                        symbol="ARB-USD",
+                        fee_profile="default",
+                        side="buy",
+                        target_notional=11.0,
+                        status="submitted",
+                        simulated=False,
+                        external_reference="extended-close-1",
+                    ),
+                ],
+            )
+
+    class StubCleanupPreviewService:
+        async def preview_from_execution(
+            self,
+            *,
+            entry: ExecutionJournalEntry,
+            pair_status: ExecutionPairStatus,
+            slippage_tolerance_bps: int = 10,
+        ) -> ExecutionCleanupPreview:
+            raise AssertionError("cleanup preview should not be requested when auto_cleanup=false")
+
+    class StubCleanupLiveExecutionRouter:
+        async def submit_confirmed_cleanup_preview(
+            self,
+            *,
+            paper_trade: PaperTradeEntry,
+            confirmation: CleanupPreviewConfirmationEntry,
+            executed_at: datetime | None = None,
+        ) -> ExecutionJournalEntry:
+            raise AssertionError("cleanup live router should not be used when auto_cleanup=false")
+
+    from carryme_api.app import (
+        get_account_preflight_service,
+        get_api_settings,
+        get_cleanup_live_execution_router,
+        get_cleanup_preview_service,
+        get_execution_journal_store,
+        get_execution_observation_store,
+        get_execution_order_state_service,
+        get_pair_close_live_execution_coordinator,
+        get_pair_close_preview_confirmation_store,
+        get_paper_trade_store,
+    )
+
+    coordinator = FlakyPairCloseLiveExecutionCoordinator()
+    app.dependency_overrides[get_paper_trade_store] = lambda: paper_store
+    app.dependency_overrides[get_pair_close_preview_confirmation_store] = lambda: confirmation_store
+    app.dependency_overrides[get_execution_journal_store] = lambda: execution_store
+    app.dependency_overrides[get_execution_observation_store] = lambda: observation_store
+    app.dependency_overrides[get_account_preflight_service] = lambda: StubAccountPreflightService()
+    app.dependency_overrides[get_execution_order_state_service] = (
+        lambda: StubExecutionOrderStateService()
+    )
+    app.dependency_overrides[get_pair_close_live_execution_coordinator] = lambda: coordinator
+    app.dependency_overrides[get_cleanup_preview_service] = lambda: StubCleanupPreviewService()
+    app.dependency_overrides[get_cleanup_live_execution_router] = (
+        lambda: StubCleanupLiveExecutionRouter()
+    )
+    app.dependency_overrides[get_api_settings] = lambda: ApiSettings(
+        extended_live_enabled=True,
+        extended_api_key="extended-key",
+        extended_stark_private_key="extended-stark",
+        paradex_live_enabled=True,
+        paradex_account_address="0xabc",
+        paradex_private_key="paradex-private",
+    )
+    client = TestClient(app)
+    first = client.post(
+        f"/v1/executions/live/pair/close/from-paper-trade/{paper_trade.entry_id}",
+        params={
+            "preview_hash": "pair-close-hash",
+            "poll_attempts": 1,
+            "poll_interval_seconds": 0,
+            "auto_cleanup": "false",
+        },
+    )
+    second = client.post(
+        f"/v1/executions/live/pair/close/from-paper-trade/{paper_trade.entry_id}",
+        params={
+            "preview_hash": "pair-close-hash",
+            "poll_attempts": 1,
+            "poll_interval_seconds": 0,
+            "auto_cleanup": "false",
+        },
+    )
+    app.dependency_overrides.clear()
+
+    assert first.status_code == 400
+    assert first.json()["detail"] == "submit failed before execution journal append"
+    assert second.status_code == 200
+    assert coordinator.calls == 2
+    saved_executions = [
+        entry
+        for entry in execution_store.list_recent(limit=10)
+        if entry.paper_trade_id == paper_trade.entry_id
+    ]
+    assert len(saved_executions) == 1
+
+
 def test_execute_extended_cleanup_endpoint_submits_confirmed_cleanup_preview(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -829,6 +829,79 @@ def test_execution_journal_store_reserves_pair_close_submission_once_per_trade(
     )
 
 
+def test_execution_journal_store_releases_uncompleted_pair_close_submission(
+    tmp_path: Path,
+) -> None:
+    store = ExecutionJournalStore(tmp_path / "history.sqlite3")
+
+    assert store.reserve_pair_close_live_submission(
+        paper_trade_id=7,
+        preview_hash="pair-close-hash",
+        confirmation_entry_id=11,
+    )
+    assert store.release_pair_close_live_submission(
+        paper_trade_id=7,
+        preview_hash="pair-close-hash",
+        confirmation_entry_id=11,
+    )
+    assert store.reserve_pair_close_live_submission(
+        paper_trade_id=7,
+        preview_hash="pair-close-hash",
+        confirmation_entry_id=12,
+    )
+
+
+def test_execution_journal_store_does_not_release_completed_pair_close_submission(
+    tmp_path: Path,
+) -> None:
+    store = ExecutionJournalStore(tmp_path / "history.sqlite3")
+
+    assert store.reserve_pair_close_live_submission(
+        paper_trade_id=7,
+        preview_hash="pair-close-hash",
+        confirmation_entry_id=11,
+    )
+    store.mark_pair_close_live_submission_completed(
+        paper_trade_id=7,
+        preview_hash="pair-close-hash",
+        execution_entry_id=99,
+    )
+
+    assert not store.release_pair_close_live_submission(
+        paper_trade_id=7,
+        preview_hash="pair-close-hash",
+        confirmation_entry_id=11,
+    )
+    assert not store.reserve_pair_close_live_submission(
+        paper_trade_id=7,
+        preview_hash="pair-close-hash",
+        confirmation_entry_id=12,
+    )
+
+
+def test_execution_journal_store_does_not_release_pair_close_submission_for_mismatched_confirmation(
+    tmp_path: Path,
+) -> None:
+    store = ExecutionJournalStore(tmp_path / "history.sqlite3")
+
+    assert store.reserve_pair_close_live_submission(
+        paper_trade_id=7,
+        preview_hash="pair-close-hash",
+        confirmation_entry_id=11,
+    )
+
+    assert not store.release_pair_close_live_submission(
+        paper_trade_id=7,
+        preview_hash="pair-close-hash",
+        confirmation_entry_id=12,
+    )
+    assert not store.reserve_pair_close_live_submission(
+        paper_trade_id=7,
+        preview_hash="pair-close-hash",
+        confirmation_entry_id=13,
+    )
+
+
 def test_execution_journal_store_reserves_pair_open_submission_once_per_trade(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary
- reserve pair-close live submissions per paper trade and preview hash before live close execution
- prevent duplicate close submissions when parallel monitors create different confirmations for the same close preview
- preserve existing duplicate retry behavior by returning the existing execution when already submitted

## Why
The existing live-submission reservation was keyed by confirmation entry id and preview hash. That blocks retrying the same confirmation, but two workers can create two different pair-close confirmations for the same `paper_trade_id` and close `preview_hash`, then both submit live close orders. This PR adds a paper-trade-level close reservation so only one close submission can proceed for a given hedge/close preview.

## Validation
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run pytest -q tests/test_storage.py::test_execution_journal_store_reserves_pair_close_submission_once_per_trade tests/test_api.py::test_guarded_pair_close_endpoint_rejects_duplicate_retry`
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run pytest -q tests/test_storage.py -k 'execution_journal_store'`
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run pytest -q tests/test_api.py -k 'guarded_pair_close_endpoint_rejects_duplicate_retry or pair_close'`
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run ruff check .`
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run mypy src apps packages tests`
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run pytest` (`637 passed`)

## Stack
- Stacked on #224 / `codex/auto-close-stale-snapshot-hold-limit`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where execution submissions were not properly released when live submission encounters validation or network errors. Reservations from failed submissions could remain locked, preventing subsequent requests from completing successfully. The system now correctly clears and releases all reservations whenever submission failures occur, ensuring future requests can proceed normally.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->