### PR TITLE
fix: expire stale stable launch reservations

### DIFF
--- a/apps/worker/src/carryme_worker/poller.py
+++ b/apps/worker/src/carryme_worker/poller.py
@@ -3574,6 +3574,7 @@ async def launch_latest_stable_canary_once(
                 launch_ready_snapshot_id=launch_ready_snapshot_id,
                 owner_id=owner_id,
                 reserved_at=datetime.now(UTC),
+                max_age_seconds=settings.stable_canary_launch_reservation_ttl_seconds,
             )
             if not renewed:
                 raise HTTPException(

--- a/packages/storage/src/carryme_storage/stable_canary_launches.py
+++ b/packages/storage/src/carryme_storage/stable_canary_launches.py
@@ -75,6 +75,12 @@ class StableCanaryLaunchStore:
                 ON stable_canary_launch_reservations(label)
                 """
             )
+            connection.execute(
+                """
+                CREATE INDEX IF NOT EXISTS idx_stable_canary_launch_reservations_reserved_at
+                ON stable_canary_launch_reservations(reserved_at)
+                """
+            )
 
     def append(self, record: StableCanaryLaunchRecord) -> StableCanaryLaunchRecord:
         """Append one stable canary launch record."""
@@ -250,6 +256,7 @@ class StableCanaryLaunchStore:
         launch_ready_snapshot_id: int,
         owner_id: str,
         reserved_at: datetime,
+        max_age_seconds: int | None = None,
     ) -> bool:
         """Renew one snapshot reservation only if the caller still owns its lease."""
 
@@ -261,21 +268,45 @@ class StableCanaryLaunchStore:
             raise ValueError("owner_id must be non-empty")
         if reserved_at.tzinfo is None or reserved_at.utcoffset() is None:
             raise ValueError("reserved_at must be timezone-aware")
+        if max_age_seconds is not None and max_age_seconds <= 0:
+            raise ValueError("max_age_seconds must be positive")
 
         normalized_reserved_at = reserved_at.astimezone(UTC)
+        stale_before = (
+            normalized_reserved_at - timedelta(seconds=max_age_seconds)
+            if max_age_seconds is not None
+            else None
+        )
         with self.database.begin() as connection:
-            result = connection.execute(
-                """
-                UPDATE stable_canary_launch_reservations
-                SET reserved_at = ?
-                WHERE launch_ready_snapshot_id = ? AND owner_id = ?
-                """,
-                (
-                    normalized_reserved_at.isoformat(),
-                    launch_ready_snapshot_id,
-                    normalized_owner_id,
-                ),
-            )
+            if stale_before is None:
+                result = connection.execute(
+                    """
+                    UPDATE stable_canary_launch_reservations
+                    SET reserved_at = ?
+                    WHERE launch_ready_snapshot_id = ? AND owner_id = ?
+                    """,
+                    (
+                        normalized_reserved_at.isoformat(),
+                        launch_ready_snapshot_id,
+                        normalized_owner_id,
+                    ),
+                )
+            else:
+                result = connection.execute(
+                    """
+                    UPDATE stable_canary_launch_reservations
+                    SET reserved_at = ?
+                    WHERE launch_ready_snapshot_id = ?
+                      AND owner_id = ?
+                      AND reserved_at > ?
+                    """,
+                    (
+                        normalized_reserved_at.isoformat(),
+                        launch_ready_snapshot_id,
+                        normalized_owner_id,
+                        stale_before.isoformat(),
+                    ),
+                )
 
         rowcount = getattr(result, "rowcount", None)
         return isinstance(rowcount, int) and rowcount > 0

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -3328,7 +3328,6 @@ def test_stable_canary_launch_store_reserves_snapshot_launch_once(
     assert first_reserved is True
     assert second_reserved is False
 
-
 def test_stable_canary_launch_store_prunes_expired_snapshot_reservations(
     tmp_path: Path,
 ) -> None:
@@ -3359,8 +3358,6 @@ def test_stable_canary_launch_store_prunes_expired_snapshot_reservations(
         ).fetchall()
 
     assert [int(row[0]) for row in rows] == [10]
-
-
 def test_stable_canary_launch_store_reclaims_stale_snapshot_launch_reservation(
     tmp_path: Path,
 ) -> None:
@@ -3377,6 +3374,12 @@ def test_stable_canary_launch_store_reclaims_stale_snapshot_launch_reservation(
         launch_ready_snapshot_id=9,
         label="arb_extended_paradex",
         reserved_at=reserved_at + timedelta(seconds=59),
+        max_age_seconds=60,
+    )
+    assert not store.reserve_snapshot_launch(
+        launch_ready_snapshot_id=9,
+        label="arb_extended_paradex",
+        reserved_at=reserved_at + timedelta(seconds=60),
         max_age_seconds=60,
     )
     assert store.reserve_snapshot_launch(
@@ -3412,11 +3415,35 @@ def test_stable_canary_launch_store_rejects_lost_reservation_owner(
         launch_ready_snapshot_id=9,
         owner_id="worker-a",
         reserved_at=reserved_at + timedelta(seconds=62),
+        max_age_seconds=60,
     )
     assert store.renew_snapshot_launch_reservation(
         launch_ready_snapshot_id=9,
         owner_id="worker-b",
         reserved_at=reserved_at + timedelta(seconds=63),
+        max_age_seconds=60,
+    )
+
+
+def test_stable_canary_launch_store_rejects_expired_self_renewal(
+    tmp_path: Path,
+) -> None:
+    store = StableCanaryLaunchStore(tmp_path / "history.sqlite3")
+    reserved_at = datetime(2026, 4, 4, 10, 2, tzinfo=UTC)
+
+    assert store.reserve_snapshot_launch(
+        launch_ready_snapshot_id=9,
+        label="arb_extended_paradex",
+        reserved_at=reserved_at,
+        max_age_seconds=60,
+        owner_id="worker-a",
+    )
+
+    assert not store.renew_snapshot_launch_reservation(
+        launch_ready_snapshot_id=9,
+        owner_id="worker-a",
+        reserved_at=reserved_at + timedelta(seconds=61),
+        max_age_seconds=60,
     )
 
 

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -270,6 +270,10 @@ def _clear_worker_env(monkeypatch: pytest.MonkeyPatch) -> None:
         raising=False,
     )
     monkeypatch.delenv(
+        "CARRYME_WORKER_STABLE_CANARY_LAUNCH_RESERVATION_RETENTION_SECONDS",
+        raising=False,
+    )
+    monkeypatch.delenv(
         "CARRYME_WORKER_STABLE_CANARY_LAUNCH_MIN_EXECUTION_QUALITY_SCORE",
         raising=False,
     )
@@ -357,6 +361,7 @@ def test_worker_defaults(monkeypatch: pytest.MonkeyPatch) -> None:
     assert settings.execution_auto_pair_close_timeout_seconds == 30.0
     assert settings.stable_canary_launch_shadow_mode is False
     assert settings.stable_canary_launch_close_position is True
+    assert settings.stable_canary_launch_reservation_retention_seconds == 86_400
     assert settings.stable_launch_ready_min_edge_retention_ratio == 0.7
     assert settings.stable_launch_ready_max_entry_break_even_funding_windows == 6.0
     assert settings.stable_launch_ready_max_round_trip_break_even_funding_windows == 12.0
@@ -9610,6 +9615,196 @@ def test_launch_latest_stable_canary_once_returns_launched_summary(
     assert len(launch_records) == 1
     assert launch_records[0].paper_trade_id == 17
     assert launch_records[0].launch_ready_snapshot_id == 9
+
+
+def test_launch_latest_stable_canary_once_reclaims_stale_snapshot_reservation(
+    tmp_path: Path,
+) -> None:
+    settings = WorkerSettings(
+        database_path=str(tmp_path / "history.sqlite3"),
+        stable_canary_launch_reservation_ttl_seconds=60,
+        extended_live_enabled=True,
+        extended_api_key="extended-key",
+        extended_stark_private_key="extended-secret",
+        paradex_live_enabled=True,
+        paradex_account_address="0x123",
+        paradex_private_key="0x456",
+    )
+    approval, candidate, snapshot, stability = _build_stable_launch_test_snapshot(
+        label="arb_extended_paradex",
+        launch_ready_snapshot_id=9,
+        approved_snapshot_id=8,
+        suggested_canary_notional=11.0,
+    )
+    approved_store = ApprovedCanaryStore(settings.database_path)
+    persisted_snapshot = approved_store.append(snapshot.approved_snapshot)
+    snapshot = snapshot.model_copy(update={"approved_snapshot": persisted_snapshot})
+    stability = stability.model_copy(update={"snapshot": snapshot})
+    launch_store = StableCanaryLaunchStore(settings.database_path)
+    now = datetime(2026, 4, 4, 10, 2, tzinfo=UTC)
+    assert launch_store.reserve_snapshot_launch(
+        launch_ready_snapshot_id=9,
+        label="arb_extended_paradex",
+        reserved_at=now - timedelta(seconds=61),
+        max_age_seconds=60,
+    )
+
+    class StubLifecycleResult:
+        def __init__(self) -> None:
+            self.paper_trade = PaperTradeEntry(
+                entry_id=17,
+                created_at=now,
+                intent=FundingPairTradeIntent(
+                    label="arb_extended_paradex",
+                    canonical_symbol="ARB-USD-PERP",
+                    source_recorded_at=datetime(2026, 4, 4, 10, 1, tzinfo=UTC),
+                    one_day_net_edge_after_entry=0.00355,
+                    break_even_days_entry=0.2,
+                    capacity_limit_notional=900.0,
+                    target_notional=11.0,
+                    capacity_fraction=11.0 / 900.0,
+                    max_target_notional=11.0,
+                    long_leg=TradeLegIntent(
+                        venue="paradex",
+                        symbol="ARB-USD-PERP",
+                        fee_profile="pro_fastfills",
+                        side="buy",
+                        target_notional=11.0,
+                    ),
+                    short_leg=TradeLegIntent(
+                        venue="extended",
+                        symbol="ARB-USD",
+                        fee_profile="default",
+                        side="sell",
+                        target_notional=11.0,
+                    ),
+                ),
+                note="worker launch",
+            )
+            self.final_pair_status = ExecutionPairStatus(
+                execution_entry_id=31,
+                paper_trade_id=17,
+                preview_hash="preview",
+                derived_state="closed",
+                recommended_action="no_action",
+                order_state=ExecutionOrderState(
+                    execution_entry_id=31,
+                    paper_trade_id=17,
+                    preview_hash="preview",
+                    legs=[],
+                    notes=[],
+                ),
+                reconciliation=ExecutionReconciliation(
+                    execution_entry_id=31,
+                    paper_trade_id=17,
+                    preview_hash="preview",
+                    status="accepted",
+                    recommended_action="no_action",
+                    matched_all_leg_symbols=True,
+                    venues=[],
+                    notes=[],
+                ),
+                notes=[],
+            )
+
+    async def run_stub_lifecycle(**_: object) -> StubLifecycleResult:
+        return StubLifecycleResult()
+
+    with pytest.MonkeyPatch.context() as monkeypatch:
+        monkeypatch.setattr(
+            "carryme_worker.poller._build_launch_ready_canary_stability",
+            lambda **_: stability,
+        )
+        monkeypatch.setattr(
+            "carryme_worker.poller._select_latest_launch_ready_canary_snapshot",
+            lambda **_: (snapshot, candidate, approval),
+        )
+        monkeypatch.setattr(
+            "carryme_worker.poller._run_guarded_canary_lifecycle",
+            run_stub_lifecycle,
+        )
+        summary = asyncio.run(
+            launch_latest_stable_canary_once(
+                settings,
+                launch_store=launch_store,
+                approved_store=approved_store,
+                now=now,
+            )
+        )
+
+    assert summary.status == "launched"
+    assert summary.label == "arb_extended_paradex"
+    assert summary.launch_ready_snapshot_id == 9
+    assert summary.paper_trade_id == 17
+
+
+def test_launch_latest_stable_canary_once_aborts_when_reservation_owner_is_lost(
+    tmp_path: Path,
+) -> None:
+    settings = WorkerSettings(
+        database_path=str(tmp_path / "history.sqlite3"),
+        stable_canary_launch_reservation_ttl_seconds=60,
+        extended_live_enabled=True,
+        extended_api_key="extended-key",
+        extended_stark_private_key="extended-secret",
+        paradex_live_enabled=True,
+        paradex_account_address="0x123",
+        paradex_private_key="0x456",
+    )
+    approval, candidate, snapshot, stability = _build_stable_launch_test_snapshot(
+        label="arb_extended_paradex",
+        launch_ready_snapshot_id=9,
+        approved_snapshot_id=8,
+        suggested_canary_notional=11.0,
+    )
+    approved_store = ApprovedCanaryStore(settings.database_path)
+    persisted_snapshot = approved_store.append(snapshot.approved_snapshot)
+    snapshot = snapshot.model_copy(update={"approved_snapshot": persisted_snapshot})
+    stability = stability.model_copy(update={"snapshot": snapshot})
+    launch_store = StableCanaryLaunchStore(settings.database_path)
+    now = datetime(2026, 4, 4, 10, 2, tzinfo=UTC)
+
+    async def run_stub_lifecycle(**kwargs: object) -> object:
+        before_open_submission = cast(Any, kwargs["before_open_submission"])
+        assert launch_store.reserve_snapshot_launch(
+            launch_ready_snapshot_id=9,
+            label="arb_extended_paradex",
+            reserved_at=now + timedelta(seconds=61),
+            max_age_seconds=60,
+            owner_id="stealing-worker",
+        )
+        await before_open_submission()
+        pytest.fail("lost reservation ownership must block before live submission")
+
+    with pytest.MonkeyPatch.context() as monkeypatch:
+        monkeypatch.setattr(
+            "carryme_worker.poller._build_launch_ready_canary_stability",
+            lambda **_: stability,
+        )
+        monkeypatch.setattr(
+            "carryme_worker.poller._select_latest_launch_ready_canary_snapshot",
+            lambda **_: (snapshot, candidate, approval),
+        )
+        monkeypatch.setattr(
+            "carryme_worker.poller._run_guarded_canary_lifecycle",
+            run_stub_lifecycle,
+        )
+        summary = asyncio.run(
+            launch_latest_stable_canary_once(
+                settings,
+                launch_store=launch_store,
+                approved_store=approved_store,
+                now=now,
+            )
+        )
+
+    assert summary.status == "skipped"
+    assert summary.label == "arb_extended_paradex"
+    assert summary.launch_ready_snapshot_id == 9
+    assert summary.detail == (
+        "Stable launch reservation ownership was lost before live submission"
+    )
+    assert launch_store.list_recent(limit=10) == []
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- add owner-token leases to stable launch-ready snapshot reservations
- renew the stable-launch reservation immediately before the guarded live open submission and abort if ownership was lost
- reclaim stale same-snapshot reservations with a TTL while cleaning abandoned old reservation rows via a separate retention window
- migrate existing reservation tables with `owner_id` and wire Render defaults for `carryme-stable-launch`

## Why
Stable launch needs duplicate-worker protection, but a plain TTL delete can let another worker steal a reservation while the first worker is still pre-submit. This PR turns the reservation into a lease: retries can recover from stale pre-submit failures, but the original worker must still own and renew the lease immediately before live order submission.

## Validation
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run pytest -q tests/test_storage.py::test_stable_canary_launch_store_reserves_snapshot_launch_once tests/test_storage.py::test_stable_canary_launch_store_reclaims_stale_snapshot_launch_reservation tests/test_storage.py::test_stable_canary_launch_store_rejects_lost_reservation_owner tests/test_storage.py::test_stable_canary_launch_store_cleans_abandoned_reservations tests/test_worker.py::test_launch_latest_stable_canary_once_reclaims_stale_snapshot_reservation tests/test_worker.py::test_launch_latest_stable_canary_once_aborts_when_reservation_owner_is_lost`
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run pytest -q tests/test_storage.py -k 'stable_canary_launch_store'`
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run pytest -q tests/test_worker.py -k 'stable_canary_launch'`
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run pytest -q tests/test_worker.py::test_worker_defaults`
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run ruff check .`
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run mypy src apps packages tests`
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run pytest -q`
- `git diff --check`

## Stack
- Stacked on #227 / `codex/reserve-paired-open-submissions-per-trade`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced stable launch reservation management with ownership tracking and automatic renewal before submission.
  * Automatic cleanup of stale or expired reservations to improve system reliability.
  * Added validation to enforce consistent reservation time configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->