### PR TITLE
fix: reserve cleanup submissions per trade

### DIFF
--- a/apps/api/src/carryme_api/app.py
+++ b/apps/api/src/carryme_api/app.py
@@ -2116,6 +2116,34 @@ def _mark_cleanup_live_submission_completed(
     )
 
 
+def _release_cleanup_live_submission_reservations(
+    *,
+    paper_trade: PaperTradeEntry,
+    confirmation: CleanupPreviewConfirmationEntry,
+    execution_store: ExecutionJournalStore,
+) -> None:
+    """Release cleanup reservations only when submission definitely did not happen."""
+
+    if confirmation.entry_id is None:
+        raise HTTPException(
+            status_code=500,
+            detail="Cleanup preview confirmation entry_id is required before live submission",
+        )
+    paper_trade_id = _effective_cleanup_submission_paper_trade_id(
+        paper_trade=paper_trade,
+        confirmation=confirmation,
+    )
+    execution_store.release_live_submission(
+        confirmation_entry_id=confirmation.entry_id,
+        preview_hash=confirmation.preview_hash,
+    )
+    execution_store.release_cleanup_live_submission(
+        paper_trade_id=paper_trade_id,
+        preview_hash=confirmation.preview_hash,
+        confirmation_entry_id=confirmation.entry_id,
+    )
+
+
 async def _observe_pair_status_for_execution(
     *,
     paper_trade: PaperTradeEntry,
@@ -2284,6 +2312,11 @@ async def _run_guarded_auto_cleanup_sequence(
                     )
                 )
             except ValueError as exc:
+                _release_cleanup_live_submission_reservations(
+                    paper_trade=paper_trade,
+                    confirmation=cleanup_confirmation,
+                    execution_store=execution_store,
+                )
                 raise HTTPException(status_code=400, detail=str(exc)) from exc
             except (ConnectorError, UpstreamDataError, httpx.HTTPError) as exc:
                 raise HTTPException(status_code=502, detail=str(exc)) from exc
@@ -6000,6 +6033,11 @@ def create_app() -> FastAPI:
                 confirmation=confirmation,
             )
         except ValueError as exc:
+            _release_cleanup_live_submission_reservations(
+                paper_trade=paper_trade,
+                confirmation=confirmation,
+                execution_store=execution_store,
+            )
             raise HTTPException(status_code=400, detail=str(exc)) from exc
         except (ConnectorError, httpx.HTTPError) as exc:
             raise HTTPException(status_code=502, detail=str(exc)) from exc
@@ -6092,6 +6130,11 @@ def create_app() -> FastAPI:
                 confirmation=confirmation,
             )
         except ValueError as exc:
+            _release_cleanup_live_submission_reservations(
+                paper_trade=paper_trade,
+                confirmation=confirmation,
+                execution_store=execution_store,
+            )
             raise HTTPException(status_code=400, detail=str(exc)) from exc
         except (ConnectorError, httpx.HTTPError) as exc:
             raise HTTPException(status_code=502, detail=str(exc)) from exc
@@ -6184,6 +6227,11 @@ def create_app() -> FastAPI:
                 confirmation=confirmation,
             )
         except ValueError as exc:
+            _release_cleanup_live_submission_reservations(
+                paper_trade=paper_trade,
+                confirmation=confirmation,
+                execution_store=execution_store,
+            )
             raise HTTPException(status_code=400, detail=str(exc)) from exc
         except (ConnectorError, httpx.HTTPError) as exc:
             raise HTTPException(status_code=502, detail=str(exc)) from exc

--- a/apps/api/src/carryme_api/app.py
+++ b/apps/api/src/carryme_api/app.py
@@ -2133,14 +2133,24 @@ def _release_cleanup_live_submission_reservations(
         paper_trade=paper_trade,
         confirmation=confirmation,
     )
