### PR TITLE
fix: index pair-close preview execution lookup

### DIFF
--- a/apps/api/src/carryme_api/app.py
+++ b/apps/api/src/carryme_api/app.py
@@ -409,14 +409,20 @@ def get_automation_readiness_checked_at() -> datetime:
     return datetime.now(UTC)
 
 
-async def _resolve_api_settings_for_request(request: Request) -> ApiSettings:
-    """Resolve API settings while honoring FastAPI dependency overrides in tests."""
+async def _resolve_api_settings_for_app(app: FastAPI) -> ApiSettings:
+    """Resolve API settings while honoring FastAPI dependency overrides."""
 
-    resolver = request.app.dependency_overrides.get(get_api_settings) or get_api_settings
+    resolver = app.dependency_overrides.get(get_api_settings) or get_api_settings
     settings = resolver()
     if inspect.isawaitable(settings):
         settings = await cast(Awaitable[ApiSettings], settings)
     return cast(ApiSettings, settings)
+
+
+async def _resolve_api_settings_for_request(request: Request) -> ApiSettings:
+    """Resolve API settings while honoring FastAPI dependency overrides in tests."""
+
+    return await _resolve_api_settings_for_app(request.app)
 
 
 def _operator_auth_error(status_code: int, detail: str) -> JSONResponse:
@@ -4120,7 +4126,7 @@ def create_app() -> FastAPI:
     async def lifespan(_: FastAPI) -> AsyncIterator[None]:
         """Warm the shared execution journal store before serving live requests."""
 
-        settings = get_api_settings()
+        settings = await _resolve_api_settings_for_app(app)
         _execution_journal_store_for_path(settings.database_path).initialize()
         yield
 

--- a/apps/api/src/carryme_api/app.py
+++ b/apps/api/src/carryme_api/app.py
@@ -8,7 +8,8 @@ import logging
 import math
 import os
 import secrets
