### PR TITLE
fix: reserve paired open submissions per trade

### DIFF
--- a/apps/api/src/carryme_api/app.py
+++ b/apps/api/src/carryme_api/app.py
@@ -3754,11 +3754,12 @@ def _reserve_pair_open_live_submission_or_existing(
     )
     if existing_entry is not None:
         return existing_entry
-    if not execution_store.reserve_pair_open_live_submission(
+    reservation_result = execution_store.reserve_pair_open_and_live_submission(
         paper_trade_id=paper_trade_id,
         preview_hash=confirmation.preview_hash,
         confirmation_entry_id=confirmation.entry_id,
-    ):
+    )
+    if reservation_result == "pair_open_conflict":
         existing_entry = execution_store.find_by_paper_trade_preview_hash(
             paper_trade_id=paper_trade_id,
             preview_hash=confirmation.preview_hash,
@@ -3772,10 +3773,7 @@ def _reserve_pair_open_live_submission_or_existing(
                 "and preview hash; manual reconciliation is required before retrying"
             ),
         )
-    if not execution_store.reserve_live_submission(
-        confirmation_entry_id=confirmation.entry_id,
-        preview_hash=confirmation.preview_hash,
-    ):
+    if reservation_result == "live_conflict":
         existing_entry = execution_store.find_by_confirmation(
             confirmation_entry_id=confirmation.entry_id,
             preview_hash=confirmation.preview_hash,

--- a/packages/storage/src/carryme_storage/executions.py
+++ b/packages/storage/src/carryme_storage/executions.py
@@ -374,6 +374,62 @@ class ExecutionJournalStore:
         rowcount = getattr(result, "rowcount", None)
         return isinstance(rowcount, int) and rowcount > 0
 
+    def reserve_pair_open_and_live_submission(
+        self,
+        *,
+        paper_trade_id: int,
+        preview_hash: str,
+        confirmation_entry_id: int,
+    ) -> str:
+        """Reserve paired-open and confirmation submission slots atomically."""
+
+        self.initialize()
+        if paper_trade_id < 1:
+            raise ValueError("paper_trade_id must be positive")
+        if confirmation_entry_id < 1:
+            raise ValueError("confirmation_entry_id must be positive")
+        normalized_preview_hash = preview_hash.strip()
+        if not normalized_preview_hash:
+            raise ValueError("preview_hash must be non-empty")
+        with self.database.begin() as connection:
+            pair_open_result = connection.execute(
+                """
+                INSERT INTO pair_open_live_submission_reservations (
+                    paper_trade_id,
+                    preview_hash,
+                    confirmation_entry_id
+                ) VALUES (?, ?, ?)
+                ON CONFLICT(paper_trade_id, preview_hash) DO NOTHING
+                """,
+                (paper_trade_id, normalized_preview_hash, confirmation_entry_id),
+            )
+            pair_open_rowcount = getattr(pair_open_result, "rowcount", None)
+            if not (isinstance(pair_open_rowcount, int) and pair_open_rowcount > 0):
+                return "pair_open_conflict"
+
+            live_result = connection.execute(
+                """
+                INSERT INTO live_submission_reservations (
+                    confirmation_entry_id,
+                    preview_hash
+                ) VALUES (?, ?)
+                ON CONFLICT(confirmation_entry_id, preview_hash) DO NOTHING
+                """,
+                (confirmation_entry_id, normalized_preview_hash),
+            )
+            live_rowcount = getattr(live_result, "rowcount", None)
+            if isinstance(live_rowcount, int) and live_rowcount > 0:
+                return "reserved"
+
+            connection.execute(
+                """
+                DELETE FROM pair_open_live_submission_reservations
+                WHERE paper_trade_id = ? AND preview_hash = ? AND confirmation_entry_id = ?
+                """,
+                (paper_trade_id, normalized_preview_hash, confirmation_entry_id),
+            )
+            return "live_conflict"
+
     def mark_pair_open_live_submission_completed(
         self,
         *,

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -828,7 +828,6 @@ def test_execution_journal_store_reserves_pair_close_submission_once_per_trade(
         confirmation_entry_id=14,
     )
 
-
 def test_execution_journal_store_releases_uncompleted_pair_close_submission(
     tmp_path: Path,
 ) -> None:
@@ -900,8 +899,6 @@ def test_execution_journal_store_does_not_release_pair_close_submission_for_mism
         preview_hash="pair-close-hash",
         confirmation_entry_id=13,
     )
-
-
 def test_execution_journal_store_reserves_pair_open_submission_once_per_trade(
     tmp_path: Path,
 ) -> None:
@@ -926,6 +923,30 @@ def test_execution_journal_store_reserves_pair_open_submission_once_per_trade(
         paper_trade_id=8,
         preview_hash="preview-hash",
         confirmation_entry_id=14,
+    )
+
+
+def test_execution_journal_store_rolls_back_pair_open_when_live_reservation_conflicts(
+    tmp_path: Path,
+) -> None:
+    store = ExecutionJournalStore(tmp_path / "history.sqlite3")
+
+    assert store.reserve_live_submission(
+        confirmation_entry_id=11,
+        preview_hash="preview-hash",
+    )
+    assert (
+        store.reserve_pair_open_and_live_submission(
+            paper_trade_id=7,
+            preview_hash="preview-hash",
+            confirmation_entry_id=11,
+        )
+        == "live_conflict"
+    )
+    assert store.reserve_pair_open_live_submission(
+        paper_trade_id=7,
+        preview_hash="preview-hash",
+        confirmation_entry_id=12,
     )
 
 


### PR DESCRIPTION
## Summary
- reserve paired live open submissions per paper trade and open preview hash before paired open execution
- block duplicate paired opens when a parallel launcher creates a newer duplicate confirmation for the same preview
- mark paired-open reservations completed alongside the existing confirmation-level reservation

## Why
The stable launch stack now reserves launch snapshots, pair-close submissions, and cleanup submissions. The paired open path still relied only on `confirmation_entry_id + preview_hash`, so a duplicate confirmation row for the same `paper_trade_id` and `preview_hash` could bypass the reservation and submit a second live hedge open. This PR adds the same paper-trade-level guard to paired opens.

## Validation
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run pytest -q tests/test_storage.py::test_execution_journal_store_reserves_pair_open_submission_once_per_trade tests/test_api.py::test_guarded_paired_live_execution_endpoint_rejects_duplicate_retry`
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run pytest -q tests/test_storage.py -k 'execution_journal_store'`
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run pytest -q tests/test_api.py -k 'guarded_paired_live_execution_endpoint or execute_saved_paper_trade_as_pair or paired_live'`
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run ruff check .`
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run mypy src apps packages tests`
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run pytest` (`639 passed`)

## Stack
- Stacked on #226 / `codex/reserve-cleanup-submissions-per-trade`