-    execution_store.release_live_submission(
+    released_live = execution_store.release_live_submission(
         confirmation_entry_id=confirmation.entry_id,
         preview_hash=confirmation.preview_hash,
     )
-    execution_store.release_cleanup_live_submission(
+    released_cleanup = execution_store.release_cleanup_live_submission(
         paper_trade_id=paper_trade_id,
         preview_hash=confirmation.preview_hash,
         confirmation_entry_id=confirmation.entry_id,
+    )
+    if released_live and released_cleanup:
+        return
+    raise HTTPException(
+        status_code=409,
+        detail=(
+            "Cleanup live submission failed before journaling, but its "
+            "reservations could not be safely released; manual reconciliation "
+            "is required before retrying"
+        ),
     )
 
 
@@ -4039,7 +4049,6 @@ async def _execute_guarded_pair_close_from_confirmation(
         _release_pair_close_reservations_or_raise()
         raise HTTPException(status_code=400, detail=str(exc)) from exc
     except (ConnectorError, UpstreamDataError, httpx.HTTPError) as exc:
-        _release_pair_close_reservations_or_raise()
         raise HTTPException(status_code=502, detail=str(exc)) from exc
 
     primary_execution = execution_store.append(primary_execution)
@@ -5967,6 +5976,10 @@ def create_app() -> FastAPI:
         preview_hash: str,
         settings: Annotated[ApiSettings, Depends(get_api_settings)],
         paper_store: Annotated[PaperTradeStore, Depends(get_paper_trade_store)],
+        approval_service: Annotated[
+            RouteApprovalService,
+            Depends(get_route_approval_service),
+        ],
         execution_store: Annotated[ExecutionJournalStore, Depends(get_execution_journal_store)],
         account_service: Annotated[
             AccountPreflightService,
@@ -5992,6 +6005,16 @@ def create_app() -> FastAPI:
         normalized_preview_hash = preview_hash.strip()
         if not normalized_preview_hash:
             raise HTTPException(status_code=400, detail="preview_hash must be non-empty")
+        paper_trade = paper_store.get(paper_trade_id)
+        if paper_trade is None:
+            raise HTTPException(
+                status_code=404,
+                detail=f"Paper trade {paper_trade_id} was not found",
+            )
+        _require_live_route_approval(
+            paper_trade=paper_trade,
+            approval_service=approval_service,
+        )
         await _ensure_cleanup_live_ready(
             venue="extended",
             settings=settings,
@@ -6064,6 +6087,10 @@ def create_app() -> FastAPI:
         preview_hash: str,
         settings: Annotated[ApiSettings, Depends(get_api_settings)],
         paper_store: Annotated[PaperTradeStore, Depends(get_paper_trade_store)],
+        approval_service: Annotated[
+            RouteApprovalService,
+            Depends(get_route_approval_service),
+        ],
         execution_store: Annotated[ExecutionJournalStore, Depends(get_execution_journal_store)],
         account_service: Annotated[
             AccountPreflightService,
@@ -6089,6 +6116,16 @@ def create_app() -> FastAPI:
         normalized_preview_hash = preview_hash.strip()
         if not normalized_preview_hash:
             raise HTTPException(status_code=400, detail="preview_hash must be non-empty")
+        paper_trade = paper_store.get(paper_trade_id)
+        if paper_trade is None:
+            raise HTTPException(
+                status_code=404,
+                detail=f"Paper trade {paper_trade_id} was not found",
+            )
+        _require_live_route_approval(
+            paper_trade=paper_trade,
+            approval_service=approval_service,
+        )
         await _ensure_cleanup_live_ready(
             venue="paradex",
             settings=settings,
@@ -6161,6 +6198,10 @@ def create_app() -> FastAPI:
         preview_hash: str,
         settings: Annotated[ApiSettings, Depends(get_api_settings)],
         paper_store: Annotated[PaperTradeStore, Depends(get_paper_trade_store)],
+        approval_service: Annotated[
+            RouteApprovalService,
+            Depends(get_route_approval_service),
+        ],
         execution_store: Annotated[ExecutionJournalStore, Depends(get_execution_journal_store)],
         account_service: Annotated[
             AccountPreflightService,
@@ -6186,6 +6227,16 @@ def create_app() -> FastAPI:
         normalized_preview_hash = preview_hash.strip()
         if not normalized_preview_hash:
             raise HTTPException(status_code=400, detail="preview_hash must be non-empty")
+        paper_trade = paper_store.get(paper_trade_id)
+        if paper_trade is None:
+            raise HTTPException(
+                status_code=404,
+                detail=f"Paper trade {paper_trade_id} was not found",
+            )
+        _require_live_route_approval(
+            paper_trade=paper_trade,
+            approval_service=approval_service,
+        )
         await _ensure_cleanup_live_ready(
             venue="hyperliquid",
             settings=settings,

--- a/packages/storage/src/carryme_storage/executions.py
+++ b/packages/storage/src/carryme_storage/executions.py
@@ -550,6 +550,37 @@ class ExecutionJournalStore:
                 (execution_entry_id, paper_trade_id, normalized_preview_hash),
             )
 
+    def release_cleanup_live_submission(
+        self,
+        *,
+        paper_trade_id: int,
+        preview_hash: str,
+        confirmation_entry_id: int,
+    ) -> bool:
+        """Release one cleanup reservation that never reached the journal."""
+
+        self.initialize()
+        if paper_trade_id < 1:
+            raise ValueError("paper_trade_id must be positive")
+        if confirmation_entry_id < 1:
+            raise ValueError("confirmation_entry_id must be positive")
+        normalized_preview_hash = preview_hash.strip()
+        if not normalized_preview_hash:
+            raise ValueError("preview_hash must be non-empty")
+        with self.database.begin() as connection:
+            result = connection.execute(
+                """
+                DELETE FROM cleanup_live_submission_reservations
+                WHERE paper_trade_id = ?
+                  AND preview_hash = ?
+                  AND confirmation_entry_id = ?
+                  AND execution_entry_id IS NULL
+                """,
+                (paper_trade_id, normalized_preview_hash, confirmation_entry_id),
+            )
+        rowcount = getattr(result, "rowcount", None)
+        return isinstance(rowcount, int) and rowcount > 0
+
     def find_by_paper_trade_preview_hash(
         self,
         *,

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -8127,6 +8127,268 @@ def test_execute_extended_cleanup_endpoint_submits_confirmed_cleanup_preview(
     assert stored_entries[0].confirmation_entry_id == confirmation.entry_id
 
 
+def test_execute_extended_cleanup_endpoint_releases_reservations_after_value_error(
+    tmp_path: Path,
+) -> None:
+    paper_store = PaperTradeStore(tmp_path / "paper.sqlite3")
+    paper_trade = paper_store.append(
+        PaperTradeEntry(
+            created_at=datetime(2026, 3, 29, 12, 50, tzinfo=UTC),
+            intent=FundingPairTradeIntent(
+                label="arb_extended_paradex",
+                canonical_symbol="ARB-USD-PERP",
+                source_recorded_at=datetime(2026, 3, 29, 12, 45, tzinfo=UTC),
+                one_day_net_edge_after_entry=0.0012,
+                break_even_days_entry=0.35,
+                capacity_limit_notional=1000.0,
+                target_notional=11.0,
+                capacity_fraction=0.25,
+                max_target_notional=11.0,
+                long_leg=TradeLegIntent(
+                    venue="paradex",
+                    symbol="ARB-USD-PERP",
+                    fee_profile="pro",
+                    side="buy",
+                    target_notional=11.0,
+                ),
+                short_leg=TradeLegIntent(
+                    venue="extended",
+                    symbol="ARB-USD",
+                    fee_profile="default",
+                    side="sell",
+                    target_notional=11.0,
+                ),
+            ),
+        )
+    )
+    execution_store = ExecutionJournalStore(tmp_path / "history.sqlite3")
+    latest_execution = execution_store.append(
+        ExecutionJournalEntry(
+            executed_at=datetime(2026, 3, 29, 13, 0, tzinfo=UTC),
+            adapter="paired_live:extended_then_paradex",
+            mode="live",
+            status="submitted",
+            paper_trade_id=paper_trade.entry_id,
+            preview_hash="preview-hash",
+            confirmation_entry_id=3,
+            paper_trade=paper_trade,
+            legs=[
+                ExecutionLegResult(
+                    venue="extended",
+                    symbol="ARB-USD",
+                    fee_profile="default",
+                    side="sell",
+                    target_notional=11.0,
+                    status="submitted",
+                    simulated=False,
+                    external_reference="ext-order",
+                )
+            ],
+        )
+    )
+    cleanup_store = CleanupPreviewConfirmationStore(tmp_path / "history.sqlite3")
+    confirmation = cleanup_store.append(
+        CleanupPreviewConfirmationEntry(
+            confirmed_at=datetime(2026, 3, 29, 13, 2, tzinfo=UTC),
+            paper_trade_id=paper_trade.entry_id or 0,
+            label="arb_extended_paradex",
+            preview_hash="cleanup-hash",
+            preview=ExecutionCleanupPreview(
+                execution_entry_id=latest_execution.entry_id,
+                paper_trade_id=paper_trade.entry_id,
+                generated_at=datetime(2026, 3, 29, 13, 1, tzinfo=UTC),
+                preview_hash="cleanup-hash",
+                reason="close_open_leg",
+                leg=VenueOrderPreview(
+                    venue="extended",
+                    symbol="ARB-USD",
+                    fee_profile="default",
+                    side="buy",
+                    target_notional=11.0,
+                    effective_notional=11.0,
+                    quantity=123.0,
+                    quantity_text="123",
+                    reference_price=0.0895,
+                    reference_price_source="best_ask",
+                    worst_acceptable_price=0.0896,
+                    worst_price_text="0.0896",
+                    reduce_only=True,
+                    endpoint_path_hint="/api/v1/user/order",
+                    required_auth_env_vars=[],
+                    auth_scheme="api key + Stark signing key",
+                    payload={"symbol": "ARB-USD", "reduce_only": True},
+                    notes=[],
+                ),
+                notes=[],
+            ),
+            note="operator confirmed cleanup",
+        )
+    )
+
+    from carryme_api.app import (
+        get_account_preflight_service,
+        get_api_settings,
+        get_cleanup_preview_confirmation_store,
+        get_cleanup_preview_service,
+        get_execution_journal_store,
+        get_execution_order_state_service,
+        get_extended_live_execution_service,
+        get_paper_trade_store,
+    )
+
+    class StubExecutionOrderStateService:
+        async def observe_execution(self, entry: ExecutionJournalEntry) -> ExecutionOrderState:
+            return ExecutionOrderState(
+                execution_entry_id=entry.entry_id,
+                paper_trade_id=entry.paper_trade_id,
+                preview_hash=entry.preview_hash,
+                legs=[
+                    ExecutionLegOrderState(
+                        venue="extended",
+                        supported=True,
+                        external_reference="ext-order",
+                        derived_state="unknown",
+                    )
+                ],
+            )
+
+    class StubAccountPreflightService:
+        async def probe_paper_trade(
+            self,
+            entry: PaperTradeEntry,
+            configs: object,
+        ) -> PaperTradeAccountPreflight:
+            return PaperTradeAccountPreflight(
+                paper_trade_id=entry.entry_id or 0,
+                label="arb_extended_paradex",
+                ready=True,
+                venues=[
+                    VenueAccountPreflight(
+                        venue="extended",
+                        enabled=True,
+                        authenticated=True,
+                        ready=True,
+                        credential_mode="api_key",
+                        position_symbols=["ARB-USD"],
+                    ),
+                    VenueAccountPreflight(
+                        venue="paradex",
+                        enabled=True,
+                        authenticated=True,
+                        ready=True,
+                        credential_mode="subkey_jwt",
+                        position_symbols=[],
+                    ),
+                ],
+                blocking_reasons=[],
+            )
+
+        async def probe_venues(self, configs: object) -> list[VenueAccountPreflight]:
+            return [
+                VenueAccountPreflight(
+                    venue="extended",
+                    enabled=True,
+                    authenticated=True,
+                    ready=True,
+                    credential_mode="api_key",
+                ),
+                VenueAccountPreflight(
+                    venue="paradex",
+                    enabled=False,
+                    authenticated=False,
+                    ready=False,
+                    credential_mode="subkey_jwt",
+                ),
+            ]
+
+    class StubCleanupPreviewService:
+        async def preview_from_execution(
+            self,
+            *,
+            entry: ExecutionJournalEntry,
+            pair_status: ExecutionPairStatus,
+            slippage_tolerance_bps: int = 10,
+            generated_at: datetime | None = None,
+        ) -> ExecutionCleanupPreview:
+            return confirmation.preview
+
+    class FlakyExtendedLiveExecutionService:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        async def submit_confirmed_cleanup_preview(
+            self,
+            *,
+            paper_trade: PaperTradeEntry,
+            confirmation: CleanupPreviewConfirmationEntry,
+            executed_at: datetime | None = None,
+        ) -> ExecutionJournalEntry:
+            self.calls += 1
+            if self.calls == 1:
+                raise ValueError("cleanup submit failed before execution journal append")
+            assert confirmation.entry_id is not None
+            return ExecutionJournalEntry(
+                executed_at=datetime(2026, 3, 29, 13, 3, tzinfo=UTC),
+                adapter="extended_cleanup_live",
+                mode="live",
+                status="submitted",
+                paper_trade_id=paper_trade.entry_id,
+                preview_hash=confirmation.preview_hash,
+                confirmation_entry_id=confirmation.entry_id,
+                paper_trade=paper_trade,
+                legs=[
+                    ExecutionLegResult(
+                        venue="extended",
+                        symbol="ARB-USD",
+                        fee_profile="default",
+                        side="buy",
+                        target_notional=11.0,
+                        status="submitted",
+                        simulated=False,
+                        external_reference="cleanup-order-1",
+                    )
+                ],
+            )
+
+    service = FlakyExtendedLiveExecutionService()
+    app.dependency_overrides[get_api_settings] = lambda: ApiSettings(
+        extended_live_enabled=True,
+        extended_api_key="extended-key",
+        extended_stark_private_key="stark-key",
+    )
+    app.dependency_overrides[get_paper_trade_store] = lambda: paper_store
+    app.dependency_overrides[get_execution_journal_store] = lambda: execution_store
+    app.dependency_overrides[get_cleanup_preview_confirmation_store] = lambda: cleanup_store
+    app.dependency_overrides[get_execution_order_state_service] = (
+        lambda: StubExecutionOrderStateService()
+    )
+    app.dependency_overrides[get_account_preflight_service] = lambda: StubAccountPreflightService()
+    app.dependency_overrides[get_cleanup_preview_service] = lambda: StubCleanupPreviewService()
+    app.dependency_overrides[get_extended_live_execution_service] = lambda: service
+    app.dependency_overrides[get_route_approval_service] = lambda: _AllowAllRouteApprovalService()
+    client = TestClient(app)
+    assert paper_trade.entry_id is not None
+    first = client.post(
+        f"/v1/executions/live/extended/cleanup/from-paper-trade/{paper_trade.entry_id}",
+        params={"preview_hash": "cleanup-hash"},
+    )
+    second = client.post(
+        f"/v1/executions/live/extended/cleanup/from-paper-trade/{paper_trade.entry_id}",
+        params={"preview_hash": "cleanup-hash"},
+    )
+    app.dependency_overrides.clear()
+
+    assert first.status_code == 400
+    assert first.json()["detail"] == "cleanup submit failed before execution journal append"
+    assert second.status_code == 200
+    assert service.calls == 2
+    stored_entries = execution_store.list_recent(limit=10)
+    assert len(stored_entries) == 2
+    assert stored_entries[0].paper_trade_id == paper_trade.entry_id
+    assert stored_entries[0].preview_hash == "cleanup-hash"
+    assert stored_entries[0].confirmation_entry_id == confirmation.entry_id
+
+
 def test_execute_paradex_cleanup_endpoint_submits_confirmed_cleanup_preview(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -28,6 +28,7 @@ from carryme_api.app import (
     get_system_state_service,
 )
 from carryme_api.config import ApiSettings
+from carryme_connectors.base import ConnectorError
 from carryme_models import (
     ApprovedCanaryAlertEvent,
     ApprovedCanaryBasketEntry,
@@ -101,6 +102,7 @@ from carryme_storage import (
     SystemStateAlertStore,
     WatchlistStore,
 )
+from fastapi import HTTPException
 from fastapi.testclient import TestClient
 from pydantic import SecretStr, ValidationError
 
@@ -7872,6 +7874,330 @@ def test_guarded_pair_close_endpoint_releases_reservations_after_failed_submit(
     assert len(saved_executions) == 1
 
 
+def test_guarded_pair_close_endpoint_keeps_reservations_after_transport_failure(
+    tmp_path: Path,
+) -> None:
+    paper_store = PaperTradeStore(tmp_path / "history.sqlite3")
+    confirmation_store = PairClosePreviewConfirmationStore(tmp_path / "history.sqlite3")
+    execution_store = ExecutionJournalStore(tmp_path / "history.sqlite3")
+    observation_store = ExecutionObservationStore(tmp_path / "history.sqlite3")
+    paper_trade = paper_store.append(
+        PaperTradeEntry(
+            created_at=datetime(2026, 3, 29, 13, 0, tzinfo=UTC),
+            note="operator accepted candidate",
+            intent=FundingPairTradeIntent(
+                label="arb_extended_paradex",
+                canonical_symbol="ARB-USD-PERP",
+                source_recorded_at=datetime(2026, 3, 29, 12, 55, tzinfo=UTC),
+                one_day_net_edge_after_entry=0.00055,
+                break_even_days_entry=0.45,
+                capacity_limit_notional=4500.0,
+                target_notional=11.0,
+                capacity_fraction=0.25,
+                max_target_notional=11.0,
+                long_leg=TradeLegIntent(
+                    venue="paradex",
+                    symbol="ARB-USD-PERP",
+                    fee_profile="pro",
+                    side="buy",
+                    target_notional=11.0,
+                ),
+                short_leg=TradeLegIntent(
+                    venue="extended",
+                    symbol="ARB-USD",
+                    fee_profile="default",
+                    side="sell",
+                    target_notional=11.0,
+                ),
+            ),
+        )
+    )
+    confirmation_store.append(
+        carryme_models_module.PairClosePreviewConfirmationEntry(
+            confirmed_at=datetime(2026, 3, 29, 13, 10, tzinfo=UTC),
+            paper_trade_id=paper_trade.entry_id or 0,
+            label="arb_extended_paradex",
+            preview_hash="pair-close-hash",
+            preview=ExecutionPairClosePreview(
+                execution_entry_id=12,
+                paper_trade_id=paper_trade.entry_id or 0,
+                label="arb_extended_paradex",
+                generated_at=datetime(2026, 3, 29, 13, 5, tzinfo=UTC),
+                slippage_tolerance_bps=10,
+                preview_hash="pair-close-hash",
+                reason="close_pair",
+                legs=[
+                    VenueOrderPreview(
+                        venue="paradex",
+                        symbol="ARB-USD-PERP",
+                        fee_profile="pro",
+                        side="sell",
+                        target_notional=11.0,
+                        effective_notional=10.99,
+                        quantity=123.1,
+                        quantity_text="123.10000000",
+                        quantity_increment=0.1,
+                        minimum_order_size=0.1,
+                        minimum_notional=10.0,
+                        reference_price=0.0892,
+                        reference_price_source="best_bid",
+                        worst_acceptable_price=0.0891,
+                        worst_price_text="0.08910000",
+                        price_increment=0.0001,
+                        max_order_value=1_000_000.0,
+                        reduce_only=True,
+                        endpoint_path_hint="/v1/orders",
+                        auth_scheme="main account address + subkey private key",
+                        payload={"market": "ARB-USD-PERP", "reduce_only": True},
+                        notes=[],
+                    ),
+                    VenueOrderPreview(
+                        venue="extended",
+                        symbol="ARB-USD",
+                        fee_profile="default",
+                        side="buy",
+                        target_notional=11.0,
+                        effective_notional=10.95,
+                        quantity=123.0,
+                        quantity_text="123",
+                        quantity_increment=1.0,
+                        minimum_order_size=10.0,
+                        minimum_notional=0.918,
+                        reference_price=0.0890,
+                        reference_price_source="best_ask",
+                        worst_acceptable_price=0.0891,
+                        worst_price_text="0.0891",
+                        price_increment=0.0001,
+                        max_order_value=1_250_000.0,
+                        reduce_only=True,
+                        endpoint_path_hint="/api/v1/user/order",
+                        auth_scheme="api key + Stark signing key",
+                        payload={"symbol": "ARB-USD", "reduce_only": True},
+                        notes=[],
+                    ),
+                ],
+                notes=[],
+            ),
+            note="operator confirmed",
+        )
+    )
+
+    class StubAccountPreflightService:
+        async def probe_paper_trade(
+            self,
+            paper_trade: PaperTradeEntry,
+            configs: dict[str, object],
+        ) -> PaperTradeAccountPreflight:
+            return PaperTradeAccountPreflight(
+                paper_trade_id=paper_trade.entry_id or 0,
+                label=paper_trade.intent.label,
+                ready=True,
+                venues=[
+                    VenueAccountPreflight(
+                        venue="extended",
+                        enabled=True,
+                        authenticated=True,
+                        ready=True,
+                        credential_mode="api_key",
+                        free_collateral=25.0,
+                        position_symbols=["ARB-USD"],
+                    ),
+                    VenueAccountPreflight(
+                        venue="paradex",
+                        enabled=True,
+                        authenticated=True,
+                        ready=True,
+                        credential_mode="subkey_jwt",
+                        available_to_trade=25.0,
+                        position_symbols=["ARB-USD-PERP"],
+                    ),
+                ],
+                blocking_reasons=[],
+            )
+
+        async def probe_venues(self, configs: object) -> list[VenueAccountPreflight]:
+            return [
+                VenueAccountPreflight(
+                    venue="extended",
+                    enabled=True,
+                    authenticated=True,
+                    ready=True,
+                    credential_mode="api_key",
+                    free_collateral=25.0,
+                ),
+                VenueAccountPreflight(
+                    venue="paradex",
+                    enabled=True,
+                    authenticated=True,
+                    ready=True,
+                    credential_mode="subkey_jwt",
+                    available_to_trade=25.0,
+                ),
+            ]
+
+    class StubExecutionOrderStateService:
+        async def observe_execution(self, entry: ExecutionJournalEntry) -> ExecutionOrderState:
+            return ExecutionOrderState(
+                execution_entry_id=entry.entry_id,
+                paper_trade_id=entry.paper_trade_id,
+                preview_hash=entry.preview_hash,
+                legs=[
+                    ExecutionLegOrderState(
+                        venue="paradex",
+                        supported=True,
+                        external_reference="paradex-close-1",
+                        derived_state="filled",
+                    ),
+                    ExecutionLegOrderState(
+                        venue="extended",
+                        supported=True,
+                        external_reference="extended-close-1",
+                        derived_state="filled",
+                    ),
+                ],
+            )
+
+    class FlakyPairCloseLiveExecutionCoordinator:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        async def submit_confirmed_preview(
+            self,
+            *,
+            paper_trade: PaperTradeEntry,
+            confirmation: carryme_models_module.PairClosePreviewConfirmationEntry,
+            first_venue: str,
+            executed_at: datetime | None = None,
+        ) -> ExecutionJournalEntry:
+            self.calls += 1
+            if self.calls == 1:
+                raise ConnectorError("transport failed after submit attempt")
+            adapter_first = (
+                confirmation.preview.legs[0].venue if first_venue in {"", "auto"} else first_venue
+            )
+            adapter_second = confirmation.preview.legs[1].venue
+            return ExecutionJournalEntry(
+                executed_at=datetime(2026, 3, 29, 13, 15, tzinfo=UTC),
+                adapter=f"paired_cleanup:{adapter_first}_then_{adapter_second}",
+                mode="live",
+                status="submitted",
+                paper_trade_id=paper_trade.entry_id,
+                preview_hash=confirmation.preview_hash,
+                confirmation_entry_id=confirmation.entry_id,
+                paper_trade=paper_trade,
+                legs=[
+                    ExecutionLegResult(
+                        venue="paradex",
+                        symbol="ARB-USD-PERP",
+                        fee_profile="pro",
+                        side="sell",
+                        target_notional=11.0,
+                        status="submitted",
+                        simulated=False,
+                        external_reference="paradex-close-1",
+                    ),
+                    ExecutionLegResult(
+                        venue="extended",
+                        symbol="ARB-USD",
+                        fee_profile="default",
+                        side="buy",
+                        target_notional=11.0,
+                        status="submitted",
+                        simulated=False,
+                        external_reference="extended-close-1",
+                    ),
+                ],
+            )
+
+    class StubCleanupPreviewService:
+        async def preview_from_execution(
+            self,
+            *,
+            entry: ExecutionJournalEntry,
+            pair_status: ExecutionPairStatus,
+            slippage_tolerance_bps: int = 10,
+        ) -> ExecutionCleanupPreview:
+            raise AssertionError("cleanup preview should not be requested when auto_cleanup=false")
+
+    class StubCleanupLiveExecutionRouter:
+        async def submit_confirmed_cleanup_preview(
+            self,
+            *,
+            paper_trade: PaperTradeEntry,
+            confirmation: CleanupPreviewConfirmationEntry,
+            executed_at: datetime | None = None,
+        ) -> ExecutionJournalEntry:
+            raise AssertionError("cleanup live router should not be used when auto_cleanup=false")
+
+    from carryme_api.app import (
+        get_account_preflight_service,
+        get_api_settings,
+        get_cleanup_live_execution_router,
+        get_cleanup_preview_service,
+        get_execution_journal_store,
+        get_execution_observation_store,
+        get_execution_order_state_service,
+        get_pair_close_live_execution_coordinator,
+        get_pair_close_preview_confirmation_store,
+        get_paper_trade_store,
+    )
+
+    coordinator = FlakyPairCloseLiveExecutionCoordinator()
+    app.dependency_overrides[get_paper_trade_store] = lambda: paper_store
+    app.dependency_overrides[get_pair_close_preview_confirmation_store] = lambda: confirmation_store
+    app.dependency_overrides[get_execution_journal_store] = lambda: execution_store
+    app.dependency_overrides[get_execution_observation_store] = lambda: observation_store
+    app.dependency_overrides[get_account_preflight_service] = lambda: StubAccountPreflightService()
+    app.dependency_overrides[get_execution_order_state_service] = (
+        lambda: StubExecutionOrderStateService()
+    )
+    app.dependency_overrides[get_pair_close_live_execution_coordinator] = lambda: coordinator
+    app.dependency_overrides[get_cleanup_preview_service] = lambda: StubCleanupPreviewService()
+    app.dependency_overrides[get_cleanup_live_execution_router] = (
+        lambda: StubCleanupLiveExecutionRouter()
+    )
+    app.dependency_overrides[get_api_settings] = lambda: ApiSettings(
+        extended_live_enabled=True,
+        extended_api_key="extended-key",
+        extended_stark_private_key="extended-stark",
+        paradex_live_enabled=True,
+        paradex_account_address="0xabc",
+        paradex_private_key="paradex-private",
+    )
+    client = TestClient(app)
+    first = client.post(
+        f"/v1/executions/live/pair/close/from-paper-trade/{paper_trade.entry_id}",
+        params={
+            "preview_hash": "pair-close-hash",
+            "poll_attempts": 1,
+            "poll_interval_seconds": 0,
+            "auto_cleanup": "false",
+        },
+    )
+    second = client.post(
+        f"/v1/executions/live/pair/close/from-paper-trade/{paper_trade.entry_id}",
+        params={
+            "preview_hash": "pair-close-hash",
+            "poll_attempts": 1,
+            "poll_interval_seconds": 0,
+            "auto_cleanup": "false",
+        },
+    )
+    app.dependency_overrides.clear()
+
+    assert first.status_code == 502
+    assert first.json()["detail"] == "transport failed after submit attempt"
+    assert second.status_code == 409
+    assert "manual reconciliation is required" in second.json()["detail"]
+    assert coordinator.calls == 1
+    saved_executions = [
+        entry
+        for entry in execution_store.list_recent(limit=10)
+        if entry.paper_trade_id == paper_trade.entry_id
+    ]
+    assert saved_executions == []
+
+
 def test_execute_extended_cleanup_endpoint_submits_confirmed_cleanup_preview(
     tmp_path: Path,
 ) -> None:
@@ -8125,6 +8451,184 @@ def test_execute_extended_cleanup_endpoint_submits_confirmed_cleanup_preview(
     assert stored_entries[0].paper_trade_id == paper_trade.entry_id
     assert stored_entries[0].preview_hash == "cleanup-hash"
     assert stored_entries[0].confirmation_entry_id == confirmation.entry_id
+
+
+def test_execute_extended_cleanup_endpoint_requires_route_approval(tmp_path: Path) -> None:
+    paper_store = PaperTradeStore(tmp_path / "paper.sqlite3")
+    paper_trade = paper_store.append(
+        PaperTradeEntry(
+            created_at=datetime(2026, 3, 29, 12, 50, tzinfo=UTC),
+            intent=FundingPairTradeIntent(
+                label="arb_extended_paradex",
+                canonical_symbol="ARB-USD-PERP",
+                source_recorded_at=datetime(2026, 3, 29, 12, 45, tzinfo=UTC),
+                one_day_net_edge_after_entry=0.0012,
+                break_even_days_entry=0.35,
+                capacity_limit_notional=1000.0,
+                target_notional=11.0,
+                capacity_fraction=0.25,
+                max_target_notional=11.0,
+                long_leg=TradeLegIntent(
+                    venue="paradex",
+                    symbol="ARB-USD-PERP",
+                    fee_profile="pro",
+                    side="buy",
+                    target_notional=11.0,
+                ),
+                short_leg=TradeLegIntent(
+                    venue="extended",
+                    symbol="ARB-USD",
+                    fee_profile="default",
+                    side="sell",
+                    target_notional=11.0,
+                ),
+            ),
+        )
+    )
+
+    class StubRouteApprovalService:
+        def require_live_approval(self, intent: FundingPairTradeIntent) -> None:
+            assert intent.label == "arb_extended_paradex"
+            raise ValueError("Live execution is blocked because this route has not been approved")
+
+    from carryme_api.app import (
+        get_account_preflight_service,
+        get_cleanup_preview_confirmation_store,
+        get_cleanup_preview_service,
+        get_execution_journal_store,
+        get_execution_order_state_service,
+        get_extended_live_execution_service,
+        get_paper_trade_store,
+    )
+
+    app.dependency_overrides[get_api_settings] = lambda: ApiSettings(
+        extended_live_enabled=True,
+        extended_api_key="extended-key",
+        extended_stark_private_key="stark-key",
+    )
+    app.dependency_overrides[get_paper_trade_store] = lambda: paper_store
+    class NoopDependency:
+        pass
+
+    noop = NoopDependency()
+    app.dependency_overrides[get_execution_journal_store] = lambda: noop
+    app.dependency_overrides[get_cleanup_preview_confirmation_store] = lambda: noop
+    app.dependency_overrides[get_execution_order_state_service] = lambda: noop
+    app.dependency_overrides[get_account_preflight_service] = lambda: noop
+    app.dependency_overrides[get_cleanup_preview_service] = lambda: noop
+    app.dependency_overrides[get_extended_live_execution_service] = lambda: noop
+    app.dependency_overrides[get_route_approval_service] = lambda: StubRouteApprovalService()
+    client = TestClient(app)
+    response = client.post(
+        f"/v1/executions/live/extended/cleanup/from-paper-trade/{paper_trade.entry_id}",
+        params={"preview_hash": "cleanup-hash"},
+    )
+    app.dependency_overrides.clear()
+
+    assert response.status_code == 409
+    assert "has not been approved" in response.json()["detail"]
+
+
+def test_release_cleanup_live_submission_reservations_fails_closed_on_partial_release() -> None:
+    from carryme_api.app import _release_cleanup_live_submission_reservations
+
+    paper_trade = PaperTradeEntry(
+        entry_id=7,
+        created_at=datetime(2026, 3, 29, 12, 50, tzinfo=UTC),
+        intent=FundingPairTradeIntent(
+            label="arb_extended_paradex",
+            canonical_symbol="ARB-USD-PERP",
+            source_recorded_at=datetime(2026, 3, 29, 12, 45, tzinfo=UTC),
+            one_day_net_edge_after_entry=0.0012,
+            break_even_days_entry=0.35,
+            capacity_limit_notional=1000.0,
+            target_notional=11.0,
+            capacity_fraction=0.25,
+            max_target_notional=11.0,
+            long_leg=TradeLegIntent(
+                venue="paradex",
+                symbol="ARB-USD-PERP",
+                fee_profile="pro",
+                side="buy",
+                target_notional=11.0,
+            ),
+            short_leg=TradeLegIntent(
+                venue="extended",
+                symbol="ARB-USD",
+                fee_profile="default",
+                side="sell",
+                target_notional=11.0,
+            ),
+        ),
+    )
+    confirmation = CleanupPreviewConfirmationEntry(
+        entry_id=13,
+        confirmed_at=datetime(2026, 3, 29, 13, 2, tzinfo=UTC),
+        paper_trade_id=paper_trade.entry_id or 0,
+        label="arb_extended_paradex",
+        preview_hash="cleanup-hash",
+        preview=ExecutionCleanupPreview(
+            execution_entry_id=5,
+            paper_trade_id=paper_trade.entry_id or 0,
+            generated_at=datetime(2026, 3, 29, 13, 1, tzinfo=UTC),
+            preview_hash="cleanup-hash",
+            reason="close_open_leg",
+            leg=VenueOrderPreview(
+                venue="extended",
+                symbol="ARB-USD",
+                fee_profile="default",
+                side="buy",
+                target_notional=11.0,
+                effective_notional=11.0,
+                quantity=123.0,
+                quantity_text="123",
+                reference_price=0.0895,
+                reference_price_source="best_ask",
+                worst_acceptable_price=0.0896,
+                worst_price_text="0.0896",
+                reduce_only=True,
+                endpoint_path_hint="/api/v1/user/order",
+                required_auth_env_vars=[],
+                auth_scheme="api key + Stark signing key",
+                payload={"symbol": "ARB-USD", "reduce_only": True},
+                notes=[],
+            ),
+            notes=[],
+        ),
+        note="operator confirmed cleanup",
+    )
+
+    class PartiallyReleasingExecutionStore:
+        def release_live_submission(
+            self,
+            *,
+            confirmation_entry_id: int,
+            preview_hash: str,
+        ) -> bool:
+            assert confirmation_entry_id == 13
+            assert preview_hash == "cleanup-hash"
+            return True
+
+        def release_cleanup_live_submission(
+            self,
+            *,
+            paper_trade_id: int,
+            preview_hash: str,
+            confirmation_entry_id: int,
+        ) -> bool:
+            assert paper_trade_id == 7
+            assert preview_hash == "cleanup-hash"
+            assert confirmation_entry_id == 13
+            return False
+
+    with pytest.raises(HTTPException, match="manual reconciliation is required") as exc_info:
+        _release_cleanup_live_submission_reservations(
+            paper_trade=paper_trade,
+            confirmation=confirmation,
+            execution_store=cast(Any, PartiallyReleasingExecutionStore()),
+        )
+
+    assert exc_info.value.status_code == 409
 
 
 def test_execute_extended_cleanup_endpoint_releases_reservations_after_value_error(
@@ -8902,6 +9406,7 @@ def test_execute_paradex_cleanup_endpoint_refreshes_stale_confirmation(
     app.dependency_overrides[get_paradex_live_execution_service] = (
         lambda: StubParadexLiveExecutionService()
     )
+    app.dependency_overrides[get_route_approval_service] = lambda: _AllowAllRouteApprovalService()
     client = TestClient(app)
     assert paper_trade.entry_id is not None
     response = client.post(

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -956,6 +956,56 @@ def test_execution_journal_store_reserves_cleanup_submission_once_per_trade(
     )
 
 
+def test_execution_journal_store_releases_uncompleted_cleanup_submission(
+    tmp_path: Path,
+) -> None:
+    store = ExecutionJournalStore(tmp_path / "history.sqlite3")
+
+    assert store.reserve_cleanup_live_submission(
+        paper_trade_id=7,
+        preview_hash="cleanup-hash",
+        confirmation_entry_id=11,
+    )
+    assert store.release_cleanup_live_submission(
+        paper_trade_id=7,
+        preview_hash="cleanup-hash",
+        confirmation_entry_id=11,
+    )
+    assert store.reserve_cleanup_live_submission(
+        paper_trade_id=7,
+        preview_hash="cleanup-hash",
+        confirmation_entry_id=12,
+    )
+
+
+def test_execution_journal_store_does_not_release_completed_cleanup_submission(
+    tmp_path: Path,
+) -> None:
+    store = ExecutionJournalStore(tmp_path / "history.sqlite3")
+
+    assert store.reserve_cleanup_live_submission(
+        paper_trade_id=7,
+        preview_hash="cleanup-hash",
+        confirmation_entry_id=11,
+    )
+    store.mark_cleanup_live_submission_completed(
+        paper_trade_id=7,
+        preview_hash="cleanup-hash",
+        execution_entry_id=99,
+    )
+
+    assert not store.release_cleanup_live_submission(
+        paper_trade_id=7,
+        preview_hash="cleanup-hash",
+        confirmation_entry_id=11,
+    )
+    assert not store.reserve_cleanup_live_submission(
+        paper_trade_id=7,
+        preview_hash="cleanup-hash",
+        confirmation_entry_id=12,
+    )
+
+
 def test_execution_journal_store_finds_entry_by_confirmation_entry_id(tmp_path: Path) -> None:
     store = ExecutionJournalStore(tmp_path / "history.sqlite3")
     saved = store.append(


### PR DESCRIPTION
## Summary
- reserve cleanup live submissions per paper trade and cleanup preview hash before live cleanup execution
- reuse an already-journaled cleanup execution when a parallel monitor creates a newer duplicate confirmation
- apply the shared cleanup reservation guard to auto-cleanup plus Extended, Paradex, and Hyperliquid cleanup endpoints

## Why
Pair-close submissions were protected by #225, but cleanup submissions still used only the confirmation entry id. Two workers can create different cleanup confirmation rows for the same `paper_trade_id` and cleanup `preview_hash`, then both submit a reduce-only cleanup order. This PR adds a paper-trade-level cleanup reservation and pre-existing execution lookup so duplicate cleanup submissions fail closed or reuse the already-journaled cleanup.

## Validation
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run pytest -q tests/test_storage.py::test_execution_journal_store_reserves_cleanup_submission_once_per_trade tests/test_api.py::test_guarded_paired_live_execution_endpoint_returns_existing_cleanup_execution`
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run pytest -q tests/test_api.py::test_guarded_paired_live_execution_endpoint_rejects_cleanup_reservation_without_execution tests/test_api.py::test_guarded_paired_live_execution_endpoint_returns_existing_cleanup_execution tests/test_storage.py::test_execution_journal_store_reserves_cleanup_submission_once_per_trade`
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run pytest -q tests/test_storage.py -k 'execution_journal_store'`
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run pytest -q tests/test_api.py -k 'cleanup_endpoint or execute_extended_cleanup_endpoint or execute_paradex_cleanup_endpoint or execute_hyperliquid_cleanup_endpoint or auto_cleanup or guarded_paired_live_execution_endpoint_returns_existing_cleanup_execution or guarded_paired_live_execution_endpoint_rejects_cleanup_reservation_without_execution or guarded_paired_live_execution_endpoint_chains_auto_cleanup_until_closed'`
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run ruff check .`
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run mypy src apps packages tests`
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run pytest` (`638 passed`)

## Stack
- Stacked on #225 / `codex/reserve-pair-close-per-paper-trade`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error handling during cleanup operations to properly release reservations when cleanup fails before execution is journaled
  * Enhanced validation and error recovery for live trading endpoints with stricter approval checks
  * Better handling of transport-layer failures during pair-close execution to prevent orphaned reservations and enable proper recovery

* **Tests**
  * Added test coverage for cleanup reservation release behavior, transport failure scenarios, and endpoint validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->