-from collections.abc import Awaitable, Callable
+from collections.abc import AsyncIterator, Awaitable, Callable
+from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from functools import lru_cache
@@ -4115,7 +4116,15 @@ async def _execute_guarded_pair_close_from_confirmation(
 def create_app() -> FastAPI:
     """Create the FastAPI application."""
 
-    app = FastAPI(title="carryme", version=APP_VERSION)
+    @asynccontextmanager
+    async def lifespan(_: FastAPI) -> AsyncIterator[None]:
+        """Warm the shared execution journal store before serving live requests."""
+
+        settings = get_api_settings()
+        _execution_journal_store_for_path(settings.database_path).initialize()
+        yield
+
+    app = FastAPI(title="carryme", version=APP_VERSION, lifespan=lifespan)
 
     @app.middleware("http")
     async def require_operator_auth_for_mutations(

--- a/apps/api/src/carryme_api/app.py
+++ b/apps/api/src/carryme_api/app.py
@@ -13,6 +13,7 @@ from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from functools import lru_cache
+from pathlib import Path
 from typing import Annotated, Any, cast
 
 import httpx
@@ -151,7 +152,11 @@ from carryme_storage import (
     SystemStateAlertStore,
     WatchlistStore,
 )
-from carryme_storage.db import DEFAULT_DATABASE_PING_TIMEOUT_SECONDS, Database
+from carryme_storage.db import (
+    DEFAULT_DATABASE_PING_TIMEOUT_SECONDS,
+    Database,
+    normalize_database_url,
+)
 from fastapi import Body, Depends, FastAPI, HTTPException, Query, Request, Response
 from fastapi.responses import HTMLResponse, JSONResponse
 from pydantic import BaseModel, Field
@@ -428,9 +433,19 @@ async def _resolve_api_settings_for_request(request: Request) -> ApiSettings:
 def _should_prewarm_execution_journal(settings: ApiSettings) -> bool:
     """Return whether startup should prewarm the execution journal store."""
 
+    def _normalized_database_target(database: str) -> str:
+        normalized = normalize_database_url(database.strip())
+        sqlite_prefix = "sqlite:///"
+        if normalized == f"{sqlite_prefix}:memory:":
+            return normalized
+        if normalized.startswith(sqlite_prefix):
+            return f"{sqlite_prefix}{Path(normalized.removeprefix(sqlite_prefix)).resolve()}"
+        return normalized
+
     return not (
         settings.environment == "development"
-        and settings.database_path == "data/carryme.sqlite3"
+        and _normalized_database_target(settings.database_path)
+        == _normalized_database_target("data/carryme.sqlite3")
     )
 
 

--- a/apps/api/src/carryme_api/app.py
+++ b/apps/api/src/carryme_api/app.py
@@ -425,6 +425,15 @@ async def _resolve_api_settings_for_request(request: Request) -> ApiSettings:
     return await _resolve_api_settings_for_app(request.app)
 
 
+def _should_prewarm_execution_journal(settings: ApiSettings) -> bool:
+    """Return whether startup should prewarm the execution journal store."""
+
+    return not (
+        settings.environment == "development"
+        and settings.database_path == "data/carryme.sqlite3"
+    )
+
+
 def _operator_auth_error(status_code: int, detail: str) -> JSONResponse:
     headers = {"WWW-Authenticate": "Bearer"} if status_code == 401 else None
     return JSONResponse(status_code=status_code, content={"detail": detail}, headers=headers)
@@ -4123,11 +4132,12 @@ def create_app() -> FastAPI:
     """Create the FastAPI application."""
 
     @asynccontextmanager
-    async def lifespan(_: FastAPI) -> AsyncIterator[None]:
+    async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         """Warm the shared execution journal store before serving live requests."""
 
         settings = await _resolve_api_settings_for_app(app)
-        _execution_journal_store_for_path(settings.database_path).initialize()
+        if _should_prewarm_execution_journal(settings):
+            _execution_journal_store_for_path(settings.database_path).initialize()
         yield
 
     app = FastAPI(title="carryme", version=APP_VERSION, lifespan=lifespan)

--- a/packages/storage/src/carryme_storage/executions.py
+++ b/packages/storage/src/carryme_storage/executions.py
@@ -107,6 +107,17 @@ class ExecutionJournalStore:
                 )
                 connection.execute(
                     """
+                    CREATE INDEX IF NOT EXISTS idx_execution_journal_entries_paper_trade_preview
+                    ON execution_journal_entries(
+                        paper_trade_id,
+                        preview_hash,
+                        executed_at DESC,
+                        id DESC
+                    )
+                    """
+                )
+                connection.execute(
+                    """
                     CREATE TABLE IF NOT EXISTS live_submission_reservations (
                         confirmation_entry_id INTEGER NOT NULL,
                         preview_hash TEXT NOT NULL,

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -163,6 +163,30 @@ def test_app_startup_prewarms_execution_store_with_overridden_settings(
     }
 
 
+def test_app_startup_skips_prewarm_for_default_development_database(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    seen: dict[str, object] = {}
+
+    class StubExecutionStore:
+        def initialize(self) -> None:
+            seen["initialized"] = True
+
+    def build_store(database_path: str) -> StubExecutionStore:
+        seen["database_path"] = database_path
+        return StubExecutionStore()
+
+    get_api_settings.cache_clear()
+    monkeypatch.setattr(app_module, "_execution_journal_store_for_path", build_store)
+    try:
+        with TestClient(app):
+            pass
+    finally:
+        get_api_settings.cache_clear()
+
+    assert seen == {}
+
+
 def test_app_startup_fails_closed_when_execution_store_prewarm_fails(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -132,6 +132,61 @@ def test_versioned_health_endpoint() -> None:
     assert response.json()["status"] == "ok"
 
 
+def test_app_startup_prewarms_execution_store_with_overridden_settings(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    seen: dict[str, object] = {}
+
+    class StubExecutionStore:
+        def initialize(self) -> None:
+            seen["initialized"] = True
+
+    async def override_settings() -> ApiSettings:
+        return ApiSettings(database_path=str(tmp_path / "override.sqlite3"))
+
+    def build_store(database_path: str) -> StubExecutionStore:
+        seen["database_path"] = database_path
+        return StubExecutionStore()
+
+    monkeypatch.setattr(app_module, "_execution_journal_store_for_path", build_store)
+    app.dependency_overrides[get_api_settings] = override_settings
+    try:
+        with TestClient(app):
+            pass
+    finally:
+        app.dependency_overrides.clear()
+
+    assert seen == {
+        "database_path": str(tmp_path / "override.sqlite3"),
+        "initialized": True,
+    }
+
+
+def test_app_startup_fails_closed_when_execution_store_prewarm_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def override_settings() -> ApiSettings:
+        return ApiSettings(database_path=str(tmp_path / "blocked.sqlite3"))
+
+    class FailingExecutionStore:
+        def initialize(self) -> None:
+            raise RuntimeError("prewarm failed")
+
+    monkeypatch.setattr(
+        app_module,
+        "_execution_journal_store_for_path",
+        lambda database_path: FailingExecutionStore(),
+    )
+    app.dependency_overrides[get_api_settings] = override_settings
+    try:
+        with pytest.raises(RuntimeError, match="prewarm failed"), TestClient(app):
+            pass
+    finally:
+        app.dependency_overrides.clear()
+
+
 def test_operator_auth_does_not_gate_get_requests(tmp_path: Path) -> None:
     app.dependency_overrides[get_api_settings] = lambda: ApiSettings(
         database_path=str(tmp_path / "history.sqlite3"),

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -187,6 +187,33 @@ def test_app_startup_skips_prewarm_for_default_development_database(
     assert seen == {}
 
 
+def test_app_startup_skips_prewarm_for_equivalent_default_development_database(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    seen: dict[str, object] = {}
+
+    class StubExecutionStore:
+        def initialize(self) -> None:
+            seen["initialized"] = True
+
+    async def override_settings() -> ApiSettings:
+        return ApiSettings(database_path="./data/carryme.sqlite3")
+
+    def build_store(database_path: str) -> StubExecutionStore:
+        seen["database_path"] = database_path
+        return StubExecutionStore()
+
+    monkeypatch.setattr(app_module, "_execution_journal_store_for_path", build_store)
+    app.dependency_overrides[get_api_settings] = override_settings
+    try:
+        with TestClient(app):
+            pass
+    finally:
+        app.dependency_overrides.clear()
+
+    assert seen == {}
+
+
 def test_app_startup_fails_closed_when_execution_store_prewarm_fails(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary
- pre-check existing pair-close executions by `paper_trade_id + preview_hash` before live readiness/submission
- prevent duplicate live pair-close submissions when a legacy execution exists but the newer reservation row is missing
- extend the duplicate pair-close retry test to simulate the missing-reservation legacy state

## Why
Recent reservation fixes protect new pair-close submissions, but older journaled executions may not have a matching `pair_close_live_submission_reservations` row. Without a journal pre-check, a retry with the same paper trade and preview hash can submit another live close.

## Validation
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run pytest -q tests/test_api.py::test_guarded_pair_close_endpoint_rejects_duplicate_retry`
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run pytest -q tests/test_api.py -k 'pair_close'`
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run ruff check apps/api/src/carryme_api/app.py tests/test_api.py`
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run mypy src apps packages tests`
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run pytest -q`
- `git diff --check`

## Stack
- Stacked on #228 / `codex/expire-stable-launch-reservations`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved execution-related query performance via a new database index.
  * Refined application startup and initialization flow for more predictable startup behavior.
* **Bug Fixes**
  * Startup now fails fast if pre-initialization of the execution store encounters an error.
* **Tests**
  * Added startup tests covering prewarming behavior, default-skip cases, and failure handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->