### PR TITLE
fix: bundle stable launch activation safety

### DIFF
--- a/apps/api/src/carryme_api/app.py
+++ b/apps/api/src/carryme_api/app.py
@@ -2013,6 +2013,108 @@ def _resolve_cleanup_confirmation_for_live_submit(
     )
 
 
+def _effective_cleanup_submission_paper_trade_id(
+    *,
+    paper_trade: PaperTradeEntry,
+    confirmation: CleanupPreviewConfirmationEntry,
+) -> int:
+    paper_trade_id = paper_trade.entry_id or confirmation.paper_trade_id
+    if paper_trade_id < 1:
+        raise HTTPException(
+            status_code=500,
+            detail="paper_trade_id is required before cleanup live submission",
+        )
+    return paper_trade_id
+
+
+def _reserve_cleanup_live_submission_or_existing(
+    *,
+    paper_trade: PaperTradeEntry,
+    confirmation: CleanupPreviewConfirmationEntry,
+    execution_store: ExecutionJournalStore,
+) -> ExecutionJournalEntry | None:
+    if confirmation.entry_id is None:
+        raise HTTPException(
+            status_code=500,
+            detail="Cleanup preview confirmation entry_id is required before live submission",
+        )
+    paper_trade_id = _effective_cleanup_submission_paper_trade_id(
+        paper_trade=paper_trade,
+        confirmation=confirmation,
+    )
+    existing_entry = execution_store.find_by_paper_trade_preview_hash(
+        paper_trade_id=paper_trade_id,
+        preview_hash=confirmation.preview_hash,
+    )
+    if existing_entry is not None:
+        return existing_entry
+    if not execution_store.reserve_cleanup_live_submission(
+        paper_trade_id=paper_trade_id,
+        preview_hash=confirmation.preview_hash,
+        confirmation_entry_id=confirmation.entry_id,
+    ):
+        existing_entry = execution_store.find_by_paper_trade_preview_hash(
+            paper_trade_id=paper_trade_id,
+            preview_hash=confirmation.preview_hash,
+        )
+        if existing_entry is not None:
+            return existing_entry
+        raise HTTPException(
+            status_code=409,
+            detail=(
+                "Cleanup live submission was already reserved for this paper trade and "
+                "preview without a matching journaled execution; manual reconciliation "
+                "is required before retrying"
+            ),
+        )
+    if not execution_store.reserve_live_submission(
+        confirmation_entry_id=confirmation.entry_id,
+        preview_hash=confirmation.preview_hash,
+    ):
+        existing_entry = execution_store.find_by_confirmation(
+            confirmation_entry_id=confirmation.entry_id,
+            preview_hash=confirmation.preview_hash,
+        )
+        if existing_entry is not None:
+            return existing_entry
+        raise HTTPException(
+            status_code=409,
+            detail=(
+                "Cleanup live submission was already reserved without a matching "
+                "journaled execution; manual reconciliation is required before retrying"
+            ),
+        )
+    return None
+
+
+def _mark_cleanup_live_submission_completed(
+    *,
+    paper_trade: PaperTradeEntry,
+    confirmation: CleanupPreviewConfirmationEntry,
+    execution_store: ExecutionJournalStore,
+    execution_entry_id: int,
+) -> None:
+    if confirmation.entry_id is None:
+        raise HTTPException(
+            status_code=500,
+            detail="Cleanup preview confirmation entry_id is required before live submission",
+        )
+    paper_trade_id = _effective_cleanup_submission_paper_trade_id(
+        paper_trade=paper_trade,
+        confirmation=confirmation,
+    )
+    execution_store.mark_live_submission_completed(
+        confirmation_entry_id=confirmation.entry_id,
+        preview_hash=confirmation.preview_hash,
+        execution_entry_id=execution_entry_id,
+    )
+    execution_store.mark_cleanup_live_submission_completed(
+        paper_trade_id=paper_trade_id,
+        preview_hash=confirmation.preview_hash,
+        execution_entry_id=execution_entry_id,
+    )
+
+
 async def _observe_pair_status_for_execution(
     *,
     paper_trade: PaperTradeEntry,
@@ -2164,29 +2266,12 @@ async def _run_guarded_auto_cleanup_sequence(
                     note=confirmation_note,
                 )
             )
-        if cleanup_confirmation.entry_id is None:
-            raise HTTPException(
-                status_code=500,
-                detail="Cleanup preview confirmation entry_id is required before live submission",
-            )
-
-        if not execution_store.reserve_live_submission(
-            confirmation_entry_id=cleanup_confirmation.entry_id,
-            preview_hash=cleanup_confirmation.preview_hash,
-        ):
-            existing_entry = execution_store.find_by_confirmation(
-                confirmation_entry_id=cleanup_confirmation.entry_id,
-                preview_hash=cleanup_confirmation.preview_hash,
-            )
-            if existing_entry is None:
-                raise HTTPException(
-                    status_code=409,
-                    detail=(
-                        "Cleanup live submission was already reserved without a matching "
-                        "journaled execution; manual reconciliation is required before "
-                        "retrying"
-                    ),
-                )
+        existing_entry = _reserve_cleanup_live_submission_or_existing(
+            paper_trade=paper_trade,
+            confirmation=cleanup_confirmation,
+            execution_store=execution_store,
+        )
+        if existing_entry is not None:
             latest_cleanup_execution = existing_entry
             reused_existing_cleanup = True
         else:
@@ -2208,9 +2293,10 @@ async def _run_guarded_auto_cleanup_sequence(
                     status_code=500,
                     detail="Execution journal append did not return an id",
                 )
-            execution_store.mark_live_submission_completed(
-                confirmation_entry_id=cleanup_confirmation.entry_id,
-                preview_hash=cleanup_confirmation.preview_hash,
+            _mark_cleanup_live_submission_completed(
+                paper_trade=paper_trade,
+                confirmation=cleanup_confirmation,
+                execution_store=execution_store,
                 execution_entry_id=latest_cleanup_execution.entry_id,
             )
 
@@ -5748,28 +5834,13 @@ def create_app() -> FastAPI:
             )
         except ValueError as exc:
             raise HTTPException(status_code=409, detail=str(exc)) from exc
-        if confirmation.entry_id is None:
-            raise HTTPException(
-                status_code=500,
-                detail="Cleanup preview confirmation entry_id is required before live submission",
-            )
-        if not execution_store.reserve_live_submission(
-            confirmation_entry_id=confirmation.entry_id,
-            preview_hash=confirmation.preview_hash,
-        ):
-            existing_entry = execution_store.find_by_confirmation(
-                confirmation_entry_id=confirmation.entry_id,
-                preview_hash=confirmation.preview_hash,
-            )
-            if existing_entry is not None:
-                raise HTTPException(status_code=409, detail=existing_entry.model_dump(mode="json"))
-            raise HTTPException(
-                status_code=409,
-                detail=(
-                    "A live submission is already reserved for this confirmed cleanup preview; "
-                    "manual reconciliation is required before retrying"
-                ),
-            )
+        existing_entry = _reserve_cleanup_live_submission_or_existing(
+            paper_trade=paper_trade,
+            confirmation=confirmation,
+            execution_store=execution_store,
+        )
+        if existing_entry is not None:
+            raise HTTPException(status_code=409, detail=existing_entry.model_dump(mode="json"))
         try:
             journal_entry = await live_service.submit_confirmed_cleanup_preview(
                 paper_trade=paper_trade,
@@ -5785,9 +5856,10 @@ def create_app() -> FastAPI:
                 status_code=500,
                 detail="Execution journal append did not return an id",
             )
-        execution_store.mark_live_submission_completed(
-            confirmation_entry_id=confirmation.entry_id,
-            preview_hash=confirmation.preview_hash,
+        _mark_cleanup_live_submission_completed(
+            paper_trade=paper_trade,
+            confirmation=confirmation,
+            execution_store=execution_store,
             execution_entry_id=saved_entry.entry_id,
         )
         return saved_entry
@@ -5854,28 +5926,13 @@ def create_app() -> FastAPI:
             )
         except ValueError as exc:
             raise HTTPException(status_code=409, detail=str(exc)) from exc
-        if confirmation.entry_id is None:
-            raise HTTPException(
-                status_code=500,
-                detail="Cleanup preview confirmation entry_id is required before live submission",
-            )
-        if not execution_store.reserve_live_submission(
-            confirmation_entry_id=confirmation.entry_id,
-            preview_hash=confirmation.preview_hash,
-        ):
-            existing_entry = execution_store.find_by_confirmation(
-                confirmation_entry_id=confirmation.entry_id,
-                preview_hash=confirmation.preview_hash,
-            )
-            if existing_entry is not None:
-                raise HTTPException(status_code=409, detail=existing_entry.model_dump(mode="json"))
-            raise HTTPException(
-                status_code=409,
-                detail=(
-                    "A live submission is already reserved for this confirmed cleanup preview; "
-                    "manual reconciliation is required before retrying"
-                ),
-            )
+        existing_entry = _reserve_cleanup_live_submission_or_existing(
+            paper_trade=paper_trade,
+            confirmation=confirmation,
+            execution_store=execution_store,
+        )
+        if existing_entry is not None:
+            raise HTTPException(status_code=409, detail=existing_entry.model_dump(mode="json"))
         try:
             journal_entry = await live_service.submit_confirmed_cleanup_preview(
                 paper_trade=paper_trade,
@@ -5891,9 +5948,10 @@ def create_app() -> FastAPI:
                 status_code=500,
                 detail="Execution journal append did not return an id",
             )
-        execution_store.mark_live_submission_completed(
-            confirmation_entry_id=confirmation.entry_id,
-            preview_hash=confirmation.preview_hash,
+        _mark_cleanup_live_submission_completed(
+            paper_trade=paper_trade,
+            confirmation=confirmation,
+            execution_store=execution_store,
             execution_entry_id=saved_entry.entry_id,
         )
         return saved_entry
@@ -5960,6 +6018,13 @@ def create_app() -> FastAPI:
             )
         except ValueError as exc:
             raise HTTPException(status_code=409, detail=str(exc)) from exc
