### PR TITLE
fix: skip quality indexes for exact approved scans

### DIFF
--- a/packages/runtime/src/carryme_runtime/route_approvals.py
+++ b/packages/runtime/src/carryme_runtime/route_approvals.py
@@ -349,6 +349,7 @@ async def scan_exact_canary_candidate_for_approval(
         exclude_symbols=exclude_symbols,
         exclude_tags=exclude_tags,
         limit=max(1, limit),
+        use_execution_quality=False,
         use_route_stability=False,
     )
 

--- a/packages/runtime/src/carryme_runtime/universe.py
+++ b/packages/runtime/src/carryme_runtime/universe.py
@@ -187,6 +187,7 @@ class OpportunityUniverseService:
         exclude_symbols: list[str] | None = None,
         exclude_tags: list[str] | None = None,
         limit: int = 10,
+        use_execution_quality: bool = True,
         use_route_stability: bool = True,
     ) -> list[FundingUniverseCanaryCandidate]:
         scan = await self.scan(
@@ -207,6 +208,7 @@ class OpportunityUniverseService:
             exclude_symbols=exclude_symbols,
             exclude_tags=exclude_tags or ["meme", "political"],
             limit=limit,
+            use_execution_quality=use_execution_quality,
             use_route_stability=use_route_stability,
         )
         candidates: list[FundingUniverseCanaryCandidate] = []
@@ -245,6 +247,7 @@ class OpportunityUniverseService:
         exclude_symbols: list[str] | None = None,
         exclude_tags: list[str] | None = None,
         limit: int = 20,
+        use_execution_quality: bool = True,
         use_route_stability: bool = True,
     ) -> FundingUniverseScan:
         normalized_venues = _normalize_venues(venues)
@@ -275,10 +278,33 @@ class OpportunityUniverseService:
             min_roundtrip_edge=min_roundtrip_edge,
         )
         snapshots = await self._fetch_overlapping_snapshots(snapshot_overlaps)
-        (
-            execution_quality_index,
-            execution_prior_score,
-        ) = await self._build_execution_quality_index_cached()
+        needs_execution_quality = (
+            min_execution_samples > 0
+            or (
+                use_execution_quality
+                and (
+                    min_execution_quality_score > 0.0
+                    or normalized_ranking
+                    in {
+                        "execution_adjusted_roundtrip_pnl",
+                        "execution_adjusted_quality_pnl",
+                        "route_adjusted_quality_pnl",
+                    }
+                )
+            )
+        )
+        if needs_execution_quality:
+            (
+                execution_quality_index,
+                execution_prior_score,
+            ) = await self._build_execution_quality_index_cached()
+        else:
+            execution_quality_index = {}
+            execution_prior_score = (
+                self.execution_quality_service.prior_score
+                if self.execution_quality_service is not None
+                else 1.0
+            )
         needs_route_stability = (
             min_route_stability_weight > 0.0
             or min_route_presence_ratio > 0.0

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -807,10 +807,20 @@ def test_opportunity_universe_service_can_skip_route_stability_for_exact_canary(
         ) -> dict[tuple[str, str, str, str, str], RouteStabilitySummary]:
             raise AssertionError("exact approved scans should not build route stability")
 
+    class FailingExecutionQualityService:
+        prior_score = 0.65
+
+        def build_index(self) -> dict[tuple[str, str, str], ExecutionQualitySummary]:
+            raise AssertionError("exact approved scans should not build execution quality")
+
     async def run() -> None:
         service = OpportunityUniverseService(
             list_symbols=list_symbols,
             fetch_snapshot=fetch_snapshot,
+            execution_quality_service=cast(
+                ExecutionQualityService,
+                FailingExecutionQualityService(),
+            ),
             route_stability_service=cast(
                 RouteStabilityService,
                 FailingRouteStabilityService(),
@@ -823,6 +833,7 @@ def test_opportunity_universe_service_can_skip_route_stability_for_exact_canary(
             min_route_presence_ratio=0.0,
             min_route_samples=0,
             limit=1,
+            use_execution_quality=False,
             use_route_stability=False,
         )
 
@@ -3491,6 +3502,7 @@ def test_scan_exact_canary_candidate_for_approval_skips_route_stability_index(
     asyncio.run(run())
 
     assert captured["include_symbols"] == ["NEAR-USD-PERP"]
+    assert captured["use_execution_quality"] is False
     assert captured["use_route_stability"] is False
 
 


### PR DESCRIPTION
## Summary
- skip execution-quality index building for exact approved canary scans when no execution sample gate is requested
- keep execution-quality indexing for normal scans, rankings, and filters that require it
- extend exact-scan tests to prove both quality indexes are bypassed for the production approved refresh path

## Production reason
After #231, approved exact scans no longer build route stability, but production still timed out while refreshing the five approved labels. The remaining blocking work is the execution-quality index. Exact approved refreshes are already constrained to one operator-approved route; current stable-launch production gates do not require execution sample maturity, so the refresh path should use the configured prior score instead of blocking on the full index.

## Validation
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run pytest -q tests/test_runtime.py::test_opportunity_universe_service_can_skip_route_stability_for_exact_canary tests/test_runtime.py::test_scan_exact_canary_candidate_for_approval_skips_route_stability_index`
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run ruff check packages/runtime/src/carryme_runtime/universe.py packages/runtime/src/carryme_runtime/route_approvals.py tests/test_runtime.py`
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run mypy src apps packages tests`
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run pytest -q tests/test_worker.py -k 'approved_canary' tests/test_runtime.py -k 'scan_exact_canary or route_stability or scan_canary_candidates'`
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run ruff check .`
- `git diff --check`
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run pytest -q`