+        existing_entry = _reserve_cleanup_live_submission_or_existing(
+            paper_trade=paper_trade,
+            confirmation=confirmation,
+            execution_store=execution_store,
+        )
+        if existing_entry is not None:
+            raise HTTPException(status_code=409, detail=existing_entry.model_dump(mode="json"))
         try:
             journal_entry = await live_service.submit_confirmed_cleanup_preview(
                 paper_trade=paper_trade,
@@ -5969,7 +6034,19 @@ def create_app() -> FastAPI:
             raise HTTPException(status_code=400, detail=str(exc)) from exc
         except (ConnectorError, httpx.HTTPError) as exc:
             raise HTTPException(status_code=502, detail=str(exc)) from exc
-        return execution_store.append(journal_entry)
+        saved_entry = execution_store.append(journal_entry)
+        if saved_entry.entry_id is None:
+            raise HTTPException(
+                status_code=500,
+                detail="Execution journal append did not return an id",
+            )
+        _mark_cleanup_live_submission_completed(
+            paper_trade=paper_trade,
+            confirmation=confirmation,
+            execution_store=execution_store,
+            execution_entry_id=saved_entry.entry_id,
+        )
+        return saved_entry
 
     @app.post(
         "/v1/executions/live/pair/from-paper-trade/{paper_trade_id}",

--- a/apps/api/src/carryme_api/app.py
+++ b/apps/api/src/carryme_api/app.py
@@ -3857,11 +3857,25 @@ async def _execute_guarded_pair_close_from_confirmation(
     poll_interval_seconds: float,
     auto_cleanup: bool,
 ) -> GuardedPairExecutionResult:
-    paper_trade_id = paper_trade.entry_id or 0
     if confirmation.entry_id is None:
         raise HTTPException(
             status_code=500,
             detail="Pair-close confirmation entry_id is required before live submission",
+        )
+    paper_trade_id = paper_trade.entry_id or confirmation.paper_trade_id
+    if paper_trade_id < 1:
+        raise HTTPException(
+            status_code=500,
+            detail="paper_trade_id is required before pair-close live submission",
+        )
+    existing_entry = execution_store.find_by_paper_trade_preview_hash(
+        paper_trade_id=paper_trade_id,
+        preview_hash=confirmation.preview_hash,
+    )
+    if existing_entry is not None:
+        raise HTTPException(
+            status_code=409,
+            detail=existing_entry.model_dump(mode="json"),
         )
     for venue in {leg.venue for leg in confirmation.preview.legs}:
         try:

--- a/apps/api/src/carryme_api/app.py
+++ b/apps/api/src/carryme_api/app.py
@@ -3635,6 +3635,107 @@ def _append_pair_close_confirmation_for_preview(
     )
 
 
+def _effective_pair_open_submission_paper_trade_id(
+    *,
+    paper_trade: PaperTradeEntry,
+    confirmation: PreviewConfirmationEntry,
+) -> int:
+    paper_trade_id = paper_trade.entry_id or confirmation.paper_trade_id
+    if paper_trade_id < 1:
+        raise HTTPException(
+            status_code=500,
+            detail="paper_trade_id is required before paired live submission",
+        )
+    return paper_trade_id
+
+
+def _reserve_pair_open_live_submission_or_existing(
+    *,
+    paper_trade: PaperTradeEntry,
+    confirmation: PreviewConfirmationEntry,
+    execution_store: ExecutionJournalStore,
+) -> ExecutionJournalEntry | None:
+    if confirmation.entry_id is None:
+        raise HTTPException(
+            status_code=500,
+            detail="Preview confirmation entry_id is required before live submission",
+        )
+    paper_trade_id = _effective_pair_open_submission_paper_trade_id(
+        paper_trade=paper_trade,
+        confirmation=confirmation,
+    )
+    existing_entry = execution_store.find_by_paper_trade_preview_hash(
+        paper_trade_id=paper_trade_id,
+        preview_hash=confirmation.preview_hash,
+    )
+    if existing_entry is not None:
+        return existing_entry
+    if not execution_store.reserve_pair_open_live_submission(
+        paper_trade_id=paper_trade_id,
+        preview_hash=confirmation.preview_hash,
+        confirmation_entry_id=confirmation.entry_id,
+    ):
+        existing_entry = execution_store.find_by_paper_trade_preview_hash(
+            paper_trade_id=paper_trade_id,
+            preview_hash=confirmation.preview_hash,
+        )
+        if existing_entry is not None:
+            return existing_entry
+        raise HTTPException(
+            status_code=409,
+            detail=(
+                "A paired live submission is already reserved for this paper trade "
+                "and preview hash; manual reconciliation is required before retrying"
+            ),
+        )
+    if not execution_store.reserve_live_submission(
+        confirmation_entry_id=confirmation.entry_id,
+        preview_hash=confirmation.preview_hash,
+    ):
+        existing_entry = execution_store.find_by_confirmation(
+            confirmation_entry_id=confirmation.entry_id,
+            preview_hash=confirmation.preview_hash,
+        )
+        if existing_entry is not None:
+            return existing_entry
+        raise HTTPException(
+            status_code=409,
+            detail=(
+                "A live submission is already reserved for this confirmed preview; "
+                "manual reconciliation is required before retrying"
+            ),
+        )
+    return None
+
+
+def _mark_pair_open_live_submission_completed(
+    *,
+    paper_trade: PaperTradeEntry,
+    confirmation: PreviewConfirmationEntry,
+    execution_store: ExecutionJournalStore,
+    execution_entry_id: int,
+) -> None:
+    if confirmation.entry_id is None:
+        raise HTTPException(
+            status_code=500,
+            detail="Preview confirmation entry_id is required before live submission",
+        )
+    paper_trade_id = _effective_pair_open_submission_paper_trade_id(
+        paper_trade=paper_trade,
+        confirmation=confirmation,
+    )
+    execution_store.mark_live_submission_completed(
+        confirmation_entry_id=confirmation.entry_id,
+        preview_hash=confirmation.preview_hash,
+        execution_entry_id=execution_entry_id,
+    )
+    execution_store.mark_pair_open_live_submission_completed(
+        paper_trade_id=paper_trade_id,
+        preview_hash=confirmation.preview_hash,
+        execution_entry_id=execution_entry_id,
+    )
+
+
 async def _execute_guarded_pair_from_confirmation(
     *,
     paper_trade: PaperTradeEntry,
@@ -3654,30 +3755,15 @@ async def _execute_guarded_pair_from_confirmation(
     auto_cleanup: bool,
 ) -> GuardedPairExecutionResult:
     paper_trade_id = paper_trade.entry_id or 0
-    if confirmation.entry_id is None:
-        raise HTTPException(
-            status_code=500,
-            detail="Preview confirmation entry_id is required before live submission",
-        )
-    if not execution_store.reserve_live_submission(
-        confirmation_entry_id=confirmation.entry_id,
-        preview_hash=confirmation.preview_hash,
-    ):
-        existing_entry = execution_store.find_by_confirmation(
-            confirmation_entry_id=confirmation.entry_id,
-            preview_hash=confirmation.preview_hash,
-        )
-        if existing_entry is not None:
-            raise HTTPException(
-                status_code=409,
-                detail=existing_entry.model_dump(mode="json"),
-            )
+    existing_entry = _reserve_pair_open_live_submission_or_existing(
+        paper_trade=paper_trade,
+        confirmation=confirmation,
+        execution_store=execution_store,
+    )
+    if existing_entry is not None:
         raise HTTPException(
             status_code=409,
-            detail=(
-                "A live submission is already reserved for this confirmed preview; "
-                "manual reconciliation is required before retrying"
-            ),
+            detail=existing_entry.model_dump(mode="json"),
         )
     try:
         primary_execution = await service.submit_confirmed_preview(
@@ -3696,9 +3782,10 @@ async def _execute_guarded_pair_from_confirmation(
             status_code=500,
             detail="Execution journal append did not return an id",
         )
-    execution_store.mark_live_submission_completed(
-        confirmation_entry_id=confirmation.entry_id,
-        preview_hash=confirmation.preview_hash,
+    _mark_pair_open_live_submission_completed(
+        paper_trade=paper_trade,
+        confirmation=confirmation,
+        execution_store=execution_store,
         execution_entry_id=primary_execution.entry_id,
     )
     try:
@@ -5493,30 +5580,15 @@ def create_app() -> FastAPI:
                     "No preview confirmation matched the requested paper trade and preview hash"
                 ),
             )
-        if confirmation.entry_id is None:
-            raise HTTPException(
-                status_code=500,
-                detail="Preview confirmation entry_id is required before live submission",
-            )
-        if not execution_store.reserve_live_submission(
-            confirmation_entry_id=confirmation.entry_id,
-            preview_hash=confirmation.preview_hash,
-        ):
-            existing_entry = execution_store.find_by_confirmation(
-                confirmation_entry_id=confirmation.entry_id,
-                preview_hash=confirmation.preview_hash,
-            )
-            if existing_entry is not None:
-                raise HTTPException(
-                    status_code=409,
-                    detail=existing_entry.model_dump(mode="json"),
-                )
+        existing_entry = _reserve_pair_open_live_submission_or_existing(
+            paper_trade=paper_trade,
+            confirmation=confirmation,
+            execution_store=execution_store,
+        )
+        if existing_entry is not None:
             raise HTTPException(
                 status_code=409,
-                detail=(
-                    "A live submission is already reserved for this confirmed preview; "
-                    "manual reconciliation is required before retrying"
-                ),
+                detail=existing_entry.model_dump(mode="json"),
             )
 
         try:
@@ -5535,9 +5607,10 @@ def create_app() -> FastAPI:
                 status_code=500,
                 detail="Execution journal append did not return an id",
             )
-        execution_store.mark_live_submission_completed(
-            confirmation_entry_id=confirmation.entry_id,
-            preview_hash=confirmation.preview_hash,
+        _mark_pair_open_live_submission_completed(
+            paper_trade=paper_trade,
+            confirmation=confirmation,
+            execution_store=execution_store,
             execution_entry_id=saved_entry.entry_id,
         )
         return saved_entry

--- a/apps/api/src/carryme_api/app.py
+++ b/apps/api/src/carryme_api/app.py
@@ -3232,6 +3232,7 @@ async def _run_guarded_canary_lifecycle(
     poll_interval_seconds: float,
     auto_cleanup: bool,
     close_position: bool,
+    before_open_submission: Callable[[], Awaitable[None] | None] | None = None,
 ) -> CanaryLifecycleResult:
     paper_trade = _append_paper_trade_from_canary_candidate(
         candidate=candidate,
@@ -3269,6 +3270,10 @@ async def _run_guarded_canary_lifecycle(
     )
     if not readiness.ready:
         raise HTTPException(status_code=409, detail=readiness.model_dump(mode="json"))
+    if before_open_submission is not None:
+        callback_result = before_open_submission()
+        if inspect.isawaitable(callback_result):
+            await callback_result
     open_execution = await _execute_guarded_pair_from_confirmation(
         paper_trade=paper_trade,
         confirmation=open_confirmation,

--- a/apps/api/src/carryme_api/app.py
+++ b/apps/api/src/carryme_api/app.py
@@ -3703,6 +3703,28 @@ async def _execute_guarded_pair_close_from_confirmation(
         except (ConnectorError, UpstreamDataError, httpx.HTTPError) as exc:
             raise HTTPException(status_code=502, detail=str(exc)) from exc
 
+    if not execution_store.reserve_pair_close_live_submission(
+        paper_trade_id=paper_trade_id,
+        preview_hash=confirmation.preview_hash,
+        confirmation_entry_id=confirmation.entry_id,
+    ):
+        existing_entry = execution_store.find_by_paper_trade_preview_hash(
+            paper_trade_id=paper_trade_id,
+            preview_hash=confirmation.preview_hash,
+        )
+        if existing_entry is not None:
+            raise HTTPException(
+                status_code=409,
+                detail=existing_entry.model_dump(mode="json"),
+            )
+        raise HTTPException(
+            status_code=409,
+            detail=(
+                "A pair-close live submission is already reserved for this paper trade "
+                "and preview hash; manual reconciliation is required before retrying"
+            ),
+        )
+
     if not execution_store.reserve_live_submission(
         confirmation_entry_id=confirmation.entry_id,
         preview_hash=confirmation.preview_hash,
@@ -3742,6 +3764,11 @@ async def _execute_guarded_pair_close_from_confirmation(
         )
     execution_store.mark_live_submission_completed(
         confirmation_entry_id=confirmation.entry_id,
+        preview_hash=confirmation.preview_hash,
+        execution_entry_id=primary_execution.entry_id,
+    )
+    execution_store.mark_pair_close_live_submission_completed(
+        paper_trade_id=paper_trade_id,
         preview_hash=confirmation.preview_hash,
         execution_entry_id=primary_execution.entry_id,
     )

--- a/apps/worker/src/carryme_worker/config.py
+++ b/apps/worker/src/carryme_worker/config.py
@@ -31,6 +31,8 @@ class WorkerSettings(BaseSettings):
     launch_ready_canary_max_backoff_seconds: int = Field(default=120, gt=0)
     stable_canary_launch_interval_seconds: int = Field(default=30, gt=0)
     stable_canary_launch_max_backoff_seconds: int = Field(default=300, gt=0)
+    stable_canary_launch_reservation_ttl_seconds: int = Field(default=300, gt=0)
+    stable_canary_launch_reservation_retention_seconds: int = Field(default=86_400, gt=0)
     # `0` is intentionally fail-closed: any active live execution blocks unattended launch.
     stable_canary_launch_max_active_live_executions: int = Field(default=0, ge=0)
     # Fetch enough rows to decide whether the blocking threshold is exceeded.
@@ -392,6 +394,20 @@ class WorkerSettings(BaseSettings):
             raise ValueError(
                 "stable_canary_launch_recent_launch_window_seconds is required when "
                 "stable launch rate caps are configured"
+            )
+        return self
+
+    @model_validator(mode="after")
+    def validate_stable_launch_reservation_retention(self) -> "WorkerSettings":
+        """Keep reservation cleanup from deleting leases before they are stale."""
+
+        if (
+            self.stable_canary_launch_reservation_retention_seconds
+            < self.stable_canary_launch_reservation_ttl_seconds
+        ):
+            raise ValueError(
+                "stable_canary_launch_reservation_retention_seconds must be greater than "
+                "or equal to stable_canary_launch_reservation_ttl_seconds"
             )
         return self
 

--- a/apps/worker/src/carryme_worker/config.py
+++ b/apps/worker/src/carryme_worker/config.py
@@ -35,6 +35,7 @@ class WorkerSettings(BaseSettings):
     stable_canary_launch_max_active_live_executions: int = Field(default=0, ge=0)
     # Fetch enough rows to decide whether the blocking threshold is exceeded.
     stable_canary_launch_active_execution_limit: int = Field(default=20, gt=0)
+    stable_canary_launch_candidate_scan_limit: int = Field(default=100, gt=0)
     stable_canary_launch_max_total_live_notional: float | None = Field(
         default=None,
         ge=0,

--- a/apps/worker/src/carryme_worker/poller.py
+++ b/apps/worker/src/carryme_worker/poller.py
@@ -2932,6 +2932,40 @@ async def launch_latest_stable_canary_once(
     selected: FundingUniverseCanaryCandidate | None = None
     approval: RouteApprovalEntry | None = None
     candidate_skip_details: list[str] = []
+    single_candidate = len(stable_candidates) == 1
+
+    def _single_candidate_skip(
+        *,
+        candidate_snapshot: LaunchReadyCanarySnapshot | None,
+        detail: str,
+        approved_snapshot_id: int | None = None,
+        paper_trade_id: int | None = None,
+        final_pair_state: str | None = None,
+    ) -> StableCanaryLaunchSummary | None:
+        if not single_candidate:
+            return None
+        return StableCanaryLaunchSummary(
+            status="skipped",
+            database_path=settings.database_target,
+            label=candidate_snapshot.label if candidate_snapshot is not None else None,
+            launch_ready_snapshot_id=(
+                candidate_snapshot.launch_ready_snapshot_id
+                if candidate_snapshot is not None
+                else None
+            ),
+            approved_snapshot_id=(
+                approved_snapshot_id
+                if approved_snapshot_id is not None
+                else (
+                    candidate_snapshot.approved_snapshot.snapshot_id
+                    if candidate_snapshot is not None
+                    else None
+                )
+            ),
+            paper_trade_id=paper_trade_id,
+            final_pair_state=final_pair_state,
+            detail=detail,
+        )
 
     for candidate_stability in stable_candidates:
         try:
@@ -2946,6 +2980,12 @@ async def launch_latest_stable_canary_once(
             )
         except HTTPException as exc:
             if exc.status_code in {404, 409}:
+                summary = _single_candidate_skip(
+                    candidate_snapshot=None,
+                    detail=str(exc.detail),
+                )
+                if summary is not None:
+                    return summary
                 candidate_skip_details.append(
                     f"{candidate_stability.snapshot.label}: {exc.detail}"
                 )
@@ -2959,6 +2999,12 @@ async def launch_latest_stable_canary_once(
             label=candidate_snapshot.label,
         )
         if label_cooldown_reason is not None:
+            summary = _single_candidate_skip(
+                candidate_snapshot=candidate_snapshot,
+                detail=label_cooldown_reason,
+            )
+            if summary is not None:
+                return summary
             candidate_skip_details.append(
                 f"{candidate_snapshot.label}: {label_cooldown_reason}"
             )
@@ -2971,6 +3017,12 @@ async def launch_latest_stable_canary_once(
             label=candidate_snapshot.label,
         )
         if label_rate_cap_reason is not None:
+            summary = _single_candidate_skip(
+                candidate_snapshot=candidate_snapshot,
+                detail=label_rate_cap_reason,
+            )
+            if summary is not None:
+                return summary
             candidate_skip_details.append(
                 f"{candidate_snapshot.label}: {label_rate_cap_reason}"
             )
@@ -2980,6 +3032,12 @@ async def launch_latest_stable_canary_once(
             label=candidate_snapshot.label
         )
         if candidate_latest_approved_snapshot is None:
+            summary = _single_candidate_skip(
+                candidate_snapshot=candidate_snapshot,
+                detail="Latest approved canary snapshot is missing for the selected label",
+            )
+            if summary is not None:
+                return summary
             candidate_skip_details.append(
                 f"{candidate_snapshot.label}: latest approved canary snapshot is missing"
             )
@@ -2988,6 +3046,15 @@ async def launch_latest_stable_canary_once(
             candidate_latest_approved_snapshot.snapshot_id
             != candidate_snapshot.approved_snapshot.snapshot_id
         ):
+            summary = _single_candidate_skip(
+                candidate_snapshot=candidate_snapshot,
+                detail=(
+                    "Launch-ready canary snapshot is stale relative to the latest "
+                    "approved snapshot"
+                ),
+            )
+            if summary is not None:
+                return summary
             candidate_skip_details.append(
                 f"{candidate_snapshot.label}: launch-ready canary snapshot is stale relative "
                 "to the latest approved snapshot"
@@ -3005,6 +3072,12 @@ async def launch_latest_stable_canary_once(
                     candidate_snapshot.label,
                     execution_maturity_reason,
                 )
+            summary = _single_candidate_skip(
+                candidate_snapshot=candidate_snapshot,
+                detail=execution_maturity_reason,
+            )
+            if summary is not None:
+                return summary
             candidate_skip_details.append(
                 f"{candidate_snapshot.label}: {execution_maturity_reason}"
             )
@@ -3021,6 +3094,12 @@ async def launch_latest_stable_canary_once(
                     candidate_snapshot.label,
                     latest_outcome_reason,
                 )
+            summary = _single_candidate_skip(
+                candidate_snapshot=candidate_snapshot,
+                detail=latest_outcome_reason,
+            )
+            if summary is not None:
+                return summary
             candidate_skip_details.append(
                 f"{candidate_snapshot.label}: {latest_outcome_reason}"
             )
@@ -3037,6 +3116,12 @@ async def launch_latest_stable_canary_once(
                     candidate_snapshot.label,
                     liquidity_and_value_reason,
                 )
+            summary = _single_candidate_skip(
+                candidate_snapshot=candidate_snapshot,
+                detail=liquidity_and_value_reason,
+            )
+            if summary is not None:
+                return summary
             candidate_skip_details.append(
                 f"{candidate_snapshot.label}: {liquidity_and_value_reason}"
             )
@@ -3059,6 +3144,15 @@ async def launch_latest_stable_canary_once(
                     candidate_snapshot.label,
                     automation_gate_reason,
                 )
+            summary = _single_candidate_skip(
+                candidate_snapshot=candidate_snapshot,
+                detail=(
+                    "Latest approved snapshot no longer satisfies automated launch "
+                    f"gates: {automation_gate_reason}"
+                ),
+            )
+            if summary is not None:
+                return summary
             candidate_skip_details.append(
                 f"{candidate_snapshot.label}: latest approved snapshot no longer "
                 f"satisfies automated launch gates: {automation_gate_reason}"
@@ -3072,6 +3166,16 @@ async def launch_latest_stable_canary_once(
             if previous_launch is not None:
                 if previous_launch.status == "shadowed":
                     if settings.stable_canary_launch_shadow_mode:
+                        summary = _single_candidate_skip(
+                            candidate_snapshot=candidate_snapshot,
+                            detail=(
+                                "Launch-ready canary snapshot already evaluated in shadow mode "
+                                "by worker"
+                            ),
+                            final_pair_state=previous_launch.final_pair_state,
+                        )
+                        if summary is not None:
+                            return summary
                         candidate_skip_details.append(
                             f"{candidate_snapshot.label}: launch-ready canary snapshot "
                             "already evaluated in shadow mode by worker"
@@ -3079,6 +3183,17 @@ async def launch_latest_stable_canary_once(
                         continue
                     # Shadow mode is off but was previously on: allow a real launch now.
                 else:
+                    summary = _single_candidate_skip(
+                        candidate_snapshot=candidate_snapshot,
+                        detail=(
+                            "Launch-ready canary snapshot already launched by worker as "
+                            f"paper trade {previous_launch.paper_trade_id}"
+                        ),
+                        paper_trade_id=previous_launch.paper_trade_id,
+                        final_pair_state=previous_launch.final_pair_state,
+                    )
+                    if summary is not None:
+                        return summary
                     candidate_skip_details.append(
                         f"{candidate_snapshot.label}: launch-ready canary snapshot already "
                         f"launched by worker as paper trade {previous_launch.paper_trade_id}"
@@ -3097,29 +3212,14 @@ async def launch_latest_stable_canary_once(
                     candidate_snapshot.label,
                     risk_budget_reason,
                 )
+            summary = _single_candidate_skip(
+                candidate_snapshot=candidate_snapshot,
+                detail=risk_budget_reason,
+            )
+            if summary is not None:
+                return summary
             candidate_skip_details.append(
                 f"{candidate_snapshot.label}: {risk_budget_reason}"
-            )
-            continue
-
-        execution_preflight = _build_candidate_live_execution_preflight(
-            settings=runtime_settings,
-            candidate=candidate_selected,
-            label=candidate_snapshot.label,
-        )
-        if not execution_preflight.ready:
-            try:
-                launch_ready_store.delete_label(candidate_snapshot.label)
-            except Exception:
-                logging.getLogger("carryme.worker").exception(
-                    "failed to invalidate launch-ready snapshots for label=%s "
-                    "during stable launch preflight",
-                    candidate_snapshot.label,
-                )
-            candidate_skip_details.append(
-                f"{candidate_snapshot.label}: latest launch-ready snapshot no longer "
-                "satisfies live execution readiness: "
-                f"{'; '.join(execution_preflight.blocking_reasons)}"
             )
             continue
 
@@ -3180,6 +3280,32 @@ async def launch_latest_stable_canary_once(
             launch_ready_snapshot_id=snapshot.launch_ready_snapshot_id,
             approved_snapshot_id=snapshot.approved_snapshot.snapshot_id,
             detail=hold_mode_blocker,
+        )
+
+    execution_preflight = _build_candidate_live_execution_preflight(
+        settings=runtime_settings,
+        candidate=selected,
+        label=snapshot.label,
+    )
+    if not execution_preflight.ready:
+        try:
+            launch_ready_store.delete_label(snapshot.label)
+        except Exception:
+            logging.getLogger("carryme.worker").exception(
+                "failed to invalidate launch-ready snapshots for label=%s "
+                "during stable launch preflight",
+                snapshot.label,
+            )
+        return StableCanaryLaunchSummary(
+            status="skipped",
+            database_path=settings.database_target,
+            label=snapshot.label,
+            launch_ready_snapshot_id=snapshot.launch_ready_snapshot_id,
+            approved_snapshot_id=snapshot.approved_snapshot.snapshot_id,
+            detail=(
+                "Latest launch-ready snapshot no longer satisfies live execution "
+                f"readiness: {'; '.join(execution_preflight.blocking_reasons)}"
+            ),
         )
 
     try:

--- a/apps/worker/src/carryme_worker/poller.py
+++ b/apps/worker/src/carryme_worker/poller.py
@@ -2111,6 +2111,70 @@ def _build_latest_launch_ready_stability(
     )
 
 
+def _rank_launch_ready_stability(
+    stability: LaunchReadyCanaryStability,
+) -> tuple[float, float, float, datetime, int]:
+    """Return the deterministic launch ranking for one stable launch-ready label."""
+
+    snapshot_id = stability.snapshot.launch_ready_snapshot_id or 0
+    return (
+        *_rank_approved_canary_candidate(stability.snapshot.approved_snapshot.candidate),
+        stability.snapshot.captured_at,
+        snapshot_id,
+    )
+
+
+def _list_ranked_stable_launch_ready_stabilities(
+    *,
+    store: LaunchReadyCanaryStore,
+    max_snapshot_age_seconds: int,
+    min_snapshot_count: int,
+    min_stable_seconds: float,
+    now: datetime,
+    scan_limit: int,
+) -> list[LaunchReadyCanaryStability]:
+    """Return stable launch-ready labels ranked by route quality, then freshness."""
+
+    if scan_limit < 1:
+        raise ValueError("scan_limit must be positive")
+
+    recent_snapshots = store.list_recent(limit=scan_limit)
+    if not recent_snapshots:
+        return [
+            _build_launch_ready_canary_stability(
+                store=store,
+                label=None,
+                max_snapshot_age_seconds=max_snapshot_age_seconds,
+                min_snapshot_count=min_snapshot_count,
+                min_stable_seconds=min_stable_seconds,
+                now=now,
+            )
+        ]
+
+    labels: list[str] = []
+    seen_labels: set[str] = set()
+    for snapshot in recent_snapshots:
+        if snapshot.label in seen_labels:
+            continue
+        seen_labels.add(snapshot.label)
+        labels.append(snapshot.label)
+
+    stabilities: list[LaunchReadyCanaryStability] = []
+    for label in labels:
+        stability = _build_latest_launch_ready_stability(
+            store=store,
+            label=label,
+            max_snapshot_age_seconds=max_snapshot_age_seconds,
+            min_snapshot_count=min_snapshot_count,
+            min_stable_seconds=min_stable_seconds,
+            now=now,
+        )
+        if stability is not None:
+            stabilities.append(stability)
+
+    return sorted(stabilities, key=_rank_launch_ready_stability, reverse=True)
+
+
 async def scan_approved_canary_once(
     settings: WorkerSettings,
     *,
@@ -2764,14 +2828,20 @@ async def launch_latest_stable_canary_once(
         )
 
     try:
-        stability = _build_launch_ready_canary_stability(
+        stable_candidates = _list_ranked_stable_launch_ready_stabilities(
             store=launch_ready_store,
-            label=None,
             max_snapshot_age_seconds=settings.launch_ready_canary_max_snapshot_age_seconds,
             min_snapshot_count=settings.stable_launch_ready_min_snapshot_count,
             min_stable_seconds=settings.stable_launch_ready_min_stable_seconds,
             now=timestamp,
+            scan_limit=settings.stable_canary_launch_candidate_scan_limit,
         )
+        if not stable_candidates:
+            raise HTTPException(
+                status_code=409,
+                detail="No stable launch-ready canary snapshot found",
+            )
+        stability = stable_candidates[0]
         snapshot, selected, approval = _select_latest_launch_ready_canary_snapshot(
             store=launch_ready_store,
             approval_service=route_approval_service,

--- a/apps/worker/src/carryme_worker/poller.py
+++ b/apps/worker/src/carryme_worker/poller.py
@@ -390,6 +390,7 @@ def _list_blocking_live_executions_for_stable_launch(
         limit=scan_limit,
         now=now,
         max_age_seconds=settings.execution_observation_max_age_seconds,
+        unobserved_requires_monitoring=True,
     )
     for execution in recent_live_executions:
         paper_trade_id = execution.paper_trade_id
@@ -2894,6 +2895,7 @@ async def launch_latest_stable_canary_once(
         limit=risk_budget_scan_limit + 1,
         now=timestamp,
         max_age_seconds=settings.execution_observation_max_age_seconds,
+        unobserved_requires_monitoring=True,
     )
     if (
         (
@@ -5017,6 +5019,7 @@ def _list_recent_live_executions(
     limit: int,
     now: datetime,
     max_age_seconds: int,
+    unobserved_requires_monitoring: bool = False,
 ) -> list[ExecutionJournalEntry]:
     """Return recent unique live executions after filtering irrelevant journal rows."""
 
@@ -5038,6 +5041,7 @@ def _list_recent_live_executions(
             if age_seconds > max_age_seconds and not _execution_requires_continued_monitoring(
                 observation_store,
                 execution=execution,
+                unobserved_requires_monitoring=unobserved_requires_monitoring,
             ):
                 continue
             if execution.paper_trade_id is None or execution.paper_trade_id in seen_paper_trade_ids:
@@ -5058,6 +5062,7 @@ def _execution_requires_continued_monitoring(
     *,
     execution: ExecutionJournalEntry,
     latest_observation: ExecutionObservationEntry | None = None,
+    unobserved_requires_monitoring: bool = False,
 ) -> bool:
     """Return whether an older live execution still has an active monitoring state."""
 
@@ -5068,7 +5073,7 @@ def _execution_requires_continued_monitoring(
     if latest is None:
         latest = observation_store.latest_for_paper_trade(paper_trade_id)
     if latest is None:
-        return False
+        return unobserved_requires_monitoring
     pair_status = latest.pair_status
     if pair_status is None:
         for observation in observation_store.list_recent(limit=None, paper_trade_id=paper_trade_id):

--- a/apps/worker/src/carryme_worker/poller.py
+++ b/apps/worker/src/carryme_worker/poller.py
@@ -2106,10 +2106,9 @@ def _evaluate_latest_launch_ready_stability(
         return None, f"label={label}: no launch-ready canary snapshot found"
 
     latest_snapshot = snapshots[0]
-    snapshot_age_seconds = max(
-        0.0,
-        (now - latest_snapshot.captured_at).total_seconds(),
-    )
+    snapshot_age_seconds = (now - latest_snapshot.captured_at).total_seconds()
+    if snapshot_age_seconds < 0:
+        return None, f"label={label}: snapshot timestamp is in the future"
     effective_max_age_seconds = min(
         max_snapshot_age_seconds,
         latest_snapshot.max_snapshot_age_seconds,
@@ -2992,6 +2991,44 @@ async def launch_latest_stable_canary_once(
                 continue
             raise
 
+        try:
+            revalidated_stability = _build_launch_ready_canary_stability(
+                store=launch_ready_store,
+                label=candidate_snapshot.label,
+                max_snapshot_age_seconds=settings.launch_ready_canary_max_snapshot_age_seconds,
+                min_snapshot_count=settings.stable_launch_ready_min_snapshot_count,
+                min_stable_seconds=settings.stable_launch_ready_min_stable_seconds,
+                now=timestamp,
+            )
+        except HTTPException as exc:
+            detail = str(exc.detail) or (
+                "Launch-ready canary snapshot no longer satisfies stability requirements"
+            )
+            summary = _single_candidate_skip(
+                candidate_snapshot=candidate_snapshot,
+                detail=detail,
+            )
+            if summary is not None:
+                return summary
+            candidate_skip_details.append(f"{candidate_snapshot.label}: {detail}")
+            continue
+        if (
+            revalidated_stability.snapshot.launch_ready_snapshot_id
+            != candidate_snapshot.launch_ready_snapshot_id
+        ):
+            detail = (
+                "Launch-ready canary snapshot changed before stability could be revalidated"
+            )
+            summary = _single_candidate_skip(
+                candidate_snapshot=candidate_snapshot,
+                detail=detail,
+            )
+            if summary is not None:
+                return summary
+            candidate_skip_details.append(f"{candidate_snapshot.label}: {detail}")
+            continue
+        candidate_stability = revalidated_stability
+
         label_cooldown_reason = _build_stable_launch_cooldown_reason(
             settings=settings,
             launch_store=stable_launch_store,
@@ -3316,7 +3353,7 @@ async def launch_latest_stable_canary_once(
             note="worker stable launch-ready canary",
             lifecycle_note=(
                 "Launched by carryme-worker from stable launch-ready snapshot "
-                f"{stability.snapshot.launch_ready_snapshot_id} after "
+                f"{snapshot.launch_ready_snapshot_id} after "
                 f"{stability.consecutive_snapshots} stable snapshots over "
                 f"{stability.stable_seconds:.1f}s."
             ),

--- a/apps/worker/src/carryme_worker/poller.py
+++ b/apps/worker/src/carryme_worker/poller.py
@@ -7,6 +7,7 @@ import logging
 import math
 import signal
 import sqlite3
+import uuid
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
 from datetime import UTC, datetime, timedelta
@@ -3382,10 +3383,14 @@ async def launch_latest_stable_canary_once(
         )
 
     if snapshot.launch_ready_snapshot_id is not None:
+        reservation_owner_id = uuid.uuid4().hex
         reserved = stable_launch_store.reserve_snapshot_launch(
             launch_ready_snapshot_id=snapshot.launch_ready_snapshot_id,
             label=snapshot.label,
             reserved_at=timestamp,
+            max_age_seconds=settings.stable_canary_launch_reservation_ttl_seconds,
+            retention_seconds=settings.stable_canary_launch_reservation_retention_seconds,
+            owner_id=reservation_owner_id,
         )
         if not reserved:
             return StableCanaryLaunchSummary(
@@ -3395,6 +3400,25 @@ async def launch_latest_stable_canary_once(
                 launch_ready_snapshot_id=snapshot.launch_ready_snapshot_id,
                 approved_snapshot_id=snapshot.approved_snapshot.snapshot_id,
                 detail="Launch-ready canary snapshot is already reserved for launch by worker",
+            )
+    else:
+        reservation_owner_id = None
+
+    async def renew_stable_launch_reservation_before_open(
+        launch_ready_snapshot_id: int | None = snapshot.launch_ready_snapshot_id,
+        owner_id: str | None = reservation_owner_id,
+    ) -> None:
+        if launch_ready_snapshot_id is None or owner_id is None:
+            return
+        renewed = stable_launch_store.renew_snapshot_launch_reservation(
+            launch_ready_snapshot_id=launch_ready_snapshot_id,
+            owner_id=owner_id,
+            reserved_at=datetime.now(UTC),
+        )
+        if not renewed:
+            raise HTTPException(
+                status_code=409,
+                detail="Stable launch reservation ownership was lost before live submission",
             )
 
     try:
@@ -3457,6 +3481,7 @@ async def launch_latest_stable_canary_once(
             poll_interval_seconds=2.0,
             auto_cleanup=True,
             close_position=settings.stable_canary_launch_close_position,
+            before_open_submission=renew_stable_launch_reservation_before_open,
         )
     except HTTPException as exc:
         if exc.status_code in {404, 409}:

--- a/apps/worker/src/carryme_worker/poller.py
+++ b/apps/worker/src/carryme_worker/poller.py
@@ -3277,7 +3277,6 @@ async def launch_latest_stable_canary_once(
             database_path=settings.database_target,
             detail=detail,
         )
-
     if settings.stable_canary_launch_shadow_mode:
         logging.getLogger("carryme.worker").info(
             "shadow launch for label=%s from launch_ready_snapshot_id=%s",
@@ -3344,6 +3343,22 @@ async def launch_latest_stable_canary_once(
                 f"readiness: {'; '.join(execution_preflight.blocking_reasons)}"
             ),
         )
+
+    if snapshot.launch_ready_snapshot_id is not None:
+        reserved = stable_launch_store.reserve_snapshot_launch(
+            launch_ready_snapshot_id=snapshot.launch_ready_snapshot_id,
+            label=snapshot.label,
+            reserved_at=timestamp,
+        )
+        if not reserved:
+            return StableCanaryLaunchSummary(
+                status="skipped",
+                database_path=settings.database_target,
+                label=snapshot.label,
+                launch_ready_snapshot_id=snapshot.launch_ready_snapshot_id,
+                approved_snapshot_id=snapshot.approved_snapshot.snapshot_id,
+                detail="Launch-ready canary snapshot is already reserved for launch by worker",
+            )
 
     try:
         lifecycle = await _run_guarded_canary_lifecycle(

--- a/apps/worker/src/carryme_worker/poller.py
+++ b/apps/worker/src/carryme_worker/poller.py
@@ -17,7 +17,6 @@ from carryme_api.app import (
     _append_pair_close_confirmation_for_preview,
     _build_cleanup_live_execution_router_for_candidate,
     _build_cleanup_preview_router_for_candidate,
-    _build_launch_ready_canary_stability,
     _build_pair_close_context_for_paper_trade,
     _build_pair_close_live_execution_coordinator_for_candidate,
     _build_pair_close_preview_service_for_candidate,
@@ -25,6 +24,9 @@ from carryme_api.app import (
     _execute_guarded_pair_close_from_confirmation,
     _run_guarded_canary_lifecycle,
     _select_latest_launch_ready_canary_snapshot,
+)
+from carryme_api.app import (
+    _build_launch_ready_canary_stability as _api_build_launch_ready_canary_stability,
 )
 from carryme_api.config import ApiSettings
 from carryme_models import (
@@ -125,6 +127,12 @@ FUNDING_WINDOW_HOURS_BY_VENUE: dict[str, float] = {
     "paradex": 8.0,
     "hyperliquid": 8.0,
 }
+
+
+def _build_launch_ready_canary_stability(**kwargs: Any) -> LaunchReadyCanaryStability:
+    """Delegate to the API-layer stability helper for legacy worker call sites and tests."""
+
+    return _api_build_launch_ready_canary_stability(**kwargs)
 
 
 def _rank_approved_canary_candidate(
@@ -2071,9 +2079,33 @@ def _build_latest_launch_ready_stability(
 ) -> LaunchReadyCanaryStability | None:
     """Return the latest stable launch-ready snapshot for one label, if any."""
 
-    latest_snapshot = store.latest(label=label)
-    if latest_snapshot is None:
-        return None
+    stability, _ = _evaluate_latest_launch_ready_stability(
+        store=store,
+        label=label,
+        max_snapshot_age_seconds=max_snapshot_age_seconds,
+        min_snapshot_count=min_snapshot_count,
+        min_stable_seconds=min_stable_seconds,
+        now=now,
+    )
+    return stability
+
+
+def _evaluate_latest_launch_ready_stability(
+    *,
+    store: LaunchReadyCanaryStore,
+    label: str,
+    max_snapshot_age_seconds: int,
+    min_snapshot_count: int,
+    min_stable_seconds: float,
+    now: datetime,
+) -> tuple[LaunchReadyCanaryStability | None, str | None]:
+    """Return the latest stable launch-ready snapshot and failure detail for one label."""
+
+    snapshots = store.list_recent(limit=max(min_snapshot_count + 5, 20), label=label)
+    if not snapshots:
+        return None, f"label={label}: no launch-ready canary snapshot found"
+
+    latest_snapshot = snapshots[0]
     snapshot_age_seconds = max(
         0.0,
         (now - latest_snapshot.captured_at).total_seconds(),
@@ -2083,14 +2115,20 @@ def _build_latest_launch_ready_stability(
         latest_snapshot.max_snapshot_age_seconds,
     )
     if snapshot_age_seconds > effective_max_age_seconds:
-        return None
+        return (
+            None,
+            "label="
+            f"{label}: snapshot stale ({snapshot_age_seconds:.1f}s > {effective_max_age_seconds}s)",
+        )
 
-    snapshots = store.list_recent(limit=max(min_snapshot_count + 5, 20), label=label)
     chain: list[LaunchReadyCanarySnapshot] = []
     for snapshot in snapshots:
         if _launch_ready_snapshot_payload_changed(snapshot, latest_snapshot):
             break
         chain.append(snapshot)
+
+    if not chain:
+        return None, f"label={label}: stability chain missing current snapshot"
 
     consecutive_snapshots = len(chain)
     oldest_snapshot = chain[-1]
@@ -2099,15 +2137,27 @@ def _build_latest_launch_ready_stability(
         (latest_snapshot.captured_at - oldest_snapshot.captured_at).total_seconds(),
     )
     if consecutive_snapshots < min_snapshot_count:
-        return None
+        return (
+            None,
+            "label="
+            f"{label}: not yet stable ({consecutive_snapshots} < {min_snapshot_count} "
+            "consecutive snapshots)",
+        )
     if stable_seconds < min_stable_seconds:
-        return None
-    return LaunchReadyCanaryStability(
-        snapshot=latest_snapshot,
-        consecutive_snapshots=consecutive_snapshots,
-        stable_seconds=stable_seconds,
-        min_snapshot_count=min_snapshot_count,
-        min_stable_seconds=min_stable_seconds,
+        return (
+            None,
+            "label="
+            f"{label}: stable time too short ({stable_seconds:.1f}s < {min_stable_seconds:.1f}s)",
+        )
+    return (
+        LaunchReadyCanaryStability(
+            snapshot=latest_snapshot,
+            consecutive_snapshots=consecutive_snapshots,
+            stable_seconds=stable_seconds,
+            min_snapshot_count=min_snapshot_count,
+            min_stable_seconds=min_stable_seconds,
+        ),
+        None,
     )
 
 
@@ -2132,36 +2182,34 @@ def _list_ranked_stable_launch_ready_stabilities(
     min_stable_seconds: float,
     now: datetime,
     scan_limit: int,
-) -> list[LaunchReadyCanaryStability]:
+) -> tuple[list[LaunchReadyCanaryStability], str | None]:
     """Return stable launch-ready labels ranked by route quality, then freshness."""
 
     if scan_limit < 1:
         raise ValueError("scan_limit must be positive")
 
-    recent_snapshots = store.list_recent(limit=scan_limit)
-    if not recent_snapshots:
-        return [
-            _build_launch_ready_canary_stability(
-                store=store,
-                label=None,
-                max_snapshot_age_seconds=max_snapshot_age_seconds,
-                min_snapshot_count=min_snapshot_count,
-                min_stable_seconds=min_stable_seconds,
-                now=now,
-            )
-        ]
-
-    labels: list[str] = []
-    seen_labels: set[str] = set()
-    for snapshot in recent_snapshots:
-        if snapshot.label in seen_labels:
-            continue
-        seen_labels.add(snapshot.label)
-        labels.append(snapshot.label)
+    labels = store.list_recent_labels(limit=scan_limit)
+    if not labels:
+        try:
+            return [
+                _build_launch_ready_canary_stability(
+                    store=store,
+                    label=None,
+                    max_snapshot_age_seconds=max_snapshot_age_seconds,
+                    min_snapshot_count=min_snapshot_count,
+                    min_stable_seconds=min_stable_seconds,
+                    now=now,
+                )
+            ], None
+        except HTTPException as exc:
+            if exc.status_code in {404, 409}:
+                return [], str(exc.detail)
+            raise
 
     stabilities: list[LaunchReadyCanaryStability] = []
+    failure_details: list[str] = []
     for label in labels:
-        stability = _build_latest_launch_ready_stability(
+        stability, failure_detail = _evaluate_latest_launch_ready_stability(
             store=store,
             label=label,
             max_snapshot_age_seconds=max_snapshot_age_seconds,
@@ -2171,8 +2219,21 @@ def _list_ranked_stable_launch_ready_stabilities(
         )
         if stability is not None:
             stabilities.append(stability)
+            continue
+        if failure_detail is not None:
+            failure_details.append(failure_detail)
 
-    return sorted(stabilities, key=_rank_launch_ready_stability, reverse=True)
+    ranked = sorted(stabilities, key=_rank_launch_ready_stability, reverse=True)
+    if ranked:
+        return ranked, None
+
+    detail = "No stable launch-ready canary snapshot found"
+    if failure_details:
+        summarized_failures = "; ".join(failure_details[:3])
+        if len(failure_details) > 3:
+            summarized_failures += f"; +{len(failure_details) - 3} more labels"
+        detail = f"{detail}: {summarized_failures}"
+    return [], detail
 
 
 async def scan_approved_canary_once(
@@ -2827,214 +2888,6 @@ async def launch_latest_stable_canary_once(
             detail=global_rate_cap_reason,
         )
 
-    try:
-        stable_candidates = _list_ranked_stable_launch_ready_stabilities(
-            store=launch_ready_store,
-            max_snapshot_age_seconds=settings.launch_ready_canary_max_snapshot_age_seconds,
-            min_snapshot_count=settings.stable_launch_ready_min_snapshot_count,
-            min_stable_seconds=settings.stable_launch_ready_min_stable_seconds,
-            now=timestamp,
-            scan_limit=settings.stable_canary_launch_candidate_scan_limit,
-        )
-        if not stable_candidates:
-            raise HTTPException(
-                status_code=409,
-                detail="No stable launch-ready canary snapshot found",
-            )
-        stability = stable_candidates[0]
-        snapshot, selected, approval = _select_latest_launch_ready_canary_snapshot(
-            store=launch_ready_store,
-            approval_service=route_approval_service,
-            label=stability.snapshot.label,
-            max_snapshot_age_seconds=settings.launch_ready_canary_max_snapshot_age_seconds,
-            now=timestamp,
-        )
-    except HTTPException as exc:
-        if exc.status_code in {404, 409}:
-            return StableCanaryLaunchSummary(
-                status="skipped",
-                database_path=settings.database_target,
-                detail=exc.detail,
-            )
-        raise
-
-    label_cooldown_reason = _build_stable_launch_cooldown_reason(
-        settings=settings,
-        launch_store=stable_launch_store,
-        now=timestamp,
-        label=snapshot.label,
-    )
-    if label_cooldown_reason is not None:
-        return StableCanaryLaunchSummary(
-            status="skipped",
-            database_path=settings.database_target,
-            label=snapshot.label,
-            launch_ready_snapshot_id=snapshot.launch_ready_snapshot_id,
-            approved_snapshot_id=snapshot.approved_snapshot.snapshot_id,
-            detail=label_cooldown_reason,
-        )
-
-    label_rate_cap_reason = _build_stable_launch_rate_cap_reason(
-        settings=settings,
-        launch_store=stable_launch_store,
-        now=timestamp,
-        label=snapshot.label,
-    )
-    if label_rate_cap_reason is not None:
-        return StableCanaryLaunchSummary(
-            status="skipped",
-            database_path=settings.database_target,
-            label=snapshot.label,
-            launch_ready_snapshot_id=snapshot.launch_ready_snapshot_id,
-            approved_snapshot_id=snapshot.approved_snapshot.snapshot_id,
-            detail=label_rate_cap_reason,
-        )
-
-    latest_approved_snapshot = source_approved_store.latest(label=snapshot.label)
-    if latest_approved_snapshot is None:
-        return StableCanaryLaunchSummary(
-            status="skipped",
-            database_path=settings.database_target,
-            label=snapshot.label,
-            launch_ready_snapshot_id=snapshot.launch_ready_snapshot_id,
-            approved_snapshot_id=snapshot.approved_snapshot.snapshot_id,
-            detail="Latest approved canary snapshot is missing for the selected label",
-        )
-    if latest_approved_snapshot.snapshot_id != snapshot.approved_snapshot.snapshot_id:
-        return StableCanaryLaunchSummary(
-            status="skipped",
-            database_path=settings.database_target,
-            label=snapshot.label,
-            launch_ready_snapshot_id=snapshot.launch_ready_snapshot_id,
-            approved_snapshot_id=snapshot.approved_snapshot.snapshot_id,
-            detail=(
-                "Launch-ready canary snapshot is stale relative to the latest "
-                "approved snapshot"
-            ),
-        )
-
-    execution_maturity_reason = _build_stable_launch_execution_maturity_reason(
-        settings=settings,
-        candidate=latest_approved_snapshot.candidate,
-    )
-    if execution_maturity_reason is not None:
-        if settings.stable_canary_launch_shadow_mode:
-            logging.getLogger("carryme.worker").info(
-                "shadow launch maturity blocked label=%s because %s",
-                snapshot.label,
-                execution_maturity_reason,
-            )
-        return StableCanaryLaunchSummary(
-            status="skipped",
-            database_path=settings.database_target,
-            label=snapshot.label,
-            launch_ready_snapshot_id=snapshot.launch_ready_snapshot_id,
-            approved_snapshot_id=snapshot.approved_snapshot.snapshot_id,
-            detail=execution_maturity_reason,
-        )
-
-    latest_outcome_reason = _build_stable_launch_latest_outcome_reason(
-        settings=settings,
-        candidate=latest_approved_snapshot.candidate,
-    )
-    if latest_outcome_reason is not None:
-        if settings.stable_canary_launch_shadow_mode:
-            logging.getLogger("carryme.worker").info(
-                "shadow launch latest-outcome blocked label=%s because %s",
-                snapshot.label,
-                latest_outcome_reason,
-            )
-        return StableCanaryLaunchSummary(
-            status="skipped",
-            database_path=settings.database_target,
-            label=snapshot.label,
-            launch_ready_snapshot_id=snapshot.launch_ready_snapshot_id,
-            approved_snapshot_id=snapshot.approved_snapshot.snapshot_id,
-            detail=latest_outcome_reason,
-        )
-
-    liquidity_and_value_reason = _build_stable_launch_liquidity_and_value_reason(
-        settings=settings,
-        candidate=latest_approved_snapshot.candidate,
-    )
-    if liquidity_and_value_reason is not None:
-        if settings.stable_canary_launch_shadow_mode:
-            logging.getLogger("carryme.worker").info(
-                "shadow launch liquidity/value blocked label=%s because %s",
-                snapshot.label,
-                liquidity_and_value_reason,
-            )
-        return StableCanaryLaunchSummary(
-            status="skipped",
-            database_path=settings.database_target,
-            label=snapshot.label,
-            launch_ready_snapshot_id=snapshot.launch_ready_snapshot_id,
-            approved_snapshot_id=snapshot.approved_snapshot.snapshot_id,
-            detail=liquidity_and_value_reason,
-        )
-
-    recent_approved_chain = _list_recent_approved_snapshot_chain(
-        store=source_approved_store,
-        snapshot=latest_approved_snapshot,
-        max_snapshot_age_seconds=settings.launch_ready_canary_max_snapshot_age_seconds,
-    )
-    automation_gate_reason = _build_approved_snapshot_automation_gate_reason(
-        snapshot=latest_approved_snapshot,
-        recent_chain=recent_approved_chain or [latest_approved_snapshot],
-        settings=settings,
-    )
-    if automation_gate_reason is not None:
-        if settings.stable_canary_launch_shadow_mode:
-            logging.getLogger("carryme.worker").info(
-                "shadow launch gate blocked label=%s because %s",
-                snapshot.label,
-                automation_gate_reason,
-            )
-        return StableCanaryLaunchSummary(
-            status="skipped",
-            database_path=settings.database_target,
-            label=snapshot.label,
-            launch_ready_snapshot_id=snapshot.launch_ready_snapshot_id,
-            approved_snapshot_id=snapshot.approved_snapshot.snapshot_id,
-            detail=(
-                "Latest approved snapshot no longer satisfies automated launch "
-                f"gates: {automation_gate_reason}"
-            ),
-        )
-
-    if snapshot.launch_ready_snapshot_id is not None:
-        previous_launch = stable_launch_store.latest_for_snapshot(snapshot.launch_ready_snapshot_id)
-        if previous_launch is not None:
-            if previous_launch.status == "shadowed":
-                if settings.stable_canary_launch_shadow_mode:
-                    return StableCanaryLaunchSummary(
-                        status="skipped",
-                        database_path=settings.database_target,
-                        label=snapshot.label,
-                        launch_ready_snapshot_id=snapshot.launch_ready_snapshot_id,
-                        approved_snapshot_id=snapshot.approved_snapshot.snapshot_id,
-                        final_pair_state=previous_launch.final_pair_state,
-                        detail=(
-                            "Launch-ready canary snapshot already evaluated in shadow mode by "
-                            "worker"
-                        ),
-                    )
-                # Shadow mode is off but was previously on: allow a real launch now.
-            else:
-                return StableCanaryLaunchSummary(
-                    status="skipped",
-                    database_path=settings.database_target,
-                    label=snapshot.label,
-                    launch_ready_snapshot_id=snapshot.launch_ready_snapshot_id,
-                    approved_snapshot_id=snapshot.approved_snapshot.snapshot_id,
-                    paper_trade_id=previous_launch.paper_trade_id,
-                    final_pair_state=previous_launch.final_pair_state,
-                    detail=(
-                        "Launch-ready canary snapshot already launched by worker as "
-                        f"paper trade {previous_launch.paper_trade_id}"
-                    ),
-                )
-
     risk_budget_scan_limit = settings.stable_canary_launch_active_execution_limit
     active_executions_for_budget = _list_recent_live_executions(
         execution_store,
@@ -3053,34 +2906,239 @@ async def launch_latest_stable_canary_once(
         return StableCanaryLaunchSummary(
             status="skipped",
             database_path=settings.database_target,
-            label=snapshot.label,
-            launch_ready_snapshot_id=snapshot.launch_ready_snapshot_id,
-            approved_snapshot_id=snapshot.approved_snapshot.snapshot_id,
             detail=(
                 "Stable launch risk-budget check truncated by "
                 "stable_canary_launch_active_execution_limit; increase limit"
             ),
         )
 
-    risk_budget_reason = _build_stable_launch_risk_budget_reason(
-        settings=settings,
-        active_executions=active_executions_for_budget,
-        candidate=selected,
+    stable_candidates, no_candidate_detail = _list_ranked_stable_launch_ready_stabilities(
+        store=launch_ready_store,
+        max_snapshot_age_seconds=settings.launch_ready_canary_max_snapshot_age_seconds,
+        min_snapshot_count=settings.stable_launch_ready_min_snapshot_count,
+        min_stable_seconds=settings.stable_launch_ready_min_stable_seconds,
+        now=timestamp,
+        scan_limit=settings.stable_canary_launch_candidate_scan_limit,
     )
-    if risk_budget_reason is not None:
-        if settings.stable_canary_launch_shadow_mode:
-            logging.getLogger("carryme.worker").info(
-                "shadow launch budget blocked label=%s because %s",
-                snapshot.label,
-                risk_budget_reason,
-            )
+    if not stable_candidates:
         return StableCanaryLaunchSummary(
             status="skipped",
             database_path=settings.database_target,
-            label=snapshot.label,
-            launch_ready_snapshot_id=snapshot.launch_ready_snapshot_id,
-            approved_snapshot_id=snapshot.approved_snapshot.snapshot_id,
-            detail=risk_budget_reason,
+            detail=no_candidate_detail or "No stable launch-ready canary snapshot found",
+        )
+
+    stability: LaunchReadyCanaryStability | None = None
+    snapshot: LaunchReadyCanarySnapshot | None = None
+    selected: FundingUniverseCanaryCandidate | None = None
+    approval: RouteApprovalEntry | None = None
+    candidate_skip_details: list[str] = []
+
+    for candidate_stability in stable_candidates:
+        try:
+            candidate_snapshot, candidate_selected, candidate_approval = (
+                _select_latest_launch_ready_canary_snapshot(
+                    store=launch_ready_store,
+                    approval_service=route_approval_service,
+                    label=candidate_stability.snapshot.label,
+                    max_snapshot_age_seconds=settings.launch_ready_canary_max_snapshot_age_seconds,
+                    now=timestamp,
+                )
+            )
+        except HTTPException as exc:
+            if exc.status_code in {404, 409}:
+                candidate_skip_details.append(
+                    f"{candidate_stability.snapshot.label}: {exc.detail}"
+                )
+                continue
+            raise
+
+        label_cooldown_reason = _build_stable_launch_cooldown_reason(
+            settings=settings,
+            launch_store=stable_launch_store,
+            now=timestamp,
+            label=candidate_snapshot.label,
+        )
+        if label_cooldown_reason is not None:
+            candidate_skip_details.append(
+                f"{candidate_snapshot.label}: {label_cooldown_reason}"
+            )
+            continue
+
+        label_rate_cap_reason = _build_stable_launch_rate_cap_reason(
+            settings=settings,
+            launch_store=stable_launch_store,
+            now=timestamp,
+            label=candidate_snapshot.label,
+        )
+        if label_rate_cap_reason is not None:
+            candidate_skip_details.append(
+                f"{candidate_snapshot.label}: {label_rate_cap_reason}"
+            )
+            continue
+
+        candidate_latest_approved_snapshot = source_approved_store.latest(
+            label=candidate_snapshot.label
+        )
+        if candidate_latest_approved_snapshot is None:
+            candidate_skip_details.append(
+                f"{candidate_snapshot.label}: latest approved canary snapshot is missing"
+            )
+            continue
+        if (
+            candidate_latest_approved_snapshot.snapshot_id
+            != candidate_snapshot.approved_snapshot.snapshot_id
+        ):
+            candidate_skip_details.append(
+                f"{candidate_snapshot.label}: launch-ready canary snapshot is stale relative "
+                "to the latest approved snapshot"
+            )
+            continue
+
+        execution_maturity_reason = _build_stable_launch_execution_maturity_reason(
+            settings=settings,
+            candidate=candidate_latest_approved_snapshot.candidate,
+        )
+        if execution_maturity_reason is not None:
+            if settings.stable_canary_launch_shadow_mode:
+                logging.getLogger("carryme.worker").info(
+                    "shadow launch maturity blocked label=%s because %s",
+                    candidate_snapshot.label,
+                    execution_maturity_reason,
+                )
+            candidate_skip_details.append(
+                f"{candidate_snapshot.label}: {execution_maturity_reason}"
+            )
+            continue
+
+        latest_outcome_reason = _build_stable_launch_latest_outcome_reason(
+            settings=settings,
+            candidate=candidate_latest_approved_snapshot.candidate,
+        )
+        if latest_outcome_reason is not None:
+            if settings.stable_canary_launch_shadow_mode:
+                logging.getLogger("carryme.worker").info(
+                    "shadow launch latest-outcome blocked label=%s because %s",
+                    candidate_snapshot.label,
+                    latest_outcome_reason,
+                )
+            candidate_skip_details.append(
+                f"{candidate_snapshot.label}: {latest_outcome_reason}"
+            )
+            continue
+
+        liquidity_and_value_reason = _build_stable_launch_liquidity_and_value_reason(
+            settings=settings,
+            candidate=candidate_latest_approved_snapshot.candidate,
+        )
+        if liquidity_and_value_reason is not None:
+            if settings.stable_canary_launch_shadow_mode:
+                logging.getLogger("carryme.worker").info(
+                    "shadow launch liquidity/value blocked label=%s because %s",
+                    candidate_snapshot.label,
+                    liquidity_and_value_reason,
+                )
+            candidate_skip_details.append(
+                f"{candidate_snapshot.label}: {liquidity_and_value_reason}"
+            )
+            continue
+
+        recent_approved_chain = _list_recent_approved_snapshot_chain(
+            store=source_approved_store,
+            snapshot=candidate_latest_approved_snapshot,
+            max_snapshot_age_seconds=settings.launch_ready_canary_max_snapshot_age_seconds,
+        )
+        automation_gate_reason = _build_approved_snapshot_automation_gate_reason(
+            snapshot=candidate_latest_approved_snapshot,
+            recent_chain=recent_approved_chain or [candidate_latest_approved_snapshot],
+            settings=settings,
+        )
+        if automation_gate_reason is not None:
+            if settings.stable_canary_launch_shadow_mode:
+                logging.getLogger("carryme.worker").info(
+                    "shadow launch gate blocked label=%s because %s",
+                    candidate_snapshot.label,
+                    automation_gate_reason,
+                )
+            candidate_skip_details.append(
+                f"{candidate_snapshot.label}: latest approved snapshot no longer "
+                f"satisfies automated launch gates: {automation_gate_reason}"
+            )
+            continue
+
+        if candidate_snapshot.launch_ready_snapshot_id is not None:
+            previous_launch = stable_launch_store.latest_for_snapshot(
+                candidate_snapshot.launch_ready_snapshot_id
+            )
+            if previous_launch is not None:
+                if previous_launch.status == "shadowed":
+                    if settings.stable_canary_launch_shadow_mode:
+                        candidate_skip_details.append(
+                            f"{candidate_snapshot.label}: launch-ready canary snapshot "
+                            "already evaluated in shadow mode by worker"
+                        )
+                        continue
+                    # Shadow mode is off but was previously on: allow a real launch now.
+                else:
+                    candidate_skip_details.append(
+                        f"{candidate_snapshot.label}: launch-ready canary snapshot already "
+                        f"launched by worker as paper trade {previous_launch.paper_trade_id}"
+                    )
+                    continue
+
+        risk_budget_reason = _build_stable_launch_risk_budget_reason(
+            settings=settings,
+            active_executions=active_executions_for_budget,
+            candidate=candidate_selected,
+        )
+        if risk_budget_reason is not None:
+            if settings.stable_canary_launch_shadow_mode:
+                logging.getLogger("carryme.worker").info(
+                    "shadow launch budget blocked label=%s because %s",
+                    candidate_snapshot.label,
+                    risk_budget_reason,
+                )
+            candidate_skip_details.append(
+                f"{candidate_snapshot.label}: {risk_budget_reason}"
+            )
+            continue
+
+        execution_preflight = _build_candidate_live_execution_preflight(
+            settings=runtime_settings,
+            candidate=candidate_selected,
+            label=candidate_snapshot.label,
+        )
+        if not execution_preflight.ready:
+            try:
+                launch_ready_store.delete_label(candidate_snapshot.label)
+            except Exception:
+                logging.getLogger("carryme.worker").exception(
+                    "failed to invalidate launch-ready snapshots for label=%s "
+                    "during stable launch preflight",
+                    candidate_snapshot.label,
+                )
+            candidate_skip_details.append(
+                f"{candidate_snapshot.label}: latest launch-ready snapshot no longer "
+                "satisfies live execution readiness: "
+                f"{'; '.join(execution_preflight.blocking_reasons)}"
+            )
+            continue
+
+        stability = candidate_stability
+        snapshot = candidate_snapshot
+        selected = candidate_selected
+        approval = candidate_approval
+        break
+
+    if stability is None or snapshot is None or selected is None or approval is None:
+        detail = "No stable launch-ready canary snapshot passed launch gating"
+        if candidate_skip_details:
+            detail = f"{detail}: {'; '.join(candidate_skip_details[:3])}"
+            if len(candidate_skip_details) > 3:
+                detail += f"; +{len(candidate_skip_details) - 3} more labels"
+        return StableCanaryLaunchSummary(
+            status="skipped",
+            database_path=settings.database_target,
+            detail=detail,
         )
 
     if settings.stable_canary_launch_shadow_mode:
@@ -3122,32 +3180,6 @@ async def launch_latest_stable_canary_once(
             launch_ready_snapshot_id=snapshot.launch_ready_snapshot_id,
             approved_snapshot_id=snapshot.approved_snapshot.snapshot_id,
             detail=hold_mode_blocker,
-        )
-
-    execution_preflight = _build_candidate_live_execution_preflight(
-        settings=runtime_settings,
-        candidate=selected,
-        label=snapshot.label,
-    )
-    if not execution_preflight.ready:
-        try:
-            launch_ready_store.delete_label(snapshot.label)
-        except Exception:
-            logging.getLogger("carryme.worker").exception(
-                "failed to invalidate launch-ready snapshots for label=%s "
-                "during stable launch preflight",
-                snapshot.label,
-            )
-        return StableCanaryLaunchSummary(
-            status="skipped",
-            database_path=settings.database_target,
-            label=snapshot.label,
-            launch_ready_snapshot_id=snapshot.launch_ready_snapshot_id,
-            approved_snapshot_id=snapshot.approved_snapshot.snapshot_id,
-            detail=(
-                "Latest launch-ready snapshot no longer satisfies live execution "
-                f"readiness: {'; '.join(execution_preflight.blocking_reasons)}"
-            ),
         )
 
     try:

--- a/apps/worker/src/carryme_worker/poller.py
+++ b/apps/worker/src/carryme_worker/poller.py
@@ -2968,6 +2968,7 @@ async def launch_latest_stable_canary_once(
     snapshot: LaunchReadyCanarySnapshot | None = None
     selected: FundingUniverseCanaryCandidate | None = None
     approval: RouteApprovalEntry | None = None
+    reservation_owner_id: str | None = None
     candidate_skip_details: list[str] = []
     single_candidate = len(stable_candidates) == 1
 
@@ -3298,10 +3299,103 @@ async def launch_latest_stable_canary_once(
             )
             continue
 
+        if settings.stable_canary_launch_shadow_mode:
+            logging.getLogger("carryme.worker").info(
+                "shadow launch for label=%s from launch_ready_snapshot_id=%s",
+                candidate_snapshot.label,
+                candidate_snapshot.launch_ready_snapshot_id,
+            )
+            stable_launch_store.append(
+                StableCanaryLaunchRecord(
+                    launched_at=timestamp,
+                    status="shadowed",
+                    label=candidate_snapshot.label,
+                    launch_ready_snapshot_id=candidate_snapshot.launch_ready_snapshot_id or 0,
+                    approved_snapshot_id=candidate_snapshot.approved_snapshot.snapshot_id or 0,
+                    paper_trade_id=0,
+                    final_pair_state="shadowed",
+                    detail="Shadow mode launch marker",
+                )
+            )
+            return StableCanaryLaunchSummary(
+                status="skipped",
+                database_path=settings.database_target,
+                label=candidate_snapshot.label,
+                launch_ready_snapshot_id=candidate_snapshot.launch_ready_snapshot_id,
+                approved_snapshot_id=candidate_snapshot.approved_snapshot.snapshot_id,
+                detail=(
+                    "Shadow mode: would launch stable canary from launch-ready snapshot "
+                    f"{candidate_snapshot.launch_ready_snapshot_id}"
+                ),
+            )
+
+        hold_mode_blocker = _build_stable_launch_hold_mode_blocker(settings)
+        if hold_mode_blocker is not None:
+            return StableCanaryLaunchSummary(
+                status="skipped",
+                database_path=settings.database_target,
+                label=candidate_snapshot.label,
+                launch_ready_snapshot_id=candidate_snapshot.launch_ready_snapshot_id,
+                approved_snapshot_id=candidate_snapshot.approved_snapshot.snapshot_id,
+                detail=hold_mode_blocker,
+            )
+
+        execution_preflight = _build_candidate_live_execution_preflight(
+            settings=runtime_settings,
+            candidate=candidate_selected,
+            label=candidate_snapshot.label,
+        )
+        if not execution_preflight.ready:
+            try:
+                launch_ready_store.delete_label(candidate_snapshot.label)
+            except Exception:
+                logging.getLogger("carryme.worker").exception(
+                    "failed to invalidate launch-ready snapshots for label=%s "
+                    "during stable launch preflight",
+                    candidate_snapshot.label,
+                )
+            detail = (
+                "Latest launch-ready snapshot no longer satisfies live execution "
+                f"readiness: {'; '.join(execution_preflight.blocking_reasons)}"
+            )
+            summary = _single_candidate_skip(
+                candidate_snapshot=candidate_snapshot,
+                detail=detail,
+            )
+            if summary is not None:
+                return summary
+            candidate_skip_details.append(f"{candidate_snapshot.label}: {detail}")
+            continue
+
+        candidate_reservation_owner_id: str | None = None
+        if candidate_snapshot.launch_ready_snapshot_id is not None:
+            candidate_reservation_owner_id = uuid.uuid4().hex
+            reserved = stable_launch_store.reserve_snapshot_launch(
+                launch_ready_snapshot_id=candidate_snapshot.launch_ready_snapshot_id,
+                label=candidate_snapshot.label,
+                reserved_at=timestamp,
+                max_age_seconds=settings.stable_canary_launch_reservation_ttl_seconds,
+                retention_seconds=(
+                    settings.stable_canary_launch_reservation_retention_seconds
+                ),
+                owner_id=candidate_reservation_owner_id,
+            )
+            if not reserved:
+                detail = "Launch-ready canary snapshot is already reserved for launch by worker"
+                summary = _single_candidate_skip(
+                    candidate_snapshot=candidate_snapshot,
+                    detail=detail,
+                )
+                if summary is not None:
+                    return summary
+                candidate_skip_details.append(f"{candidate_snapshot.label}: {detail}")
+                continue
+
         stability = candidate_stability
         snapshot = candidate_snapshot
         selected = candidate_selected
         approval = candidate_approval
+        reservation_owner_id = candidate_reservation_owner_id
         break
 
     if stability is None or snapshot is None or selected is None or approval is None:
@@ -3315,97 +3409,10 @@ async def launch_latest_stable_canary_once(
             database_path=settings.database_target,
             detail=detail,
         )
-    if settings.stable_canary_launch_shadow_mode:
-        logging.getLogger("carryme.worker").info(
-            "shadow launch for label=%s from launch_ready_snapshot_id=%s",
-            snapshot.label,
-            snapshot.launch_ready_snapshot_id,
-        )
-        stable_launch_store.append(
-            StableCanaryLaunchRecord(
-                launched_at=timestamp,
-                status="shadowed",
-                label=snapshot.label,
-                launch_ready_snapshot_id=snapshot.launch_ready_snapshot_id or 0,
-                approved_snapshot_id=snapshot.approved_snapshot.snapshot_id or 0,
-                paper_trade_id=0,
-                final_pair_state="shadowed",
-                detail="Shadow mode launch marker",
-            )
-        )
-        return StableCanaryLaunchSummary(
-            status="skipped",
-            database_path=settings.database_target,
-            label=snapshot.label,
-            launch_ready_snapshot_id=snapshot.launch_ready_snapshot_id,
-            approved_snapshot_id=snapshot.approved_snapshot.snapshot_id,
-            detail=(
-                "Shadow mode: would launch stable canary from launch-ready snapshot "
-                f"{snapshot.launch_ready_snapshot_id}"
-            ),
-        )
-
-    hold_mode_blocker = _build_stable_launch_hold_mode_blocker(settings)
-    if hold_mode_blocker is not None:
-        return StableCanaryLaunchSummary(
-            status="skipped",
-            database_path=settings.database_target,
-            label=snapshot.label,
-            launch_ready_snapshot_id=snapshot.launch_ready_snapshot_id,
-            approved_snapshot_id=snapshot.approved_snapshot.snapshot_id,
-            detail=hold_mode_blocker,
-        )
-
-    execution_preflight = _build_candidate_live_execution_preflight(
-        settings=runtime_settings,
-        candidate=selected,
-        label=snapshot.label,
-    )
-    if not execution_preflight.ready:
-        try:
-            launch_ready_store.delete_label(snapshot.label)
-        except Exception:
-            logging.getLogger("carryme.worker").exception(
-                "failed to invalidate launch-ready snapshots for label=%s "
-                "during stable launch preflight",
-                snapshot.label,
-            )
-        return StableCanaryLaunchSummary(
-            status="skipped",
-            database_path=settings.database_target,
-            label=snapshot.label,
-            launch_ready_snapshot_id=snapshot.launch_ready_snapshot_id,
-            approved_snapshot_id=snapshot.approved_snapshot.snapshot_id,
-            detail=(
-                "Latest launch-ready snapshot no longer satisfies live execution "
-                f"readiness: {'; '.join(execution_preflight.blocking_reasons)}"
-            ),
-        )
-
-    if snapshot.launch_ready_snapshot_id is not None:
-        reservation_owner_id = uuid.uuid4().hex
-        reserved = stable_launch_store.reserve_snapshot_launch(
-            launch_ready_snapshot_id=snapshot.launch_ready_snapshot_id,
-            label=snapshot.label,
-            reserved_at=timestamp,
-            max_age_seconds=settings.stable_canary_launch_reservation_ttl_seconds,
-            retention_seconds=settings.stable_canary_launch_reservation_retention_seconds,
-            owner_id=reservation_owner_id,
-        )
-        if not reserved:
-            return StableCanaryLaunchSummary(
-                status="skipped",
-                database_path=settings.database_target,
-                label=snapshot.label,
-                launch_ready_snapshot_id=snapshot.launch_ready_snapshot_id,
-                approved_snapshot_id=snapshot.approved_snapshot.snapshot_id,
-                detail="Launch-ready canary snapshot is already reserved for launch by worker",
-            )
-    else:
-        reservation_owner_id = None
+    reservation_launch_ready_snapshot_id = snapshot.launch_ready_snapshot_id
 
     async def renew_stable_launch_reservation_before_open(
-        launch_ready_snapshot_id: int | None = snapshot.launch_ready_snapshot_id,
+        launch_ready_snapshot_id: int | None = reservation_launch_ready_snapshot_id,
         owner_id: str | None = reservation_owner_id,
     ) -> None:
         if launch_ready_snapshot_id is None or owner_id is None:

--- a/apps/worker/src/carryme_worker/poller.py
+++ b/apps/worker/src/carryme_worker/poller.py
@@ -1596,6 +1596,23 @@ def _build_open_hedge_auto_close_reason(
                 f"{settings.execution_auto_pair_close_max_round_trip_break_even_hold_windows:.2f}"
             )
 
+    return _build_open_hedge_max_hold_reason(
+        opened_at=opened_at,
+        hold_window_hours=hold_window_hours,
+        settings=settings,
+        now=now,
+    )
+
+
+def _build_open_hedge_max_hold_reason(
+    *,
+    opened_at: datetime,
+    hold_window_hours: float,
+    settings: WorkerSettings,
+    now: datetime,
+) -> str | None:
+    """Return the deterministic max-hold close reason for one open hedge."""
+
     hold_age_seconds = max(0.0, (now - opened_at).total_seconds())
     hold_age_windows = hold_age_seconds / (hold_window_hours * 3600.0)
     if hold_age_windows >= settings.execution_auto_pair_close_max_hold_windows:
@@ -1627,25 +1644,27 @@ async def _resolve_auto_close_snapshot(
     scanner: OpportunityUniverseService | None,
     logger: logging.Logger,
     now: datetime,
-) -> tuple[ApprovedCanarySnapshot | None, Literal["approved_snapshot", "live_revalidation"] | None]:
+) -> tuple[
+    ApprovedCanarySnapshot | None,
+    Literal["approved_snapshot", "live_revalidation", "stale_approved_snapshot"] | None,
+]:
     paper_trade = execution.paper_trade
     if paper_trade is None:
         return None, None
 
     latest_snapshot = approved_store.latest(label=paper_trade.intent.label)
-    if (
-        latest_snapshot is not None
-        and _approved_snapshot_matches_paper_trade(
-            snapshot=latest_snapshot,
-            paper_trade=paper_trade,
-        )
-        and _approved_snapshot_is_fresh(
+    stale_matching_snapshot: ApprovedCanarySnapshot | None = None
+    if latest_snapshot is not None and _approved_snapshot_matches_paper_trade(
+        snapshot=latest_snapshot,
+        paper_trade=paper_trade,
+    ):
+        if _approved_snapshot_is_fresh(
             snapshot=latest_snapshot,
             settings=settings,
             now=now,
-        )
-    ):
-        return latest_snapshot, "approved_snapshot"
+        ):
+            return latest_snapshot, "approved_snapshot"
+        stale_matching_snapshot = latest_snapshot
 
     fallback_reason = "no approved snapshot exists"
     if latest_snapshot is not None:
@@ -1722,6 +1741,8 @@ async def _resolve_auto_close_snapshot(
             paper_trade.entry_id,
             approval.label,
         )
+        if stale_matching_snapshot is not None:
+            return stale_matching_snapshot, "stale_approved_snapshot"
         return None, None
     except (ConnectorError, UpstreamDataError, httpx.HTTPError, ValueError) as exc:
         logger.warning(
@@ -1730,6 +1751,8 @@ async def _resolve_auto_close_snapshot(
             approval.label,
             exc,
         )
+        if stale_matching_snapshot is not None:
+            return stale_matching_snapshot, "stale_approved_snapshot"
         return None, None
 
     if live_candidate is None:
@@ -1741,6 +1764,8 @@ async def _resolve_auto_close_snapshot(
             paper_trade.entry_id,
             fallback_reason,
         )
+        if stale_matching_snapshot is not None:
+            return stale_matching_snapshot, "stale_approved_snapshot"
         return None, None
 
     live_snapshot = ApprovedCanarySnapshot(
@@ -1760,6 +1785,8 @@ async def _resolve_auto_close_snapshot(
             ),
             paper_trade.entry_id,
         )
+        if stale_matching_snapshot is not None:
+            return stale_matching_snapshot, "stale_approved_snapshot"
         return None, None
 
     logger.debug(
@@ -1974,13 +2001,21 @@ async def _maybe_auto_close_open_hedged_execution(
         attribution=latest_attribution,
     )
     if close_reason is None:
-        close_reason = _build_open_hedge_auto_close_reason(
-            paper_trade=paper_trade,
-            opened_at=execution.executed_at,
-            snapshot=latest_snapshot,
-            settings=settings,
-            now=now,
-        )
+        if snapshot_source == "stale_approved_snapshot":
+            close_reason = _build_open_hedge_max_hold_reason(
+                opened_at=execution.executed_at,
+                hold_window_hours=_hold_window_hours(latest_snapshot),
+                settings=settings,
+                now=now,
+            )
+        else:
+            close_reason = _build_open_hedge_auto_close_reason(
+                paper_trade=paper_trade,
+                opened_at=execution.executed_at,
+                snapshot=latest_snapshot,
+                settings=settings,
+                now=now,
+            )
     if close_reason is None:
         return None
 

--- a/packages/storage/src/carryme_storage/executions.py
+++ b/packages/storage/src/carryme_storage/executions.py
@@ -171,6 +171,24 @@ class ExecutionJournalStore:
                     ON pair_close_live_submission_reservations(confirmation_entry_id)
                     """
                 )
+                connection.execute(
+                    """
+                    CREATE TABLE IF NOT EXISTS cleanup_live_submission_reservations (
+                        paper_trade_id INTEGER NOT NULL,
+                        preview_hash TEXT NOT NULL,
+                        confirmation_entry_id INTEGER NOT NULL,
+                        execution_entry_id INTEGER,
+                        PRIMARY KEY (paper_trade_id, preview_hash)
+                    )
+                    """
+                )
+                connection.execute(
+                    """
+                    CREATE INDEX IF NOT EXISTS
+                    idx_cleanup_live_submission_reservations_confirmation_entry_id
+                    ON cleanup_live_submission_reservations(confirmation_entry_id)
+                    """
+                )
             self._initialized = True
 
     def append(self, entry: ExecutionJournalEntry) -> ExecutionJournalEntry:
@@ -332,6 +350,65 @@ class ExecutionJournalStore:
             connection.execute(
                 """
                 UPDATE pair_close_live_submission_reservations
+                SET execution_entry_id = ?
+                WHERE paper_trade_id = ? AND preview_hash = ?
+                """,
+                (execution_entry_id, paper_trade_id, normalized_preview_hash),
+            )
+
+    def reserve_cleanup_live_submission(
+        self,
+        *,
+        paper_trade_id: int,
+        preview_hash: str,
+        confirmation_entry_id: int,
+    ) -> bool:
+        """Reserve a cleanup live submission for one trade and preview hash."""
+
+        self.initialize()
+        if paper_trade_id < 1:
+            raise ValueError("paper_trade_id must be positive")
+        if confirmation_entry_id < 1:
+            raise ValueError("confirmation_entry_id must be positive")
+        normalized_preview_hash = preview_hash.strip()
+        if not normalized_preview_hash:
+            raise ValueError("preview_hash must be non-empty")
+        with self.database.begin() as connection:
+            result = connection.execute(
+                """
+                INSERT INTO cleanup_live_submission_reservations (
+                    paper_trade_id,
+                    preview_hash,
+                    confirmation_entry_id
+                ) VALUES (?, ?, ?)
+                ON CONFLICT(paper_trade_id, preview_hash) DO NOTHING
+                """,
+                (paper_trade_id, normalized_preview_hash, confirmation_entry_id),
+            )
+        rowcount = getattr(result, "rowcount", None)
+        return isinstance(rowcount, int) and rowcount > 0
+
+    def mark_cleanup_live_submission_completed(
+        self,
+        *,
+        paper_trade_id: int,
+        preview_hash: str,
+        execution_entry_id: int,
+    ) -> None:
+        """Attach the execution journal id to a cleanup live submission reservation."""
+
+        self.initialize()
+        if paper_trade_id < 1:
+            raise ValueError("paper_trade_id must be positive")
+        normalized_preview_hash = preview_hash.strip()
+        if not normalized_preview_hash:
+            raise ValueError("preview_hash must be non-empty")
+        if execution_entry_id < 1:
+            raise ValueError("execution_entry_id must be positive")
+        with self.database.begin() as connection:
+            connection.execute(
+                """
+                UPDATE cleanup_live_submission_reservations
                 SET execution_entry_id = ?
                 WHERE paper_trade_id = ? AND preview_hash = ?
                 """,

--- a/packages/storage/src/carryme_storage/executions.py
+++ b/packages/storage/src/carryme_storage/executions.py
@@ -153,6 +153,24 @@ class ExecutionJournalStore:
                     ON live_submission_reservations(confirmation_entry_id)
                     """
                 )
+                connection.execute(
+                    """
+                    CREATE TABLE IF NOT EXISTS pair_close_live_submission_reservations (
+                        paper_trade_id INTEGER NOT NULL,
+                        preview_hash TEXT NOT NULL,
+                        confirmation_entry_id INTEGER NOT NULL,
+                        execution_entry_id INTEGER,
+                        PRIMARY KEY (paper_trade_id, preview_hash)
+                    )
+                    """
+                )
+                connection.execute(
+                    """
+                    CREATE INDEX IF NOT EXISTS
+                    idx_pair_close_live_submission_reservations_confirmation_entry_id
+                    ON pair_close_live_submission_reservations(confirmation_entry_id)
+                    """
+                )
             self._initialized = True
 
     def append(self, entry: ExecutionJournalEntry) -> ExecutionJournalEntry:
@@ -260,6 +278,100 @@ class ExecutionJournalStore:
                 """,
                 (execution_entry_id, confirmation_entry_id, normalized_preview_hash),
             )
+
+    def reserve_pair_close_live_submission(
+        self,
+        *,
+        paper_trade_id: int,
+        preview_hash: str,
+        confirmation_entry_id: int,
+    ) -> bool:
+        """Reserve a pair-close live submission for one trade and preview hash."""
+
+        self.initialize()
+        if paper_trade_id < 1:
+            raise ValueError("paper_trade_id must be positive")
+        if confirmation_entry_id < 1:
+            raise ValueError("confirmation_entry_id must be positive")
+        normalized_preview_hash = preview_hash.strip()
+        if not normalized_preview_hash:
+            raise ValueError("preview_hash must be non-empty")
+        with self.database.begin() as connection:
+            result = connection.execute(
+                """
+                INSERT INTO pair_close_live_submission_reservations (
+                    paper_trade_id,
+                    preview_hash,
+                    confirmation_entry_id
+                ) VALUES (?, ?, ?)
+                ON CONFLICT(paper_trade_id, preview_hash) DO NOTHING
+                """,
+                (paper_trade_id, normalized_preview_hash, confirmation_entry_id),
+            )
+        rowcount = getattr(result, "rowcount", None)
+        return isinstance(rowcount, int) and rowcount > 0
+
+    def mark_pair_close_live_submission_completed(
+        self,
+        *,
+        paper_trade_id: int,
+        preview_hash: str,
+        execution_entry_id: int,
+    ) -> None:
+        """Attach the execution journal id to a pair-close live submission reservation."""
+
+        self.initialize()
+        if paper_trade_id < 1:
+            raise ValueError("paper_trade_id must be positive")
+        normalized_preview_hash = preview_hash.strip()
+        if not normalized_preview_hash:
+            raise ValueError("preview_hash must be non-empty")
+        if execution_entry_id < 1:
+            raise ValueError("execution_entry_id must be positive")
+        with self.database.begin() as connection:
+            connection.execute(
+                """
+                UPDATE pair_close_live_submission_reservations
+                SET execution_entry_id = ?
+                WHERE paper_trade_id = ? AND preview_hash = ?
+                """,
+                (execution_entry_id, paper_trade_id, normalized_preview_hash),
+            )
+
+    def find_by_paper_trade_preview_hash(
+        self,
+        *,
+        paper_trade_id: int,
+        preview_hash: str,
+    ) -> ExecutionJournalEntry | None:
+        """Return the most recent execution for one paper trade and preview hash."""
+
+        if paper_trade_id < 1:
+            raise ValueError("paper_trade_id must be positive")
+        normalized_preview_hash = preview_hash.strip()
+        if not normalized_preview_hash:
+            raise ValueError("preview_hash must be non-empty")
+        self.initialize()
+        with self.database.begin() as connection:
+            row = connection.execute(
+                """
+                SELECT id, entry_json
+                FROM execution_journal_entries
+                WHERE paper_trade_id = ? AND preview_hash = ?
+                ORDER BY executed_at DESC, id DESC
+                LIMIT 1
+                """,
+                (paper_trade_id, normalized_preview_hash),
+            ).fetchone()
+        if row is None:
+            return None
+        stored_id, entry_json = row
+        return ExecutionJournalEntry.model_validate(
+            {
+                **json.loads(entry_json),
+                "entry_id": stored_id,
+            }
+        )
 
     def find_by_confirmation(
         self,

--- a/packages/storage/src/carryme_storage/executions.py
+++ b/packages/storage/src/carryme_storage/executions.py
@@ -155,6 +155,24 @@ class ExecutionJournalStore:
                 )
                 connection.execute(
                     """
+                    CREATE TABLE IF NOT EXISTS pair_open_live_submission_reservations (
+                        paper_trade_id INTEGER NOT NULL,
+                        preview_hash TEXT NOT NULL,
+                        confirmation_entry_id INTEGER NOT NULL,
+                        execution_entry_id INTEGER,
+                        PRIMARY KEY (paper_trade_id, preview_hash)
+                    )
+                    """
+                )
+                connection.execute(
+                    """
+                    CREATE INDEX IF NOT EXISTS
+                    idx_pair_open_live_submission_reservations_confirmation_entry_id
+                    ON pair_open_live_submission_reservations(confirmation_entry_id)
+                    """
+                )
+                connection.execute(
+                    """
                     CREATE TABLE IF NOT EXISTS pair_close_live_submission_reservations (
                         paper_trade_id INTEGER NOT NULL,
                         preview_hash TEXT NOT NULL,
@@ -295,6 +313,65 @@ class ExecutionJournalStore:
                 WHERE confirmation_entry_id = ? AND preview_hash = ?
                 """,
                 (execution_entry_id, confirmation_entry_id, normalized_preview_hash),
+            )
+
+    def reserve_pair_open_live_submission(
+        self,
+        *,
+        paper_trade_id: int,
+        preview_hash: str,
+        confirmation_entry_id: int,
+    ) -> bool:
+        """Reserve a paired-open live submission for one trade and preview hash."""
+
+        self.initialize()
+        if paper_trade_id < 1:
+            raise ValueError("paper_trade_id must be positive")
+        if confirmation_entry_id < 1:
+            raise ValueError("confirmation_entry_id must be positive")
+        normalized_preview_hash = preview_hash.strip()
+        if not normalized_preview_hash:
+            raise ValueError("preview_hash must be non-empty")
+        with self.database.begin() as connection:
+            result = connection.execute(
+                """
+                INSERT INTO pair_open_live_submission_reservations (
+                    paper_trade_id,
+                    preview_hash,
+                    confirmation_entry_id
+                ) VALUES (?, ?, ?)
+                ON CONFLICT(paper_trade_id, preview_hash) DO NOTHING
+                """,
+                (paper_trade_id, normalized_preview_hash, confirmation_entry_id),
+            )
+        rowcount = getattr(result, "rowcount", None)
+        return isinstance(rowcount, int) and rowcount > 0
+
+    def mark_pair_open_live_submission_completed(
+        self,
+        *,
+        paper_trade_id: int,
+        preview_hash: str,
+        execution_entry_id: int,
+    ) -> None:
+        """Attach the execution journal id to a paired-open live submission reservation."""
+
+        self.initialize()
+        if paper_trade_id < 1:
+            raise ValueError("paper_trade_id must be positive")
+        normalized_preview_hash = preview_hash.strip()
+        if not normalized_preview_hash:
+            raise ValueError("preview_hash must be non-empty")
+        if execution_entry_id < 1:
+            raise ValueError("execution_entry_id must be positive")
+        with self.database.begin() as connection:
+            connection.execute(
+                """
+                UPDATE pair_open_live_submission_reservations
+                SET execution_entry_id = ?
+                WHERE paper_trade_id = ? AND preview_hash = ?
+                """,
+                (execution_entry_id, paper_trade_id, normalized_preview_hash),
             )
 
     def reserve_pair_close_live_submission(

--- a/packages/storage/src/carryme_storage/launch_ready_canaries.py
+++ b/packages/storage/src/carryme_storage/launch_ready_canaries.py
@@ -127,6 +127,24 @@ class LaunchReadyCanaryStore:
         snapshots = self.list_recent(limit=1, label=label)
         return snapshots[0] if snapshots else None
 
+    def list_recent_labels(self, *, limit: int = 50) -> list[str]:
+        """Return recent distinct labels ordered by latest snapshot timestamp."""
+
+        self.initialize()
+        with self.database.begin() as connection:
+            rows = connection.execute(
+                """
+                SELECT label, MAX(captured_at) AS latest_captured_at, MAX(id) AS latest_id
+                FROM launch_ready_canary_snapshots
+                GROUP BY label
+                ORDER BY latest_captured_at DESC, latest_id DESC
+                LIMIT ?
+                """,
+                (limit,),
+            ).fetchall()
+
+        return [label for label, _, _ in rows]
+
     def delete_label(self, label: str) -> int:
         """Delete all launch-ready canary snapshots for one label."""
 

--- a/packages/storage/src/carryme_storage/launch_ready_canaries.py
+++ b/packages/storage/src/carryme_storage/launch_ready_canaries.py
@@ -134,9 +134,20 @@ class LaunchReadyCanaryStore:
         with self.database.begin() as connection:
             rows = connection.execute(
                 """
-                SELECT label, MAX(captured_at) AS latest_captured_at, MAX(id) AS latest_id
-                FROM launch_ready_canary_snapshots
-                GROUP BY label
+                WITH ranked_snapshots AS (
+                    SELECT
+                        label,
+                        captured_at,
+                        id,
+                        ROW_NUMBER() OVER (
+                            PARTITION BY label
+                            ORDER BY captured_at DESC, id DESC
+                        ) AS row_number
+                    FROM launch_ready_canary_snapshots
+                )
+                SELECT label, captured_at AS latest_captured_at, id AS latest_id
+                FROM ranked_snapshots
+                WHERE row_number = 1
                 ORDER BY latest_captured_at DESC, latest_id DESC
                 LIMIT ?
                 """,

--- a/packages/storage/src/carryme_storage/stable_canary_launches.py
+++ b/packages/storage/src/carryme_storage/stable_canary_launches.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from datetime import UTC, datetime
 from pathlib import Path
 
 from carryme_models import StableCanaryLaunchRecord
@@ -47,6 +48,21 @@ class StableCanaryLaunchStore:
                 """
                 CREATE INDEX IF NOT EXISTS idx_stable_canary_launch_records_label
                 ON stable_canary_launch_records(label)
+                """
+            )
+            connection.execute(
+                """
+                CREATE TABLE IF NOT EXISTS stable_canary_launch_reservations (
+                    launch_ready_snapshot_id INTEGER PRIMARY KEY,
+                    reserved_at TEXT NOT NULL,
+                    label TEXT NOT NULL
+                )
+                """
+            )
+            connection.execute(
+                """
+                CREATE INDEX IF NOT EXISTS idx_stable_canary_launch_reservations_label
+                ON stable_canary_launch_reservations(label)
                 """
             )
 
@@ -137,3 +153,41 @@ class StableCanaryLaunchStore:
 
         records = self.list_recent(limit=1, launch_ready_snapshot_id=launch_ready_snapshot_id)
         return records[0] if records else None
+
+    def reserve_snapshot_launch(
+        self,
+        *,
+        launch_ready_snapshot_id: int,
+        label: str,
+        reserved_at: datetime,
+    ) -> bool:
+        """Reserve one launch-ready snapshot for a single live launch attempt."""
+
+        self.initialize()
+        if launch_ready_snapshot_id < 1:
+            raise ValueError("launch_ready_snapshot_id must be positive")
+        normalized_label = label.strip()
+        if not normalized_label:
+            raise ValueError("label must be non-empty")
+        if reserved_at.tzinfo is None or reserved_at.utcoffset() is None:
+            raise ValueError("reserved_at must be timezone-aware")
+
+        with self.database.begin() as connection:
+            result = connection.execute(
+                """
+                INSERT INTO stable_canary_launch_reservations (
+                    launch_ready_snapshot_id,
+                    reserved_at,
+                    label
+                ) VALUES (?, ?, ?)
+                ON CONFLICT(launch_ready_snapshot_id) DO NOTHING
+                """,
+                (
+                    launch_ready_snapshot_id,
+                    reserved_at.astimezone(UTC).isoformat(),
+                    normalized_label,
+                ),
+            )
+
+        rowcount = getattr(result, "rowcount", None)
+        return isinstance(rowcount, int) and rowcount > 0

--- a/packages/storage/src/carryme_storage/stable_canary_launches.py
+++ b/packages/storage/src/carryme_storage/stable_canary_launches.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 import json
-from datetime import UTC, datetime
+import uuid
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 from carryme_models import StableCanaryLaunchRecord
@@ -55,10 +56,19 @@ class StableCanaryLaunchStore:
                 CREATE TABLE IF NOT EXISTS stable_canary_launch_reservations (
                     launch_ready_snapshot_id INTEGER PRIMARY KEY,
                     reserved_at TEXT NOT NULL,
-                    label TEXT NOT NULL
+                    label TEXT NOT NULL,
+                    owner_id TEXT
                 )
                 """
             )
+            columns = connection.table_columns("stable_canary_launch_reservations")
+            if "owner_id" not in columns:
+                connection.execute(
+                    """
+                    ALTER TABLE stable_canary_launch_reservations
+                    ADD COLUMN owner_id TEXT
+                    """
+                )
             connection.execute(
                 """
                 CREATE INDEX IF NOT EXISTS idx_stable_canary_launch_reservations_label
@@ -160,6 +170,9 @@ class StableCanaryLaunchStore:
         launch_ready_snapshot_id: int,
         label: str,
         reserved_at: datetime,
+        max_age_seconds: int | None = None,
+        retention_seconds: int | None = None,
+        owner_id: str | None = None,
     ) -> bool:
         """Reserve one launch-ready snapshot for a single live launch attempt."""
 
@@ -171,21 +184,96 @@ class StableCanaryLaunchStore:
             raise ValueError("label must be non-empty")
         if reserved_at.tzinfo is None or reserved_at.utcoffset() is None:
             raise ValueError("reserved_at must be timezone-aware")
+        if max_age_seconds is not None and max_age_seconds <= 0:
+            raise ValueError("max_age_seconds must be positive")
+        if retention_seconds is not None and retention_seconds <= 0:
+            raise ValueError("retention_seconds must be positive")
+        if (
+            max_age_seconds is not None
+            and retention_seconds is not None
+            and retention_seconds < max_age_seconds
+        ):
+            raise ValueError("retention_seconds must be greater than or equal to max_age_seconds")
+        normalized_owner_id = (owner_id or uuid.uuid4().hex).strip()
+        if not normalized_owner_id:
+            raise ValueError("owner_id must be non-empty")
 
+        normalized_reserved_at = reserved_at.astimezone(UTC)
         with self.database.begin() as connection:
+            effective_retention_seconds = retention_seconds
+            if effective_retention_seconds is None and max_age_seconds is not None:
+                effective_retention_seconds = max(max_age_seconds * 12, 86_400)
+            if effective_retention_seconds is not None:
+                retention_before = normalized_reserved_at - timedelta(
+                    seconds=effective_retention_seconds
+                )
+                connection.execute(
+                    """
+                    DELETE FROM stable_canary_launch_reservations
+                    WHERE reserved_at < ?
+                    """,
+                    (retention_before.isoformat(),),
+                )
+            if max_age_seconds is not None:
+                stale_before = normalized_reserved_at - timedelta(seconds=max_age_seconds)
+                connection.execute(
+                    """
+                    DELETE FROM stable_canary_launch_reservations
+                    WHERE launch_ready_snapshot_id = ? AND reserved_at < ?
+                    """,
+                    (launch_ready_snapshot_id, stale_before.isoformat()),
+                )
             result = connection.execute(
                 """
                 INSERT INTO stable_canary_launch_reservations (
                     launch_ready_snapshot_id,
                     reserved_at,
-                    label
-                ) VALUES (?, ?, ?)
+                    label,
+                    owner_id
+                ) VALUES (?, ?, ?, ?)
                 ON CONFLICT(launch_ready_snapshot_id) DO NOTHING
                 """,
                 (
                     launch_ready_snapshot_id,
-                    reserved_at.astimezone(UTC).isoformat(),
+                    normalized_reserved_at.isoformat(),
                     normalized_label,
+                    normalized_owner_id,
+                ),
+            )
+
+        rowcount = getattr(result, "rowcount", None)
+        return isinstance(rowcount, int) and rowcount > 0
+
+    def renew_snapshot_launch_reservation(
+        self,
+        *,
+        launch_ready_snapshot_id: int,
+        owner_id: str,
+        reserved_at: datetime,
+    ) -> bool:
+        """Renew one snapshot reservation only if the caller still owns its lease."""
+
+        self.initialize()
+        if launch_ready_snapshot_id < 1:
+            raise ValueError("launch_ready_snapshot_id must be positive")
+        normalized_owner_id = owner_id.strip()
+        if not normalized_owner_id:
+            raise ValueError("owner_id must be non-empty")
+        if reserved_at.tzinfo is None or reserved_at.utcoffset() is None:
+            raise ValueError("reserved_at must be timezone-aware")
+
+        normalized_reserved_at = reserved_at.astimezone(UTC)
+        with self.database.begin() as connection:
+            result = connection.execute(
+                """
+                UPDATE stable_canary_launch_reservations
+                SET reserved_at = ?
+                WHERE launch_ready_snapshot_id = ? AND owner_id = ?
+                """,
+                (
+                    normalized_reserved_at.isoformat(),
+                    launch_ready_snapshot_id,
+                    normalized_owner_id,
                 ),
             )
 

--- a/render.yaml
+++ b/render.yaml
@@ -119,6 +119,10 @@ services:
           property: connectionString
       - key: CARRYME_WORKER_ENVIRONMENT
         value: production
+      - key: CARRYME_WORKER_STABLE_CANARY_LAUNCH_RESERVATION_TTL_SECONDS
+        value: 300
+      - key: CARRYME_WORKER_STABLE_CANARY_LAUNCH_RESERVATION_RETENTION_SECONDS
+        value: 86400
       - key: CARRYME_API_EXTENDED_LIVE_ENABLED
         sync: false
       - key: CARRYME_API_EXTENDED_API_KEY

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -7498,6 +7498,20 @@ def test_guarded_pair_close_endpoint_rejects_duplicate_retry(
             "auto_cleanup": "false",
         },
     )
+    original_confirmation = confirmation_store.find_latest_by_preview_hash(
+        paper_trade_id=paper_trade.entry_id or 0,
+        preview_hash="pair-close-hash",
+    )
+    assert original_confirmation is not None
+    confirmation_store.append(
+        original_confirmation.model_copy(
+            update={
+                "entry_id": None,
+                "confirmed_at": datetime(2026, 3, 29, 13, 11, tzinfo=UTC),
+                "note": "duplicate confirmation from parallel monitor",
+            }
+        )
+    )
     second = client.post(
         f"/v1/executions/live/pair/close/from-paper-trade/{paper_trade.entry_id}",
         params={

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -13080,6 +13080,20 @@ def test_guarded_paired_live_execution_endpoint_rejects_duplicate_retry(
             "auto_cleanup": "false",
         },
     )
+    original_confirmation = confirmation_store.find_latest_by_preview_hash(
+        paper_trade_id=paper_trade.entry_id or 0,
+        preview_hash="preview-hash",
+    )
+    assert original_confirmation is not None
+    confirmation_store.append(
+        original_confirmation.model_copy(
+            update={
+                "entry_id": None,
+                "confirmed_at": datetime(2026, 3, 29, 13, 11, tzinfo=UTC),
+                "note": "duplicate confirmation from parallel launcher",
+            }
+        )
+    )
     second = client.post(
         f"/v1/executions/live/pair/guarded/from-paper-trade/{paper_trade.entry_id}",
         params={

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -7503,6 +7503,14 @@ def test_guarded_pair_close_endpoint_rejects_duplicate_retry(
         preview_hash="pair-close-hash",
     )
     assert original_confirmation is not None
+    with execution_store.database.begin() as connection:
+        connection.execute(
+            """
+            DELETE FROM pair_close_live_submission_reservations
+            WHERE paper_trade_id = ? AND preview_hash = ?
+            """,
+            (paper_trade.entry_id or 0, "pair-close-hash"),
+        )
     confirmation_store.append(
         original_confirmation.model_copy(
             update={

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -12640,6 +12640,16 @@ def test_guarded_paired_live_execution_endpoint_returns_existing_cleanup_executi
         preview_hash=existing_cleanup.preview_hash,
         execution_entry_id=existing_cleanup_execution.entry_id,
     )
+    cleanup_confirmation_store.append(
+        CleanupPreviewConfirmationEntry(
+            confirmed_at=datetime(2026, 3, 29, 13, 17, tzinfo=UTC),
+            paper_trade_id=paper_trade.entry_id or 0,
+            label="arb_extended_paradex",
+            preview_hash=existing_cleanup.preview_hash,
+            preview=existing_cleanup.preview,
+            note="parallel monitor duplicate cleanup confirmation",
+        )
+    )
 
     class StubAccountPreflightService:
         def __init__(self) -> None:
@@ -12841,7 +12851,7 @@ def test_guarded_paired_live_execution_endpoint_returns_existing_cleanup_executi
     assert (
         "Existing cleanup execution reused for this confirmation" in payload["pair_status"]["notes"]
     )
-    assert len(cleanup_confirmation_store.list_recent(limit=10)) == 1
+    assert len(cleanup_confirmation_store.list_recent(limit=10)) == 2
     saved_executions = execution_store.list_recent(limit=10)
     assert len(saved_executions) == 2
     cleanup_entries = [

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -828,6 +828,33 @@ def test_execution_journal_store_reserves_pair_close_submission_once_per_trade(
     )
 
 
+def test_execution_journal_store_reserves_cleanup_submission_once_per_trade(
+    tmp_path: Path,
+) -> None:
+    store = ExecutionJournalStore(tmp_path / "history.sqlite3")
+
+    assert store.reserve_cleanup_live_submission(
+        paper_trade_id=7,
+        preview_hash="cleanup-hash",
+        confirmation_entry_id=11,
+    )
+    assert not store.reserve_cleanup_live_submission(
+        paper_trade_id=7,
+        preview_hash="cleanup-hash",
+        confirmation_entry_id=12,
+    )
+    assert store.reserve_cleanup_live_submission(
+        paper_trade_id=7,
+        preview_hash="next-cleanup-hash",
+        confirmation_entry_id=13,
+    )
+    assert store.reserve_cleanup_live_submission(
+        paper_trade_id=8,
+        preview_hash="cleanup-hash",
+        confirmation_entry_id=14,
+    )
+
+
 def test_execution_journal_store_finds_entry_by_confirmation_entry_id(tmp_path: Path) -> None:
     store = ExecutionJournalStore(tmp_path / "history.sqlite3")
     saved = store.append(

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -801,6 +801,33 @@ def test_execution_journal_store_allows_same_confirmation_id_for_different_hashe
     )
 
 
+def test_execution_journal_store_reserves_pair_close_submission_once_per_trade(
+    tmp_path: Path,
+) -> None:
+    store = ExecutionJournalStore(tmp_path / "history.sqlite3")
+
+    assert store.reserve_pair_close_live_submission(
+        paper_trade_id=7,
+        preview_hash="pair-close-hash",
+        confirmation_entry_id=11,
+    )
+    assert not store.reserve_pair_close_live_submission(
+        paper_trade_id=7,
+        preview_hash="pair-close-hash",
+        confirmation_entry_id=12,
+    )
+    assert store.reserve_pair_close_live_submission(
+        paper_trade_id=7,
+        preview_hash="next-pair-close-hash",
+        confirmation_entry_id=13,
+    )
+    assert store.reserve_pair_close_live_submission(
+        paper_trade_id=8,
+        preview_hash="pair-close-hash",
+        confirmation_entry_id=14,
+    )
+
+
 def test_execution_journal_store_finds_entry_by_confirmation_entry_id(tmp_path: Path) -> None:
     store = ExecutionJournalStore(tmp_path / "history.sqlite3")
     saved = store.append(

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -2741,6 +2741,107 @@ def test_launch_ready_canary_store_appends_and_lists_recent(tmp_path: Path) -> N
     assert latest.launch_ready_snapshot_id == results[0].launch_ready_snapshot_id
 
 
+def test_launch_ready_canary_store_lists_recent_labels_by_true_latest_row(
+    tmp_path: Path,
+) -> None:
+    approved_snapshot = ApprovedCanarySnapshot(
+        snapshot_id=7,
+        captured_at=datetime(2026, 3, 29, 14, 10, tzinfo=UTC),
+        label="arb_extended_paradex",
+        candidate=FundingUniverseCanaryCandidate(
+            opportunity=FundingUniverseOpportunity(
+                opportunity=FundingArbOpportunity(
+                    canonical_symbol="ARB-USD-PERP",
+                    long_venue="paradex",
+                    short_venue="extended",
+                    long_fee_profile="pro_fastfills",
+                    short_fee_profile="default",
+                    gross_daily_edge=0.004,
+                    entry_cost_rate=0.00045,
+                    round_trip_cost_rate=0.0009,
+                    one_day_net_edge_after_entry=0.00355,
+                    one_day_net_edge_after_round_trip=0.0031,
+                    break_even_days_entry=0.2,
+                    break_even_days_round_trip=0.3,
+                    capacity=CapacityEstimate(
+                        short_bid_notional=1400.0,
+                        long_ask_notional=900.0,
+                        max_entry_notional=900.0,
+                        limiting_venue="paradex",
+                    ),
+                ),
+                venue_markets={
+                    "extended": FundingUniverseVenueMarket(
+                        venue="extended",
+                        symbol="ARB-USD",
+                    ),
+                    "paradex": FundingUniverseVenueMarket(
+                        venue="paradex",
+                        symbol="ARB-USD-PERP",
+                    ),
+                },
+                deployable_notional=900.0,
+                estimated_one_day_pnl_after_round_trip=2.79,
+            ),
+            suggested_canary_notional=11.0,
+        ),
+        approval=RouteApprovalEntry(
+            updated_at=datetime(2026, 3, 29, 14, 9, tzinfo=UTC),
+            label="arb_extended_paradex",
+            canonical_symbol="ARB-USD-PERP",
+            short_venue="extended",
+            long_venue="paradex",
+            short_fee_profile="default",
+            long_fee_profile="pro_fastfills",
+            approved=True,
+            max_live_notional=11.0,
+            note="approved canary",
+        ),
+    )
+    store = LaunchReadyCanaryStore(tmp_path / "history.sqlite3")
+
+    def append(label: str, captured_at: datetime) -> None:
+        store.append(
+            LaunchReadyCanarySnapshot(
+                captured_at=captured_at,
+                label=label,
+                max_snapshot_age_seconds=300,
+                approved_snapshot=approved_snapshot.model_copy(update={"label": label}),
+                system_state=PaperTradeSystemState(
+                    paper_trade_id=0,
+                    label=label,
+                    ready=True,
+                    venues=[
+                        VenueSystemState(
+                            venue="extended",
+                            enabled=True,
+                            checked=False,
+                            healthy=True,
+                            status=None,
+                        ),
+                        VenueSystemState(
+                            venue="paradex",
+                            enabled=True,
+                            checked=True,
+                            healthy=True,
+                            status="ok",
+                        ),
+                    ],
+                    blocking_reasons=[],
+                ),
+            )
+        )
+
+    append("arb_extended_paradex", datetime(2026, 3, 29, 14, 11, tzinfo=UTC))
+    append("bera_extended_paradex", datetime(2026, 3, 29, 14, 11, tzinfo=UTC))
+    append("arb_extended_paradex", datetime(2026, 3, 29, 14, 10, tzinfo=UTC))
+
+    assert store.list_recent_labels(limit=2) == [
+        "bera_extended_paradex",
+        "arb_extended_paradex",
+    ]
+
+
 def test_stable_canary_launch_store_appends_and_filters(tmp_path: Path) -> None:
     store = StableCanaryLaunchStore(tmp_path / "history.sqlite3")
     record = store.append(

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -828,6 +828,33 @@ def test_execution_journal_store_reserves_pair_close_submission_once_per_trade(
     )
 
 
+def test_execution_journal_store_reserves_pair_open_submission_once_per_trade(
+    tmp_path: Path,
+) -> None:
+    store = ExecutionJournalStore(tmp_path / "history.sqlite3")
+
+    assert store.reserve_pair_open_live_submission(
+        paper_trade_id=7,
+        preview_hash="preview-hash",
+        confirmation_entry_id=11,
+    )
+    assert not store.reserve_pair_open_live_submission(
+        paper_trade_id=7,
+        preview_hash="preview-hash",
+        confirmation_entry_id=12,
+    )
+    assert store.reserve_pair_open_live_submission(
+        paper_trade_id=7,
+        preview_hash="next-preview-hash",
+        confirmation_entry_id=13,
+    )
+    assert store.reserve_pair_open_live_submission(
+        paper_trade_id=8,
+        preview_hash="preview-hash",
+        confirmation_entry_id=14,
+    )
+
+
 def test_execution_journal_store_reserves_cleanup_submission_once_per_trade(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -3001,6 +3001,112 @@ def test_stable_canary_launch_store_reserves_snapshot_launch_once(
     assert second_reserved is False
 
 
+def test_stable_canary_launch_store_reclaims_stale_snapshot_launch_reservation(
+    tmp_path: Path,
+) -> None:
+    store = StableCanaryLaunchStore(tmp_path / "history.sqlite3")
+    reserved_at = datetime(2026, 4, 4, 10, 2, tzinfo=UTC)
+
+    assert store.reserve_snapshot_launch(
+        launch_ready_snapshot_id=9,
+        label="arb_extended_paradex",
+        reserved_at=reserved_at,
+        max_age_seconds=60,
+    )
+    assert not store.reserve_snapshot_launch(
+        launch_ready_snapshot_id=9,
+        label="arb_extended_paradex",
+        reserved_at=reserved_at + timedelta(seconds=59),
+        max_age_seconds=60,
+    )
+    assert store.reserve_snapshot_launch(
+        launch_ready_snapshot_id=9,
+        label="arb_extended_paradex",
+        reserved_at=reserved_at + timedelta(seconds=61),
+        max_age_seconds=60,
+    )
+
+
+def test_stable_canary_launch_store_rejects_lost_reservation_owner(
+    tmp_path: Path,
+) -> None:
+    store = StableCanaryLaunchStore(tmp_path / "history.sqlite3")
+    reserved_at = datetime(2026, 4, 4, 10, 2, tzinfo=UTC)
+
+    assert store.reserve_snapshot_launch(
+        launch_ready_snapshot_id=9,
+        label="arb_extended_paradex",
+        reserved_at=reserved_at,
+        max_age_seconds=60,
+        owner_id="worker-a",
+    )
+    assert store.reserve_snapshot_launch(
+        launch_ready_snapshot_id=9,
+        label="arb_extended_paradex",
+        reserved_at=reserved_at + timedelta(seconds=61),
+        max_age_seconds=60,
+        owner_id="worker-b",
+    )
+
+    assert not store.renew_snapshot_launch_reservation(
+        launch_ready_snapshot_id=9,
+        owner_id="worker-a",
+        reserved_at=reserved_at + timedelta(seconds=62),
+    )
+    assert store.renew_snapshot_launch_reservation(
+        launch_ready_snapshot_id=9,
+        owner_id="worker-b",
+        reserved_at=reserved_at + timedelta(seconds=63),
+    )
+
+
+def test_stable_canary_launch_store_cleans_abandoned_reservations(
+    tmp_path: Path,
+) -> None:
+    store = StableCanaryLaunchStore(tmp_path / "history.sqlite3")
+    reserved_at = datetime(2026, 4, 4, 10, 2, tzinfo=UTC)
+
+    assert store.reserve_snapshot_launch(
+        launch_ready_snapshot_id=9,
+        label="arb_extended_paradex",
+        reserved_at=reserved_at,
+        owner_id="worker-a",
+    )
+    assert store.reserve_snapshot_launch(
+        launch_ready_snapshot_id=10,
+        label="bera_extended_paradex",
+        reserved_at=reserved_at + timedelta(seconds=10),
+        owner_id="worker-b",
+    )
+    assert store.reserve_snapshot_launch(
+        launch_ready_snapshot_id=11,
+        label="near_extended_paradex",
+        reserved_at=reserved_at + timedelta(seconds=100),
+        max_age_seconds=30,
+        retention_seconds=60,
+        owner_id="worker-c",
+    )
+
+    assert store.reserve_snapshot_launch(
+        launch_ready_snapshot_id=9,
+        label="arb_extended_paradex",
+        reserved_at=reserved_at + timedelta(seconds=101),
+        owner_id="worker-d",
+    )
+    assert store.reserve_snapshot_launch(
+        launch_ready_snapshot_id=10,
+        label="bera_extended_paradex",
+        reserved_at=reserved_at + timedelta(seconds=102),
+        owner_id="worker-e",
+    )
+    assert not store.reserve_snapshot_launch(
+        launch_ready_snapshot_id=11,
+        label="near_extended_paradex",
+        reserved_at=reserved_at + timedelta(seconds=103),
+        owner_id="worker-f",
+    )
+
+
 def test_approved_canary_alert_store_appends_and_lists_recent(tmp_path: Path) -> None:
     store = ApprovedCanaryAlertStore(tmp_path / "history.sqlite3")
     previous_snapshot = ApprovedCanarySnapshot(

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -2899,6 +2899,27 @@ def test_stable_canary_launch_store_filters_by_status(tmp_path: Path) -> None:
     assert results[0].launch_ready_snapshot_id == 9
 
 
+def test_stable_canary_launch_store_reserves_snapshot_launch_once(
+    tmp_path: Path,
+) -> None:
+    store = StableCanaryLaunchStore(tmp_path / "history.sqlite3")
+    reserved_at = datetime(2026, 4, 4, 10, 2, tzinfo=UTC)
+
+    first_reserved = store.reserve_snapshot_launch(
+        launch_ready_snapshot_id=9,
+        label="arb_extended_paradex",
+        reserved_at=reserved_at,
+    )
+    second_reserved = store.reserve_snapshot_launch(
+        launch_ready_snapshot_id=9,
+        label="arb_extended_paradex",
+        reserved_at=reserved_at + timedelta(seconds=1),
+    )
+
+    assert first_reserved is True
+    assert second_reserved is False
+
+
 def test_approved_canary_alert_store_appends_and_lists_recent(tmp_path: Path) -> None:
     store = ApprovedCanaryAlertStore(tmp_path / "history.sqlite3")
     previous_snapshot = ApprovedCanarySnapshot(

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -121,10 +121,12 @@ from carryme_worker.poller import (
     UniverseScanLoopSummary,
     UniverseScanSummary,
     _build_api_settings_from_worker_settings,
+    _build_latest_launch_ready_stability,
     _build_open_hedge_auto_close_reason,
     _build_open_hedge_profit_protection_reason,
     _build_order_state_observers,
     _execution_requires_continued_monitoring,
+    _list_ranked_stable_launch_ready_stabilities,
     _maybe_auto_close_open_hedged_execution,
     _probe_candidate_system_state,
     cache_launch_ready_canaries_once,
@@ -4634,7 +4636,7 @@ def test_launch_latest_stable_canary_once_ranks_stable_labels_independently(
             )
         )
 
-    append_launch_ready_pair(
+    high_launch_ready = append_launch_ready_pair(
         high_snapshot,
         high_approved,
         datetime(2026, 4, 4, 10, 0, 0, tzinfo=UTC),
@@ -4739,7 +4741,307 @@ def test_launch_latest_stable_canary_once_ranks_stable_labels_independently(
     assert latest_low.label == "arb_extended_paradex"
     assert summary.status == "launched"
     assert summary.label == "bera_extended_paradex"
+    assert summary.launch_ready_snapshot_id == high_launch_ready.launch_ready_snapshot_id
+    assert summary.approved_snapshot_id == high_approved.snapshot_id
     assert captured_labels == ["bera_extended_paradex"]
+
+
+def test_launch_latest_stable_canary_once_falls_through_blocked_top_candidate(
+    tmp_path: Path,
+) -> None:
+    settings = WorkerSettings(
+        database_path=str(tmp_path / "history.sqlite3"),
+        stable_canary_launch_label_cooldown_seconds=300,
+    )
+    launch_ready_store = LaunchReadyCanaryStore(settings.database_path)
+    approved_store = ApprovedCanaryStore(settings.database_path)
+    route_approval_store = RouteApprovalStore(settings.database_path)
+    stable_launch_store = StableCanaryLaunchStore(settings.database_path)
+
+    top_approval, _, top_snapshot, _ = _build_stable_launch_test_snapshot(
+        label="bera_extended_paradex",
+        canonical_symbol="BERA-USD-PERP",
+        short_symbol="BERA-USD",
+        long_symbol="BERA-USD-PERP",
+        launch_ready_snapshot_id=40,
+        approved_snapshot_id=39,
+        suggested_canary_notional=20.0,
+        min_daily_volume=120_000.0,
+        deployable_notional=1000.0,
+        estimated_one_day_pnl_after_round_trip=3.0,
+    )
+    fallback_approval, fallback_candidate, fallback_snapshot, _ = (
+        _build_stable_launch_test_snapshot(
+            label="arb_extended_paradex",
+            launch_ready_snapshot_id=20,
+            approved_snapshot_id=19,
+        )
+    )
+    top_approved = approved_store.append(top_snapshot.approved_snapshot)
+    fallback_approved = approved_store.append(fallback_snapshot.approved_snapshot)
+    route_approval_store.upsert(top_approval)
+    route_approval_store.upsert(fallback_approval)
+
+    def append_launch_ready_pair(
+        snapshot: LaunchReadyCanarySnapshot,
+        approved_snapshot: ApprovedCanarySnapshot,
+        first_captured_at: datetime,
+        second_captured_at: datetime,
+    ) -> LaunchReadyCanarySnapshot:
+        launch_ready_store.append(
+            snapshot.model_copy(
+                update={
+                    "launch_ready_snapshot_id": None,
+                    "captured_at": first_captured_at,
+                    "approved_snapshot": approved_snapshot,
+                }
+            )
+        )
+        return launch_ready_store.append(
+            snapshot.model_copy(
+                update={
+                    "launch_ready_snapshot_id": None,
+                    "captured_at": second_captured_at,
+                    "approved_snapshot": approved_snapshot,
+                }
+            )
+        )
+
+    top_launch_ready = append_launch_ready_pair(
+        top_snapshot,
+        top_approved,
+        datetime(2026, 4, 4, 10, 0, 0, tzinfo=UTC),
+        datetime(2026, 4, 4, 10, 1, 0, tzinfo=UTC),
+    )
+    fallback_launch_ready = append_launch_ready_pair(
+        fallback_snapshot,
+        fallback_approved,
+        datetime(2026, 4, 4, 10, 0, 10, tzinfo=UTC),
+        datetime(2026, 4, 4, 10, 1, 10, tzinfo=UTC),
+    )
+    stable_launch_store.append(
+        StableCanaryLaunchRecord(
+            launched_at=datetime(2026, 4, 4, 10, 1, 5, tzinfo=UTC),
+            status="launched",
+            label=top_launch_ready.label,
+            launch_ready_snapshot_id=top_launch_ready.launch_ready_snapshot_id or 0,
+            approved_snapshot_id=top_approved.snapshot_id or 0,
+            paper_trade_id=7,
+            final_pair_state="closed",
+        )
+    )
+
+    captured_labels: list[str] = []
+
+    class StubLifecycleResult:
+        def __init__(self, label: str) -> None:
+            self.paper_trade = PaperTradeEntry(
+                entry_id=17,
+                created_at=datetime(2026, 4, 4, 10, 1, 20, tzinfo=UTC),
+                intent=FundingPairTradeIntent(
+                    label=label,
+                    canonical_symbol=fallback_candidate.opportunity.opportunity.canonical_symbol,
+                    source_recorded_at=datetime(2026, 4, 4, 10, 1, tzinfo=UTC),
+                    one_day_net_edge_after_entry=0.00355,
+                    break_even_days_entry=0.2,
+                    capacity_limit_notional=900.0,
+                    target_notional=20.0,
+                    capacity_fraction=20.0 / 900.0,
+                    max_target_notional=20.0,
+                    long_leg=TradeLegIntent(
+                        venue="paradex",
+                        symbol=fallback_candidate.opportunity.venue_markets["paradex"].symbol,
+                        fee_profile="pro_fastfills",
+                        side="buy",
+                        target_notional=20.0,
+                    ),
+                    short_leg=TradeLegIntent(
+                        venue="extended",
+                        symbol=fallback_candidate.opportunity.venue_markets["extended"].symbol,
+                        fee_profile="default",
+                        side="sell",
+                        target_notional=20.0,
+                    ),
+                ),
+                note="worker launch",
+            )
+            self.final_pair_status = ExecutionPairStatus(
+                execution_entry_id=31,
+                paper_trade_id=17,
+                preview_hash="preview",
+                derived_state="closed",
+                recommended_action="no_action",
+                order_state=ExecutionOrderState(
+                    execution_entry_id=31,
+                    paper_trade_id=17,
+                    preview_hash="preview",
+                    legs=[],
+                    notes=[],
+                ),
+                reconciliation=ExecutionReconciliation(
+                    execution_entry_id=31,
+                    paper_trade_id=17,
+                    preview_hash="preview",
+                    status="accepted",
+                    recommended_action="no_action",
+                    matched_all_leg_symbols=True,
+                    venues=[],
+                    notes=[],
+                ),
+                notes=[],
+            )
+
+    async def run_stub_lifecycle(**kwargs: object) -> StubLifecycleResult:
+        approval = cast(RouteApprovalEntry, kwargs["approval"])
+        captured_labels.append(approval.label)
+        return StubLifecycleResult(approval.label)
+
+    api_settings = ApiSettings(
+        database_path=settings.database_path,
+        watchlist_path=settings.watchlist_path,
+        environment=settings.environment,
+        extended_live_enabled=True,
+        extended_api_key="extended-key",
+        extended_stark_private_key="extended-secret",
+        paradex_live_enabled=True,
+        paradex_account_address="0x123",
+        paradex_private_key="0x456",
+    )
+    with pytest.MonkeyPatch.context() as monkeypatch:
+        monkeypatch.setattr(
+            "carryme_worker.poller._run_guarded_canary_lifecycle",
+            run_stub_lifecycle,
+        )
+        summary = asyncio.run(
+            launch_latest_stable_canary_once(
+                settings,
+                api_settings=api_settings,
+                launch_store=stable_launch_store,
+                approved_store=approved_store,
+                now=datetime(2026, 4, 4, 10, 1, 20, tzinfo=UTC),
+            )
+        )
+
+    assert summary.status == "launched"
+    assert summary.label == fallback_launch_ready.label
+    assert summary.launch_ready_snapshot_id == fallback_launch_ready.launch_ready_snapshot_id
+    assert summary.approved_snapshot_id == fallback_approved.snapshot_id
+    assert captured_labels == [fallback_approval.label]
+
+
+def test_list_ranked_stable_launch_ready_stabilities_uses_distinct_label_scan_limit(
+    tmp_path: Path,
+) -> None:
+    settings = WorkerSettings(database_path=str(tmp_path / "history.sqlite3"))
+    launch_ready_store = LaunchReadyCanaryStore(settings.database_path)
+    approved_store = ApprovedCanaryStore(settings.database_path)
+    _, _, first_snapshot, _ = _build_stable_launch_test_snapshot(
+        label="bera_extended_paradex",
+        canonical_symbol="BERA-USD-PERP",
+        short_symbol="BERA-USD",
+        long_symbol="BERA-USD-PERP",
+        launch_ready_snapshot_id=41,
+        approved_snapshot_id=40,
+    )
+    _, _, second_snapshot, _ = _build_stable_launch_test_snapshot(
+        label="arb_extended_paradex",
+        launch_ready_snapshot_id=21,
+        approved_snapshot_id=20,
+    )
+    first_approved = approved_store.append(first_snapshot.approved_snapshot)
+    second_approved = approved_store.append(second_snapshot.approved_snapshot)
+
+    def append_snapshot(
+        snapshot: LaunchReadyCanarySnapshot,
+        approved_snapshot: ApprovedCanarySnapshot,
+        captured_at: datetime,
+    ) -> None:
+        launch_ready_store.append(
+            snapshot.model_copy(
+                update={
+                    "launch_ready_snapshot_id": None,
+                    "captured_at": captured_at,
+                    "approved_snapshot": approved_snapshot,
+                }
+            )
+        )
+
+    append_snapshot(first_snapshot, first_approved, datetime(2026, 4, 4, 10, 1, 40, tzinfo=UTC))
+    append_snapshot(first_snapshot, first_approved, datetime(2026, 4, 4, 10, 1, 20, tzinfo=UTC))
+    append_snapshot(first_snapshot, first_approved, datetime(2026, 4, 4, 10, 1, 0, tzinfo=UTC))
+    append_snapshot(second_snapshot, second_approved, datetime(2026, 4, 4, 10, 0, 50, tzinfo=UTC))
+    append_snapshot(second_snapshot, second_approved, datetime(2026, 4, 4, 10, 0, 20, tzinfo=UTC))
+
+    stabilities, detail = _list_ranked_stable_launch_ready_stabilities(
+        store=launch_ready_store,
+        max_snapshot_age_seconds=300,
+        min_snapshot_count=2,
+        min_stable_seconds=20.0,
+        now=datetime(2026, 4, 4, 10, 1, 50, tzinfo=UTC),
+        scan_limit=2,
+    )
+
+    assert detail is None
+    assert {stability.snapshot.label for stability in stabilities} == {
+        "bera_extended_paradex",
+        "arb_extended_paradex",
+    }
+
+
+def test_build_latest_launch_ready_stability_handles_empty_snapshot_chain() -> None:
+    class EmptyChainStore:
+        def list_recent(
+            self,
+            *,
+            limit: int = 50,
+            label: str | None = None,
+        ) -> list[LaunchReadyCanarySnapshot]:
+            _ = limit, label
+            return []
+
+    stability = _build_latest_launch_ready_stability(
+        store=cast(Any, EmptyChainStore()),
+        label="arb_extended_paradex",
+        max_snapshot_age_seconds=300,
+        min_snapshot_count=2,
+        min_stable_seconds=20.0,
+        now=datetime(2026, 4, 4, 10, 1, 50, tzinfo=UTC),
+    )
+
+    assert stability is None
+
+
+def test_list_ranked_stable_launch_ready_stabilities_reports_failure_detail_when_none_stable(
+    tmp_path: Path,
+) -> None:
+    settings = WorkerSettings(database_path=str(tmp_path / "history.sqlite3"))
+    launch_ready_store = LaunchReadyCanaryStore(settings.database_path)
+    approved_store = ApprovedCanaryStore(settings.database_path)
+    _, _, snapshot, _ = _build_stable_launch_test_snapshot(label="arb_extended_paradex")
+    approved_snapshot = approved_store.append(snapshot.approved_snapshot)
+    launch_ready_store.append(
+        snapshot.model_copy(
+            update={
+                "launch_ready_snapshot_id": None,
+                "captured_at": datetime(2026, 4, 4, 9, 50, 0, tzinfo=UTC),
+                "approved_snapshot": approved_snapshot,
+            }
+        )
+    )
+
+    stabilities, detail = _list_ranked_stable_launch_ready_stabilities(
+        store=launch_ready_store,
+        max_snapshot_age_seconds=300,
+        min_snapshot_count=2,
+        min_stable_seconds=20.0,
+        now=datetime(2026, 4, 4, 10, 1, 50, tzinfo=UTC),
+        scan_limit=2,
+    )
+
+    assert stabilities == []
+    assert detail is not None
+    assert "arb_extended_paradex" in detail
+    assert "stale" in detail
 
 
 def test_launch_latest_stable_canary_once_skips_when_global_cooldown_active(

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -5260,6 +5260,116 @@ def test_launch_latest_stable_canary_once_skips_when_selected_snapshot_lacks_rev
     )
 
 
+def test_launch_latest_stable_canary_once_falls_through_reserved_snapshot(
+    tmp_path: Path,
+) -> None:
+    settings = WorkerSettings(database_path=str(tmp_path / "history.sqlite3"))
+    approved_store = ApprovedCanaryStore(settings.database_path)
+    launch_store = StableCanaryLaunchStore(settings.database_path)
+    high_approval, high_candidate, high_snapshot, high_stability = (
+        _build_stable_launch_test_snapshot(
+            label="bera_extended_paradex",
+            canonical_symbol="BERA-USD-PERP",
+            short_symbol="BERA-USD",
+            long_symbol="BERA-USD-PERP",
+            launch_ready_snapshot_id=29,
+            approved_snapshot_id=28,
+            estimated_one_day_pnl_after_round_trip=3.0,
+        )
+    )
+    fallback_approval, fallback_candidate, fallback_snapshot, fallback_stability = (
+        _build_stable_launch_test_snapshot(
+            label="arb_extended_paradex",
+            canonical_symbol="ARB-USD-PERP",
+            short_symbol="ARB-USD",
+            long_symbol="ARB-USD-PERP",
+            launch_ready_snapshot_id=39,
+            approved_snapshot_id=38,
+            estimated_one_day_pnl_after_round_trip=1.5,
+        )
+    )
+    high_approved = approved_store.append(high_snapshot.approved_snapshot)
+    fallback_approved = approved_store.append(fallback_snapshot.approved_snapshot)
+    high_snapshot = high_snapshot.model_copy(update={"approved_snapshot": high_approved})
+    fallback_snapshot = fallback_snapshot.model_copy(
+        update={"approved_snapshot": fallback_approved}
+    )
+    high_stability = high_stability.model_copy(update={"snapshot": high_snapshot})
+    fallback_stability = fallback_stability.model_copy(update={"snapshot": fallback_snapshot})
+    assert high_snapshot.launch_ready_snapshot_id is not None
+    assert launch_store.reserve_snapshot_launch(
+        launch_ready_snapshot_id=high_snapshot.launch_ready_snapshot_id,
+        label=high_snapshot.label,
+        reserved_at=datetime(2026, 4, 4, 10, 1, 5, tzinfo=UTC),
+    )
+    selected_by_label = {
+        high_snapshot.label: (high_snapshot, high_candidate, high_approval),
+        fallback_snapshot.label: (
+            fallback_snapshot,
+            fallback_candidate,
+            fallback_approval,
+        ),
+    }
+    captured_labels: list[str] = []
+
+    class StubLifecycleResult:
+        def __init__(self) -> None:
+            self.paper_trade = type("StubPaperTrade", (), {"entry_id": 48})()
+            self.final_pair_status = type("StubPairStatus", (), {"derived_state": "closed"})()
+
+    async def run_stub_lifecycle(**kwargs: object) -> Any:
+        approval = cast(RouteApprovalEntry, kwargs["approval"])
+        captured_labels.append(approval.label)
+        return StubLifecycleResult()
+
+    def select_stub(**kwargs: object) -> tuple[
+        LaunchReadyCanarySnapshot,
+        FundingUniverseCanaryCandidate,
+        RouteApprovalEntry,
+    ]:
+        label = cast(str, kwargs["label"])
+        return selected_by_label[label]
+
+    api_settings = ApiSettings(
+        database_path=settings.database_path,
+        watchlist_path=settings.watchlist_path,
+        environment=settings.environment,
+        extended_live_enabled=True,
+        extended_api_key="extended-key",
+        extended_stark_private_key="extended-secret",
+        paradex_live_enabled=True,
+        paradex_account_address="0x123",
+        paradex_private_key="0x456",
+    )
+    with pytest.MonkeyPatch.context() as monkeypatch:
+        monkeypatch.setattr(
+            "carryme_worker.poller._list_ranked_stable_launch_ready_stabilities",
+            lambda **_: [high_stability, fallback_stability],
+        )
+        monkeypatch.setattr(
+            "carryme_worker.poller._select_latest_launch_ready_canary_snapshot",
+            select_stub,
+        )
+        monkeypatch.setattr(
+            "carryme_worker.poller._run_guarded_canary_lifecycle",
+            run_stub_lifecycle,
+        )
+        summary = asyncio.run(
+            launch_latest_stable_canary_once(
+                settings,
+                api_settings=api_settings,
+                launch_store=launch_store,
+                approved_store=approved_store,
+                now=datetime(2026, 4, 4, 10, 1, 30, tzinfo=UTC),
+            )
+        )
+
+    assert summary.status == "launched"
+    assert summary.label == "arb_extended_paradex"
+    assert summary.launch_ready_snapshot_id == fallback_snapshot.launch_ready_snapshot_id
+    assert captured_labels == ["arb_extended_paradex"]
+
+
 def test_launch_latest_stable_canary_once_skips_when_global_cooldown_active(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -4649,35 +4649,43 @@ def test_launch_latest_stable_canary_once_ranks_stable_labels_independently(
         datetime(2026, 4, 4, 10, 1, 10, tzinfo=UTC),
     )
     captured_labels: list[str] = []
+    captured_leg_symbols: list[tuple[str, str]] = []
 
     class StubLifecycleResult:
-        def __init__(self, label: str) -> None:
+        def __init__(
+            self,
+            approval: RouteApprovalEntry,
+            candidate: FundingUniverseCanaryCandidate,
+        ) -> None:
+            route = candidate.opportunity.opportunity
+            venue_markets = candidate.opportunity.venue_markets
+            target_notional = candidate.suggested_canary_notional
             self.paper_trade = PaperTradeEntry(
                 entry_id=17,
                 created_at=datetime(2026, 4, 4, 10, 1, 20, tzinfo=UTC),
                 intent=FundingPairTradeIntent(
-                    label=label,
-                    canonical_symbol="BERA-USD-PERP",
+                    label=approval.label,
+                    canonical_symbol=approval.canonical_symbol,
                     source_recorded_at=datetime(2026, 4, 4, 10, 1, tzinfo=UTC),
                     one_day_net_edge_after_entry=0.00355,
                     break_even_days_entry=0.2,
                     capacity_limit_notional=900.0,
-                    target_notional=20.0,
-                    capacity_fraction=20.0 / 900.0,
-                    max_target_notional=20.0,
+                    target_notional=target_notional,
+                    capacity_fraction=target_notional / 900.0,
+                    max_target_notional=target_notional,
                     long_leg=TradeLegIntent(
-                        venue="paradex",
-                        symbol="BERA-USD-PERP",
-                        fee_profile="pro_fastfills",
+                        venue=approval.long_venue,
+                        symbol=venue_markets[route.long_venue].symbol,
+                        fee_profile=approval.long_fee_profile,
                         side="buy",
-                        target_notional=20.0,
+                        target_notional=target_notional,
                     ),
                     short_leg=TradeLegIntent(
-                        venue="extended",
-                        symbol="BERA-USD",
-                        fee_profile="default",
+                        venue=approval.short_venue,
+                        symbol=venue_markets[route.short_venue].symbol,
+                        fee_profile=approval.short_fee_profile,
                         side="sell",
-                        target_notional=20.0,
+                        target_notional=target_notional,
                     ),
                 ),
                 note="worker launch",
@@ -4710,8 +4718,16 @@ def test_launch_latest_stable_canary_once_ranks_stable_labels_independently(
 
     async def run_stub_lifecycle(**kwargs: object) -> StubLifecycleResult:
         approval = cast(RouteApprovalEntry, kwargs["approval"])
+        candidate = cast(FundingUniverseCanaryCandidate, kwargs["candidate"])
         captured_labels.append(approval.label)
-        return StubLifecycleResult(approval.label)
+        result = StubLifecycleResult(approval, candidate)
+        captured_leg_symbols.append(
+            (
+                result.paper_trade.intent.long_leg.symbol,
+                result.paper_trade.intent.short_leg.symbol,
+            )
+        )
+        return result
 
     api_settings = ApiSettings(
         database_path=settings.database_path,
@@ -4744,6 +4760,7 @@ def test_launch_latest_stable_canary_once_ranks_stable_labels_independently(
     assert summary.launch_ready_snapshot_id == high_launch_ready.launch_ready_snapshot_id
     assert summary.approved_snapshot_id == high_approved.snapshot_id
     assert captured_labels == ["bera_extended_paradex"]
+    assert captured_leg_symbols == [("BERA-USD-PERP", "BERA-USD")]
 
 
 def test_launch_latest_stable_canary_once_falls_through_blocked_top_candidate(
@@ -4988,6 +5005,107 @@ def test_list_ranked_stable_launch_ready_stabilities_uses_distinct_label_scan_li
     }
 
 
+def test_launch_latest_stable_canary_once_honors_candidate_scan_limit(
+    tmp_path: Path,
+) -> None:
+    settings = WorkerSettings(
+        database_path=str(tmp_path / "history.sqlite3"),
+        stable_canary_launch_label_cooldown_seconds=300,
+        stable_canary_launch_candidate_scan_limit=1,
+    )
+    launch_ready_store = LaunchReadyCanaryStore(settings.database_path)
+    approved_store = ApprovedCanaryStore(settings.database_path)
+    route_approval_store = RouteApprovalStore(settings.database_path)
+    stable_launch_store = StableCanaryLaunchStore(settings.database_path)
+
+    top_approval, _, top_snapshot, _ = _build_stable_launch_test_snapshot(
+        label="bera_extended_paradex",
+        canonical_symbol="BERA-USD-PERP",
+        short_symbol="BERA-USD",
+        long_symbol="BERA-USD-PERP",
+        launch_ready_snapshot_id=40,
+        approved_snapshot_id=39,
+        suggested_canary_notional=20.0,
+        estimated_one_day_pnl_after_round_trip=3.0,
+    )
+    fallback_approval, _, fallback_snapshot, _ = _build_stable_launch_test_snapshot(
+        label="arb_extended_paradex",
+        launch_ready_snapshot_id=20,
+        approved_snapshot_id=19,
+        estimated_one_day_pnl_after_round_trip=1.0,
+    )
+    top_approved = approved_store.append(top_snapshot.approved_snapshot)
+    fallback_approved = approved_store.append(fallback_snapshot.approved_snapshot)
+    route_approval_store.upsert(top_approval)
+    route_approval_store.upsert(fallback_approval)
+
+    def append_launch_ready_pair(
+        snapshot: LaunchReadyCanarySnapshot,
+        approved_snapshot: ApprovedCanarySnapshot,
+        first_captured_at: datetime,
+        second_captured_at: datetime,
+    ) -> LaunchReadyCanarySnapshot:
+        launch_ready_store.append(
+            snapshot.model_copy(
+                update={
+                    "launch_ready_snapshot_id": None,
+                    "captured_at": first_captured_at,
+                    "approved_snapshot": approved_snapshot,
+                }
+            )
+        )
+        return launch_ready_store.append(
+            snapshot.model_copy(
+                update={
+                    "launch_ready_snapshot_id": None,
+                    "captured_at": second_captured_at,
+                    "approved_snapshot": approved_snapshot,
+                }
+            )
+        )
+
+    top_launch_ready = append_launch_ready_pair(
+        top_snapshot,
+        top_approved,
+        datetime(2026, 4, 4, 10, 0, 0, tzinfo=UTC),
+        datetime(2026, 4, 4, 10, 1, 0, tzinfo=UTC),
+    )
+    append_launch_ready_pair(
+        fallback_snapshot,
+        fallback_approved,
+        datetime(2026, 4, 4, 10, 0, 10, tzinfo=UTC),
+        datetime(2026, 4, 4, 10, 0, 50, tzinfo=UTC),
+    )
+    stable_launch_store.append(
+        StableCanaryLaunchRecord(
+            launched_at=datetime(2026, 4, 4, 10, 0, 30, tzinfo=UTC),
+            status="launched",
+            label=top_launch_ready.label,
+            launch_ready_snapshot_id=top_launch_ready.launch_ready_snapshot_id or 0,
+            approved_snapshot_id=top_approved.snapshot_id or 0,
+            paper_trade_id=77,
+            final_pair_state="closed",
+        )
+    )
+
+    summary = asyncio.run(
+        launch_latest_stable_canary_once(
+            settings,
+            launch_store=stable_launch_store,
+            approved_store=approved_store,
+            now=datetime(2026, 4, 4, 10, 1, 20, tzinfo=UTC),
+        )
+    )
+
+    assert summary.status == "skipped"
+    assert summary.label == "bera_extended_paradex"
+    assert summary.launch_ready_snapshot_id == top_launch_ready.launch_ready_snapshot_id
+    assert summary.detail == (
+        "Stable launch label cooldown active: "
+        "label=bera_extended_paradex remaining_seconds=250"
+    )
+
+
 def test_build_latest_launch_ready_stability_handles_empty_snapshot_chain() -> None:
     class EmptyChainStore:
         def list_recent(
@@ -5042,6 +5160,104 @@ def test_list_ranked_stable_launch_ready_stabilities_reports_failure_detail_when
     assert detail is not None
     assert "arb_extended_paradex" in detail
     assert "stale" in detail
+
+
+def test_list_ranked_stable_launch_ready_stabilities_reports_future_snapshot_detail(
+    tmp_path: Path,
+) -> None:
+    settings = WorkerSettings(database_path=str(tmp_path / "history.sqlite3"))
+    launch_ready_store = LaunchReadyCanaryStore(settings.database_path)
+    approved_store = ApprovedCanaryStore(settings.database_path)
+    _, _, snapshot, _ = _build_stable_launch_test_snapshot(label="arb_extended_paradex")
+    approved_snapshot = approved_store.append(snapshot.approved_snapshot)
+    launch_ready_store.append(
+        snapshot.model_copy(
+            update={
+                "launch_ready_snapshot_id": None,
+                "captured_at": datetime(2026, 4, 4, 10, 2, 0, tzinfo=UTC),
+                "approved_snapshot": approved_snapshot,
+            }
+        )
+    )
+
+    stabilities, detail = _list_ranked_stable_launch_ready_stabilities(
+        store=launch_ready_store,
+        max_snapshot_age_seconds=300,
+        min_snapshot_count=2,
+        min_stable_seconds=20.0,
+        now=datetime(2026, 4, 4, 10, 1, 50, tzinfo=UTC),
+        scan_limit=2,
+    )
+
+    assert stabilities == []
+    assert detail is not None
+    assert "future" in detail
+
+
+def test_launch_latest_stable_canary_once_skips_when_selected_snapshot_lacks_revalidated_stability(
+    tmp_path: Path,
+) -> None:
+    settings = WorkerSettings(database_path=str(tmp_path / "history.sqlite3"))
+    launch_ready_store = LaunchReadyCanaryStore(settings.database_path)
+    approved_store = ApprovedCanaryStore(settings.database_path)
+    route_approval_store = RouteApprovalStore(settings.database_path)
+    approval, candidate, snapshot, _ = _build_stable_launch_test_snapshot(
+        label="arb_extended_paradex",
+        launch_ready_snapshot_id=9,
+        approved_snapshot_id=8,
+    )
+    approved_snapshot = approved_store.append(snapshot.approved_snapshot)
+    route_approval_store.upsert(approval)
+    stable_snapshot = launch_ready_store.append(
+        snapshot.model_copy(
+            update={
+                "launch_ready_snapshot_id": None,
+                "captured_at": datetime(2026, 4, 4, 10, 0, 30, tzinfo=UTC),
+                "approved_snapshot": approved_snapshot,
+            }
+        )
+    )
+    launch_ready_store.append(
+        snapshot.model_copy(
+            update={
+                "launch_ready_snapshot_id": None,
+                "captured_at": datetime(2026, 4, 4, 10, 1, 0, tzinfo=UTC),
+                "approved_snapshot": approved_snapshot,
+            }
+        )
+    )
+    selected_snapshot = stable_snapshot.model_copy(
+        update={
+            "launch_ready_snapshot_id": 999,
+            "captured_at": datetime(2026, 4, 4, 10, 1, 20, tzinfo=UTC),
+        }
+    )
+
+    with pytest.MonkeyPatch.context() as monkeypatch:
+        monkeypatch.setattr(
+            "carryme_worker.poller._select_latest_launch_ready_canary_snapshot",
+            lambda **_: (selected_snapshot, candidate, approval),
+        )
+        monkeypatch.setattr(
+            "carryme_worker.poller._run_guarded_canary_lifecycle",
+            lambda **_: (_ for _ in ()).throw(
+                AssertionError("launch should skip before lifecycle when stability changed")
+            ),
+        )
+        summary = asyncio.run(
+            launch_latest_stable_canary_once(
+                settings,
+                approved_store=approved_store,
+                now=datetime(2026, 4, 4, 10, 1, 40, tzinfo=UTC),
+            )
+        )
+
+    assert summary.status == "skipped"
+    assert summary.label == "arb_extended_paradex"
+    assert summary.launch_ready_snapshot_id == 999
+    assert summary.detail == (
+        "Launch-ready canary snapshot changed before stability could be revalidated"
+    )
 
 
 def test_launch_latest_stable_canary_once_skips_when_global_cooldown_active(

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -6935,6 +6935,56 @@ def test_launch_latest_stable_canary_once_skips_when_recent_live_trade_is_unobse
     )
 
 
+def test_launch_latest_stable_canary_once_blocks_stale_unobserved_live_trade(
+    tmp_path: Path,
+) -> None:
+    settings = WorkerSettings(
+        database_path=str(tmp_path / "history.sqlite3"),
+        execution_observation_max_age_seconds=600,
+    )
+    execution_store = ExecutionJournalStore(settings.database_path)
+    execution_store.append(
+        ExecutionJournalEntry(
+            executed_at=datetime(2026, 4, 4, 10, 0, tzinfo=UTC),
+            adapter="paired_live:extended_then_paradex",
+            mode="live",
+            status="submitted",
+            paper_trade_id=33,
+            preview_hash="stale-unobserved-live-preview",
+            confirmation_entry_id=43,
+            paper_trade=_build_auto_close_paper_trade(
+                entry_id=33,
+                created_at=datetime(2026, 4, 4, 9, 58, tzinfo=UTC),
+                label="jup_extended_paradex",
+                canonical_symbol="JUP-USD-PERP",
+            ),
+            legs=[_build_auto_close_execution_leg()],
+        )
+    )
+
+    with pytest.MonkeyPatch.context() as monkeypatch:
+        monkeypatch.setattr(
+            "carryme_worker.poller._build_launch_ready_canary_stability",
+            lambda **_: (_ for _ in ()).throw(
+                AssertionError("stale unobserved live submissions must block launch")
+            ),
+        )
+        summary = asyncio.run(
+            launch_latest_stable_canary_once(
+                settings,
+                now=datetime(2026, 4, 4, 10, 20, 1, tzinfo=UTC),
+            )
+        )
+
+    assert summary.status == "skipped"
+    assert summary.detail == (
+        "Active live executions still require monitoring before unattended launch "
+        "(max_allowed=0, current=1): "
+        "paper_trade_id=33 label=jup_extended_paradex "
+        "state=pending_initial_monitoring"
+    )
+
+
 def test_launch_latest_stable_canary_once_counts_beyond_active_execution_scan_limit(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -357,6 +357,7 @@ def test_worker_defaults(monkeypatch: pytest.MonkeyPatch) -> None:
     assert settings.execution_auto_pair_close_timeout_seconds == 30.0
     assert settings.stable_canary_launch_shadow_mode is False
     assert settings.stable_canary_launch_close_position is True
+    assert settings.stable_canary_launch_reservation_retention_seconds == 86_400
     assert settings.stable_launch_ready_min_edge_retention_ratio == 0.7
     assert settings.stable_launch_ready_max_entry_break_even_funding_windows == 6.0
     assert settings.stable_launch_ready_max_round_trip_break_even_funding_windows == 12.0
@@ -8930,6 +8931,196 @@ def test_launch_latest_stable_canary_once_returns_launched_summary(
     assert len(launch_records) == 1
     assert launch_records[0].paper_trade_id == 17
     assert launch_records[0].launch_ready_snapshot_id == 9
+
+
+def test_launch_latest_stable_canary_once_reclaims_stale_snapshot_reservation(
+    tmp_path: Path,
+) -> None:
+    settings = WorkerSettings(
+        database_path=str(tmp_path / "history.sqlite3"),
+        stable_canary_launch_reservation_ttl_seconds=60,
+        extended_live_enabled=True,
+        extended_api_key="extended-key",
+        extended_stark_private_key="extended-secret",
+        paradex_live_enabled=True,
+        paradex_account_address="0x123",
+        paradex_private_key="0x456",
+    )
+    approval, candidate, snapshot, stability = _build_stable_launch_test_snapshot(
+        label="arb_extended_paradex",
+        launch_ready_snapshot_id=9,
+        approved_snapshot_id=8,
+        suggested_canary_notional=11.0,
+    )
+    approved_store = ApprovedCanaryStore(settings.database_path)
+    persisted_snapshot = approved_store.append(snapshot.approved_snapshot)
+    snapshot = snapshot.model_copy(update={"approved_snapshot": persisted_snapshot})
+    stability = stability.model_copy(update={"snapshot": snapshot})
+    launch_store = StableCanaryLaunchStore(settings.database_path)
+    now = datetime(2026, 4, 4, 10, 2, tzinfo=UTC)
+    assert launch_store.reserve_snapshot_launch(
+        launch_ready_snapshot_id=9,
+        label="arb_extended_paradex",
+        reserved_at=now - timedelta(seconds=61),
+        max_age_seconds=60,
+    )
+
+    class StubLifecycleResult:
+        def __init__(self) -> None:
+            self.paper_trade = PaperTradeEntry(
+                entry_id=17,
+                created_at=now,
+                intent=FundingPairTradeIntent(
+                    label="arb_extended_paradex",
+                    canonical_symbol="ARB-USD-PERP",
+                    source_recorded_at=datetime(2026, 4, 4, 10, 1, tzinfo=UTC),
+                    one_day_net_edge_after_entry=0.00355,
+                    break_even_days_entry=0.2,
+                    capacity_limit_notional=900.0,
+                    target_notional=11.0,
+                    capacity_fraction=11.0 / 900.0,
+                    max_target_notional=11.0,
+                    long_leg=TradeLegIntent(
+                        venue="paradex",
+                        symbol="ARB-USD-PERP",
+                        fee_profile="pro_fastfills",
+                        side="buy",
+                        target_notional=11.0,
+                    ),
+                    short_leg=TradeLegIntent(
+                        venue="extended",
+                        symbol="ARB-USD",
+                        fee_profile="default",
+                        side="sell",
+                        target_notional=11.0,
+                    ),
+                ),
+                note="worker launch",
+            )
+            self.final_pair_status = ExecutionPairStatus(
+                execution_entry_id=31,
+                paper_trade_id=17,
+                preview_hash="preview",
+                derived_state="closed",
+                recommended_action="no_action",
+                order_state=ExecutionOrderState(
+                    execution_entry_id=31,
+                    paper_trade_id=17,
+                    preview_hash="preview",
+                    legs=[],
+                    notes=[],
+                ),
+                reconciliation=ExecutionReconciliation(
+                    execution_entry_id=31,
+                    paper_trade_id=17,
+                    preview_hash="preview",
+                    status="accepted",
+                    recommended_action="no_action",
+                    matched_all_leg_symbols=True,
+                    venues=[],
+                    notes=[],
+                ),
+                notes=[],
+            )
+
+    async def run_stub_lifecycle(**_: object) -> StubLifecycleResult:
+        return StubLifecycleResult()
+
+    with pytest.MonkeyPatch.context() as monkeypatch:
+        monkeypatch.setattr(
+            "carryme_worker.poller._build_launch_ready_canary_stability",
+            lambda **_: stability,
+        )
+        monkeypatch.setattr(
+            "carryme_worker.poller._select_latest_launch_ready_canary_snapshot",
+            lambda **_: (snapshot, candidate, approval),
+        )
+        monkeypatch.setattr(
+            "carryme_worker.poller._run_guarded_canary_lifecycle",
+            run_stub_lifecycle,
+        )
+        summary = asyncio.run(
+            launch_latest_stable_canary_once(
+                settings,
+                launch_store=launch_store,
+                approved_store=approved_store,
+                now=now,
+            )
+        )
+
+    assert summary.status == "launched"
+    assert summary.label == "arb_extended_paradex"
+    assert summary.launch_ready_snapshot_id == 9
+    assert summary.paper_trade_id == 17
+
+
+def test_launch_latest_stable_canary_once_aborts_when_reservation_owner_is_lost(
+    tmp_path: Path,
+) -> None:
+    settings = WorkerSettings(
+        database_path=str(tmp_path / "history.sqlite3"),
+        stable_canary_launch_reservation_ttl_seconds=60,
+        extended_live_enabled=True,
+        extended_api_key="extended-key",
+        extended_stark_private_key="extended-secret",
+        paradex_live_enabled=True,
+        paradex_account_address="0x123",
+        paradex_private_key="0x456",
+    )
+    approval, candidate, snapshot, stability = _build_stable_launch_test_snapshot(
+        label="arb_extended_paradex",
+        launch_ready_snapshot_id=9,
+        approved_snapshot_id=8,
+        suggested_canary_notional=11.0,
+    )
+    approved_store = ApprovedCanaryStore(settings.database_path)
+    persisted_snapshot = approved_store.append(snapshot.approved_snapshot)
+    snapshot = snapshot.model_copy(update={"approved_snapshot": persisted_snapshot})
+    stability = stability.model_copy(update={"snapshot": snapshot})
+    launch_store = StableCanaryLaunchStore(settings.database_path)
+    now = datetime(2026, 4, 4, 10, 2, tzinfo=UTC)
+
+    async def run_stub_lifecycle(**kwargs: object) -> object:
+        before_open_submission = cast(Any, kwargs["before_open_submission"])
+        assert launch_store.reserve_snapshot_launch(
+            launch_ready_snapshot_id=9,
+            label="arb_extended_paradex",
+            reserved_at=now + timedelta(seconds=61),
+            max_age_seconds=60,
+            owner_id="stealing-worker",
+        )
+        await before_open_submission()
+        pytest.fail("lost reservation ownership must block before live submission")
+
+    with pytest.MonkeyPatch.context() as monkeypatch:
+        monkeypatch.setattr(
+            "carryme_worker.poller._build_launch_ready_canary_stability",
+            lambda **_: stability,
+        )
+        monkeypatch.setattr(
+            "carryme_worker.poller._select_latest_launch_ready_canary_snapshot",
+            lambda **_: (snapshot, candidate, approval),
+        )
+        monkeypatch.setattr(
+            "carryme_worker.poller._run_guarded_canary_lifecycle",
+            run_stub_lifecycle,
+        )
+        summary = asyncio.run(
+            launch_latest_stable_canary_once(
+                settings,
+                launch_store=launch_store,
+                approved_store=approved_store,
+                now=now,
+            )
+        )
+
+    assert summary.status == "skipped"
+    assert summary.label == "arb_extended_paradex"
+    assert summary.launch_ready_snapshot_id == 9
+    assert summary.detail == (
+        "Stable launch reservation ownership was lost before live submission"
+    )
+    assert launch_store.list_recent(limit=10) == []
 
 
 @pytest.mark.parametrize(

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -11449,6 +11449,152 @@ def test_maybe_auto_close_open_hedged_execution_skips_when_stale_snapshot_cannot
     assert result is None
 
 
+def test_maybe_auto_close_open_hedged_execution_uses_stale_snapshot_for_max_hold(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    settings = WorkerSettings(
+        database_path=str(tmp_path / "history.sqlite3"),
+        execution_auto_pair_close_shadow_mode=True,
+        execution_auto_pair_close_max_snapshot_age_seconds=300,
+        execution_auto_pair_close_max_hold_windows=0.01,
+    )
+    approval_store = ApprovedCanaryStore(settings.database_path)
+    approval_store.append(
+        _build_auto_close_snapshot(
+            captured_at=datetime(2026, 4, 4, 8, 0, tzinfo=UTC),
+            round_trip_edge=0.0009,
+        )
+    )
+    execution = ExecutionJournalEntry(
+        executed_at=datetime(2026, 4, 4, 9, 0, tzinfo=UTC),
+        adapter="paired_live:extended_then_paradex",
+        mode="live",
+        status="submitted",
+        paper_trade_id=27,
+        preview_hash="stale-max-hold-preview",
+        confirmation_entry_id=27,
+        paper_trade=_build_auto_close_paper_trade(
+            entry_id=27,
+            created_at=datetime(2026, 4, 4, 8, 58, tzinfo=UTC),
+        ),
+        legs=[_build_auto_close_execution_leg()],
+    )
+
+    with pytest.MonkeyPatch.context() as monkeypatch:
+        async def missing_live_revalidation(
+            **_: object,
+        ) -> tuple[FundingUniverseCanaryCandidate | None, int]:
+            return None, 0
+
+        monkeypatch.setattr(
+            "carryme_worker.poller.scan_live_route_candidate_for_approval",
+            missing_live_revalidation,
+        )
+        monkeypatch.setattr(
+            "carryme_worker.poller._build_pair_close_context_for_paper_trade",
+            lambda **_: (_ for _ in ()).throw(
+                AssertionError("shadow mode should not build a close context")
+            ),
+        )
+        caplog.set_level(logging.INFO)
+        result = asyncio.run(
+            _maybe_auto_close_open_hedged_execution(
+                settings=settings,
+                execution=execution,
+                pair_status=_build_auto_close_pair_status(execution=execution),
+                approved_store=approval_store,
+                execution_store=ExecutionJournalStore(settings.database_path),
+                observation_store=ExecutionObservationStore(settings.database_path),
+                account_service=cast(AccountPreflightService, object()),
+                order_state_service=cast(ExecutionOrderStateService, object()),
+                approval_service=RouteApprovalService(
+                    store=RouteApprovalStore(settings.database_path)
+                ),
+                scanner=cast(Any, object()),
+                logger=logging.getLogger("carryme.worker"),
+                now=datetime(2026, 4, 4, 10, 1, tzinfo=UTC),
+            )
+        )
+
+    assert result is None
+    assert "shadow auto-close for paper_trade_id=27" in caplog.text
+    assert "hold age windows" in caplog.text
+    assert "source=stale_approved_snapshot" in caplog.text
+
+
+def test_maybe_auto_close_open_hedged_execution_does_not_use_stale_edge_decay(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    settings = WorkerSettings(
+        database_path=str(tmp_path / "history.sqlite3"),
+        execution_auto_pair_close_shadow_mode=True,
+        execution_auto_pair_close_max_snapshot_age_seconds=300,
+        execution_auto_pair_close_max_hold_windows=10.0,
+    )
+    approval_store = ApprovedCanaryStore(settings.database_path)
+    approval_store.append(
+        _build_auto_close_snapshot(
+            captured_at=datetime(2026, 4, 4, 8, 0, tzinfo=UTC),
+            round_trip_edge=-0.0001,
+        )
+    )
+    execution = ExecutionJournalEntry(
+        executed_at=datetime(2026, 4, 4, 9, 55, tzinfo=UTC),
+        adapter="paired_live:extended_then_paradex",
+        mode="live",
+        status="submitted",
+        paper_trade_id=28,
+        preview_hash="stale-edge-preview",
+        confirmation_entry_id=28,
+        paper_trade=_build_auto_close_paper_trade(
+            entry_id=28,
+            created_at=datetime(2026, 4, 4, 9, 54, tzinfo=UTC),
+        ),
+        legs=[_build_auto_close_execution_leg()],
+    )
+
+    with pytest.MonkeyPatch.context() as monkeypatch:
+        async def missing_live_revalidation(
+            **_: object,
+        ) -> tuple[FundingUniverseCanaryCandidate | None, int]:
+            return None, 0
+
+        monkeypatch.setattr(
+            "carryme_worker.poller.scan_live_route_candidate_for_approval",
+            missing_live_revalidation,
+        )
+        monkeypatch.setattr(
+            "carryme_worker.poller._build_pair_close_context_for_paper_trade",
+            lambda **_: (_ for _ in ()).throw(
+                AssertionError("stale edge data must not build a close context")
+            ),
+        )
+        caplog.set_level(logging.INFO)
+        result = asyncio.run(
+            _maybe_auto_close_open_hedged_execution(
+                settings=settings,
+                execution=execution,
+                pair_status=_build_auto_close_pair_status(execution=execution),
+                approved_store=approval_store,
+                execution_store=ExecutionJournalStore(settings.database_path),
+                observation_store=ExecutionObservationStore(settings.database_path),
+                account_service=cast(AccountPreflightService, object()),
+                order_state_service=cast(ExecutionOrderStateService, object()),
+                approval_service=RouteApprovalService(
+                    store=RouteApprovalStore(settings.database_path)
+                ),
+                scanner=cast(Any, object()),
+                logger=logging.getLogger("carryme.worker"),
+                now=datetime(2026, 4, 4, 10, 1, tzinfo=UTC),
+            )
+        )
+
+    assert result is None
+    assert "shadow auto-close for paper_trade_id=28" not in caplog.text
+
+
 def test_maybe_auto_close_open_hedged_execution_revalidates_without_active_approval(
     tmp_path: Path,
     caplog: pytest.LogCaptureFixture,

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -236,6 +236,10 @@ def _clear_worker_env(monkeypatch: pytest.MonkeyPatch) -> None:
         raising=False,
     )
     monkeypatch.delenv(
+        "CARRYME_WORKER_STABLE_CANARY_LAUNCH_CANDIDATE_SCAN_LIMIT",
+        raising=False,
+    )
+    monkeypatch.delenv(
         "CARRYME_WORKER_STABLE_CANARY_LAUNCH_MAX_TOTAL_LIVE_NOTIONAL",
         raising=False,
     )
@@ -322,6 +326,7 @@ def test_worker_defaults(monkeypatch: pytest.MonkeyPatch) -> None:
     assert settings.execution_observation_max_backoff_seconds == 60
     assert settings.stable_canary_launch_max_active_live_executions == 0
     assert settings.stable_canary_launch_active_execution_limit == 20
+    assert settings.stable_canary_launch_candidate_scan_limit == 100
     assert settings.stable_canary_launch_max_total_live_notional is None
     assert settings.stable_canary_launch_max_live_notional_per_venue is None
     assert settings.stable_canary_launch_recent_closed_trade_limit == 10
@@ -4453,6 +4458,9 @@ def test_cache_launch_ready_canaries_once_emits_stable_launch_ready_available_al
 def _build_stable_launch_test_snapshot(
     *,
     label: str,
+    canonical_symbol: str = "ARB-USD-PERP",
+    short_symbol: str = "ARB-USD",
+    long_symbol: str = "ARB-USD-PERP",
     launch_ready_snapshot_id: int = 19,
     approved_snapshot_id: int = 18,
     suggested_canary_notional: float = 20.0,
@@ -4470,7 +4478,7 @@ def _build_stable_launch_test_snapshot(
     approval = RouteApprovalEntry(
         updated_at=datetime(2026, 4, 4, 10, 0, tzinfo=UTC),
         label=label,
-        canonical_symbol="ARB-USD-PERP",
+        canonical_symbol=canonical_symbol,
         short_venue="extended",
         long_venue="paradex",
         short_fee_profile="default",
@@ -4482,7 +4490,7 @@ def _build_stable_launch_test_snapshot(
     candidate = FundingUniverseCanaryCandidate(
         opportunity=FundingUniverseOpportunity(
             opportunity=FundingArbOpportunity(
-                canonical_symbol="ARB-USD-PERP",
+                canonical_symbol=canonical_symbol,
                 long_venue="paradex",
                 short_venue="extended",
                 long_fee_profile="pro_fastfills",
@@ -4502,10 +4510,10 @@ def _build_stable_launch_test_snapshot(
                 ),
             ),
             venue_markets={
-                "extended": FundingUniverseVenueMarket(venue="extended", symbol="ARB-USD"),
+                "extended": FundingUniverseVenueMarket(venue="extended", symbol=short_symbol),
                 "paradex": FundingUniverseVenueMarket(
                     venue="paradex",
-                    symbol="ARB-USD-PERP",
+                    symbol=long_symbol,
                 ),
             },
             min_daily_volume=min_daily_volume,
@@ -4568,18 +4576,170 @@ def test_launch_latest_stable_canary_once_skips_when_no_stable_snapshot(
 ) -> None:
     settings = WorkerSettings(database_path=str(tmp_path / "history.sqlite3"))
 
-    with pytest.MonkeyPatch.context() as monkeypatch:
-        monkeypatch.setattr(
-            "carryme_worker.poller._build_launch_ready_canary_stability",
-            lambda **_: (_ for _ in ()).throw(
-                HTTPException(status_code=404, detail="No launch-ready canary snapshot found")
-            ),
-        )
-        summary = asyncio.run(launch_latest_stable_canary_once(settings))
+    summary = asyncio.run(launch_latest_stable_canary_once(settings))
 
     assert summary.status == "skipped"
     assert summary.detail == "No launch-ready canary snapshot found"
     assert summary.paper_trade_id is None
+
+
+def test_launch_latest_stable_canary_once_ranks_stable_labels_independently(
+    tmp_path: Path,
+) -> None:
+    settings = WorkerSettings(database_path=str(tmp_path / "history.sqlite3"))
+    approved_store = ApprovedCanaryStore(settings.database_path)
+    launch_ready_store = LaunchReadyCanaryStore(settings.database_path)
+    route_approval_store = RouteApprovalStore(settings.database_path)
+    low_approval, _, low_snapshot, _ = _build_stable_launch_test_snapshot(
+        label="arb_extended_paradex",
+        canonical_symbol="ARB-USD-PERP",
+        short_symbol="ARB-USD",
+        long_symbol="ARB-USD-PERP",
+        estimated_one_day_pnl_after_round_trip=0.5,
+    )
+    high_approval, _, high_snapshot, _ = _build_stable_launch_test_snapshot(
+        label="bera_extended_paradex",
+        canonical_symbol="BERA-USD-PERP",
+        short_symbol="BERA-USD",
+        long_symbol="BERA-USD-PERP",
+        estimated_one_day_pnl_after_round_trip=3.0,
+    )
+    low_approved = approved_store.append(low_snapshot.approved_snapshot)
+    high_approved = approved_store.append(high_snapshot.approved_snapshot)
+    route_approval_store.upsert(low_approval)
+    route_approval_store.upsert(high_approval)
+
+    def append_launch_ready_pair(
+        snapshot: LaunchReadyCanarySnapshot,
+        approved_snapshot: ApprovedCanarySnapshot,
+        first_captured_at: datetime,
+        second_captured_at: datetime,
+    ) -> LaunchReadyCanarySnapshot:
+        launch_ready_store.append(
+            snapshot.model_copy(
+                update={
+                    "launch_ready_snapshot_id": None,
+                    "captured_at": first_captured_at,
+                    "approved_snapshot": approved_snapshot,
+                }
+            )
+        )
+        return launch_ready_store.append(
+            snapshot.model_copy(
+                update={
+                    "launch_ready_snapshot_id": None,
+                    "captured_at": second_captured_at,
+                    "approved_snapshot": approved_snapshot,
+                }
+            )
+        )
+
+    append_launch_ready_pair(
+        high_snapshot,
+        high_approved,
+        datetime(2026, 4, 4, 10, 0, 0, tzinfo=UTC),
+        datetime(2026, 4, 4, 10, 1, 0, tzinfo=UTC),
+    )
+    latest_low = append_launch_ready_pair(
+        low_snapshot,
+        low_approved,
+        datetime(2026, 4, 4, 10, 0, 10, tzinfo=UTC),
+        datetime(2026, 4, 4, 10, 1, 10, tzinfo=UTC),
+    )
+    captured_labels: list[str] = []
+
+    class StubLifecycleResult:
+        def __init__(self, label: str) -> None:
+            self.paper_trade = PaperTradeEntry(
+                entry_id=17,
+                created_at=datetime(2026, 4, 4, 10, 1, 20, tzinfo=UTC),
+                intent=FundingPairTradeIntent(
+                    label=label,
+                    canonical_symbol="BERA-USD-PERP",
+                    source_recorded_at=datetime(2026, 4, 4, 10, 1, tzinfo=UTC),
+                    one_day_net_edge_after_entry=0.00355,
+                    break_even_days_entry=0.2,
+                    capacity_limit_notional=900.0,
+                    target_notional=20.0,
+                    capacity_fraction=20.0 / 900.0,
+                    max_target_notional=20.0,
+                    long_leg=TradeLegIntent(
+                        venue="paradex",
+                        symbol="BERA-USD-PERP",
+                        fee_profile="pro_fastfills",
+                        side="buy",
+                        target_notional=20.0,
+                    ),
+                    short_leg=TradeLegIntent(
+                        venue="extended",
+                        symbol="BERA-USD",
+                        fee_profile="default",
+                        side="sell",
+                        target_notional=20.0,
+                    ),
+                ),
+                note="worker launch",
+            )
+            self.final_pair_status = ExecutionPairStatus(
+                execution_entry_id=31,
+                paper_trade_id=17,
+                preview_hash="preview",
+                derived_state="closed",
+                recommended_action="no_action",
+                order_state=ExecutionOrderState(
+                    execution_entry_id=31,
+                    paper_trade_id=17,
+                    preview_hash="preview",
+                    legs=[],
+                    notes=[],
+                ),
+                reconciliation=ExecutionReconciliation(
+                    execution_entry_id=31,
+                    paper_trade_id=17,
+                    preview_hash="preview",
+                    status="accepted",
+                    recommended_action="no_action",
+                    matched_all_leg_symbols=True,
+                    venues=[],
+                    notes=[],
+                ),
+                notes=[],
+            )
+
+    async def run_stub_lifecycle(**kwargs: object) -> StubLifecycleResult:
+        approval = cast(RouteApprovalEntry, kwargs["approval"])
+        captured_labels.append(approval.label)
+        return StubLifecycleResult(approval.label)
+
+    api_settings = ApiSettings(
+        database_path=settings.database_path,
+        watchlist_path=settings.watchlist_path,
+        environment=settings.environment,
+        extended_live_enabled=True,
+        extended_api_key="extended-key",
+        extended_stark_private_key="extended-secret",
+        paradex_live_enabled=True,
+        paradex_account_address="0x123",
+        paradex_private_key="0x456",
+    )
+    with pytest.MonkeyPatch.context() as monkeypatch:
+        monkeypatch.setattr(
+            "carryme_worker.poller._run_guarded_canary_lifecycle",
+            run_stub_lifecycle,
+        )
+        summary = asyncio.run(
+            launch_latest_stable_canary_once(
+                settings,
+                api_settings=api_settings,
+                approved_store=approved_store,
+                now=datetime(2026, 4, 4, 10, 1, 20, tzinfo=UTC),
+            )
+        )
+
+    assert latest_low.label == "arb_extended_paradex"
+    assert summary.status == "launched"
+    assert summary.label == "bera_extended_paradex"
+    assert captured_labels == ["bera_extended_paradex"]
 
 
 def test_launch_latest_stable_canary_once_skips_when_global_cooldown_active(
@@ -8874,7 +9034,24 @@ def test_launch_latest_stable_canary_once_rechecks_live_execution_readiness(
     persisted_snapshot = approved_store.append(snapshot.approved_snapshot)
     snapshot = snapshot.model_copy(update={"approved_snapshot": persisted_snapshot})
     stability = stability.model_copy(update={"snapshot": snapshot})
-    LaunchReadyCanaryStore(settings.database_path).append(snapshot)
+    launch_ready_store = LaunchReadyCanaryStore(settings.database_path)
+    launch_ready_store.append(
+        snapshot.model_copy(
+            update={
+                "launch_ready_snapshot_id": None,
+                "captured_at": datetime(2026, 3, 30, 10, 1, tzinfo=UTC),
+            }
+        )
+    )
+    snapshot = launch_ready_store.append(
+        snapshot.model_copy(
+            update={
+                "launch_ready_snapshot_id": None,
+                "captured_at": datetime(2026, 3, 30, 10, 2, tzinfo=UTC),
+            }
+        )
+    )
+    stability = stability.model_copy(update={"snapshot": snapshot})
 
     async def run_unexpected_lifecycle(**_: object) -> object:
         pytest.fail("stable launch should not submit when live execution credentials are missing")

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -5331,6 +5331,15 @@ def test_launch_latest_stable_canary_once_falls_through_reserved_snapshot(
         label = cast(str, kwargs["label"])
         return selected_by_label[label]
 
+    stability_by_label = {
+        high_snapshot.label: high_stability,
+        fallback_snapshot.label: fallback_stability,
+    }
+
+    def stability_stub(**kwargs: object) -> LaunchReadyCanaryStability:
+        label = cast(str, kwargs["label"])
+        return stability_by_label[label]
+
     api_settings = ApiSettings(
         database_path=settings.database_path,
         watchlist_path=settings.watchlist_path,
@@ -5345,11 +5354,15 @@ def test_launch_latest_stable_canary_once_falls_through_reserved_snapshot(
     with pytest.MonkeyPatch.context() as monkeypatch:
         monkeypatch.setattr(
             "carryme_worker.poller._list_ranked_stable_launch_ready_stabilities",
-            lambda **_: [high_stability, fallback_stability],
+            lambda **_: ([high_stability, fallback_stability], None),
         )
         monkeypatch.setattr(
             "carryme_worker.poller._select_latest_launch_ready_canary_snapshot",
             select_stub,
+        )
+        monkeypatch.setattr(
+            "carryme_worker.poller._build_launch_ready_canary_stability",
+            stability_stub,
         )
         monkeypatch.setattr(
             "carryme_worker.poller._run_guarded_canary_lifecycle",


### PR DESCRIPTION
## Summary
- bundle the current stable-launch ranking/revalidation work with the activation safety stack on top of current `main`
- preserve ranked fallback behavior when the top launch-ready snapshot is stale, blocked, or already reserved
- keep live submission reservations/renewals across open, pair-close, cleanup, and legacy close reuse paths
- keep stable launch fail-closed for stale/unobserved executions and max-hold auto-close fallback behavior

## Production notes
- This replaces the drifted activation stack with a single reviewable branch based on current `main`.
- This does not widen notional caps, cooldowns, or route approval scope.
- Do not enable unattended stable launch from Render until this PR is merged, deployed, and the execution monitor auto-close path is verified live.

## Validation
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run pytest -q tests/test_worker.py::test_launch_latest_stable_canary_once_falls_through_reserved_snapshot`
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run ruff check apps/worker/src/carryme_worker/poller.py tests/test_worker.py`
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run mypy src apps packages tests`
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run pytest -q tests/test_worker.py -k 'stable_canary_launch' tests/test_storage.py -k 'stable_canary_launch_store' tests/test_api.py -k 'pair_close or cleanup or guarded_pair'`
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run ruff check .`
- `git diff --check`
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run pytest -q`
