### PR TITLE
fix: tolerate repriced stable launch snapshots

### DIFF
--- a/apps/api/src/carryme_api/app.py
+++ b/apps/api/src/carryme_api/app.py
@@ -2933,22 +2933,52 @@ def _launch_ready_snapshot_payload_changed(
 def _normalized_launch_ready_snapshot_payload(
     snapshot: LaunchReadyCanarySnapshot,
 ) -> dict[str, object]:
-    payload = snapshot.model_dump(
-        mode="python",
-        exclude={
-            "launch_ready_snapshot_id": True,
-            "captured_at": True,
-            "approved_snapshot": {"snapshot_id", "captured_at"},
+    approved_snapshot = snapshot.approved_snapshot
+    candidate = approved_snapshot.candidate
+    opportunity = candidate.opportunity.opportunity
+    approval = approved_snapshot.approval
+    venue_markets = candidate.opportunity.venue_markets
+    return {
+        "label": snapshot.label,
+        "max_snapshot_age_seconds": snapshot.max_snapshot_age_seconds,
+        "suggested_canary_notional": candidate.suggested_canary_notional,
+        "route": {
+            "canonical_symbol": opportunity.canonical_symbol,
+            "long_venue": opportunity.long_venue,
+            "short_venue": opportunity.short_venue,
+            "long_fee_profile": opportunity.long_fee_profile,
+            "short_fee_profile": opportunity.short_fee_profile,
+            "venue_markets": tuple(
+                sorted(
+                    (venue, market.symbol)
+                    for venue, market in venue_markets.items()
+                )
+            ),
         },
-    )
-    system_state = payload.get("system_state")
-    if isinstance(system_state, dict):
-        venues = system_state.get("venues")
-        if isinstance(venues, list):
-            system_state["venues"] = sorted(
-                venues,
-                key=lambda venue: venue["venue"],
-            )
+        "approval": {
+            "label": approval.label,
+            "canonical_symbol": approval.canonical_symbol,
+            "short_venue": approval.short_venue,
+            "long_venue": approval.long_venue,
+            "short_fee_profile": approval.short_fee_profile,
+            "long_fee_profile": approval.long_fee_profile,
+            "approved": approval.approved,
+            "max_live_notional": approval.max_live_notional,
+        },
+        "system_state": _normalized_launch_ready_system_state_payload(snapshot.system_state),
+    }
+
+
+def _normalized_launch_ready_system_state_payload(
+    system_state: PaperTradeSystemState,
+) -> dict[str, object]:
+    payload = system_state.model_dump(mode="python")
+    venues = payload.get("venues")
+    if isinstance(venues, list):
+        payload["venues"] = sorted(
+            venues,
+            key=lambda venue: str(cast(dict[str, object], venue)["venue"]),
+        )
     return payload
 
 

--- a/apps/worker/src/carryme_worker/poller.py
+++ b/apps/worker/src/carryme_worker/poller.py
@@ -1310,24 +1310,62 @@ def _launch_ready_snapshot_payload_changed(
 def _normalized_launch_ready_snapshot_payload(
     snapshot: LaunchReadyCanarySnapshot,
 ) -> dict[str, object]:
-    """Return a stable, order-insensitive payload for one launch-ready snapshot."""
+    """Return the stable launch envelope for one launch-ready snapshot.
 
-    payload = snapshot.model_dump(
-        mode="python",
-        exclude={
-            "launch_ready_snapshot_id": True,
-            "captured_at": True,
-            "approved_snapshot": {"snapshot_id", "captured_at"},
+    The approved snapshot is repriced every scan. Stability should reset when the
+    route, live-readiness, or notional envelope changes, not when normal market
+    edge/PnL fields move inside a snapshot that has already passed launch-ready
+    gates.
+    """
+
+    approved_snapshot = snapshot.approved_snapshot
+    candidate = approved_snapshot.candidate
+    opportunity = candidate.opportunity.opportunity
+    approval = approved_snapshot.approval
+    venue_markets = candidate.opportunity.venue_markets
+    return {
+        "label": snapshot.label,
+        "max_snapshot_age_seconds": snapshot.max_snapshot_age_seconds,
+        "suggested_canary_notional": candidate.suggested_canary_notional,
+        "route": {
+            "canonical_symbol": opportunity.canonical_symbol,
+            "long_venue": opportunity.long_venue,
+            "short_venue": opportunity.short_venue,
+            "long_fee_profile": opportunity.long_fee_profile,
+            "short_fee_profile": opportunity.short_fee_profile,
+            "venue_markets": tuple(
+                sorted(
+                    (venue, market.symbol)
+                    for venue, market in venue_markets.items()
+                )
+            ),
         },
-    )
-    system_state = cast(dict[str, object] | None, payload.get("system_state"))
-    if isinstance(system_state, dict):
-        venues = system_state.get("venues")
-        if isinstance(venues, list):
-            system_state["venues"] = sorted(
-                venues,
-                key=lambda venue: str(cast(dict[str, object], venue)["venue"]),
-            )
+        "approval": {
+            "label": approval.label,
+            "canonical_symbol": approval.canonical_symbol,
+            "short_venue": approval.short_venue,
+            "long_venue": approval.long_venue,
+            "short_fee_profile": approval.short_fee_profile,
+            "long_fee_profile": approval.long_fee_profile,
+            "approved": approval.approved,
+            "max_live_notional": approval.max_live_notional,
+        },
+        "system_state": _normalized_launch_ready_system_state_payload(snapshot.system_state),
+    }
+
+
+def _normalized_launch_ready_system_state_payload(
+    system_state: PaperTradeSystemState,
+) -> dict[str, object]:
+    """Return an order-insensitive system-state payload for stability checks."""
+
+    payload = system_state.model_dump(mode="python")
+    venues = payload.get("venues")
+    if isinstance(venues, list):
+        payload["venues"] = sorted(
+            venues,
+            key=lambda venue: str(cast(dict[str, object], venue)["venue"]),
+        )
     return payload
 
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1753,6 +1753,13 @@ def test_latest_stable_launch_ready_canary_snapshot_endpoint_returns_stability(
         ),
     )
     store = LaunchReadyCanaryStore(tmp_path / "history.sqlite3")
+    repriced_approved_snapshot = approved_snapshot.model_copy(deep=True)
+    repriced_approved_snapshot.snapshot_id = 5
+    repriced_approved_snapshot.captured_at = datetime(2026, 3, 29, 16, 7, tzinfo=UTC)
+    repriced_approved_snapshot.candidate.opportunity.estimated_one_day_pnl_after_round_trip = 2.65
+    repriced_approved_snapshot.candidate.opportunity.opportunity.one_day_net_edge_after_round_trip = (  # noqa: E501
+        0.0029
+    )
     store.append(
         LaunchReadyCanarySnapshot(
             captured_at=datetime(2026, 3, 29, 16, 7, tzinfo=UTC),
@@ -1788,7 +1795,7 @@ def test_latest_stable_launch_ready_canary_snapshot_endpoint_returns_stability(
             captured_at=datetime(2026, 3, 29, 16, 8, tzinfo=UTC),
             label="arb_extended_paradex",
             max_snapshot_age_seconds=100000000,
-            approved_snapshot=approved_snapshot,
+            approved_snapshot=repriced_approved_snapshot,
             system_state=PaperTradeSystemState(
                 paper_trade_id=0,
                 label="arb_extended_paradex",

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -5009,6 +5009,68 @@ def test_list_ranked_stable_launch_ready_stabilities_uses_distinct_label_scan_li
     }
 
 
+def test_list_ranked_stable_launch_ready_stabilities_tolerates_repriced_same_route(
+    tmp_path: Path,
+) -> None:
+    settings = WorkerSettings(database_path=str(tmp_path / "history.sqlite3"))
+    launch_ready_store = LaunchReadyCanaryStore(settings.database_path)
+    approved_store = ApprovedCanaryStore(settings.database_path)
+    _, _, first_snapshot, _ = _build_stable_launch_test_snapshot(
+        label="s_extended_paradex",
+        canonical_symbol="S-USD-PERP",
+        short_symbol="S-USD",
+        long_symbol="S-USD-PERP",
+        approved_snapshot_id=18215,
+        estimated_one_day_pnl_after_round_trip=0.2863,
+    )
+    _, _, second_snapshot, _ = _build_stable_launch_test_snapshot(
+        label="s_extended_paradex",
+        canonical_symbol="S-USD-PERP",
+        short_symbol="S-USD",
+        long_symbol="S-USD-PERP",
+        approved_snapshot_id=18219,
+        estimated_one_day_pnl_after_round_trip=0.2851,
+    )
+    second_snapshot.approved_snapshot.candidate.opportunity.opportunity.one_day_net_edge_after_round_trip = (  # noqa: E501
+        0.00305
+    )
+    first_approved = approved_store.append(first_snapshot.approved_snapshot)
+    second_approved = approved_store.append(second_snapshot.approved_snapshot)
+    launch_ready_store.append(
+        first_snapshot.model_copy(
+            update={
+                "launch_ready_snapshot_id": None,
+                "captured_at": datetime(2026, 5, 2, 1, 25, 55, tzinfo=UTC),
+                "approved_snapshot": first_approved,
+            }
+        )
+    )
+    latest = launch_ready_store.append(
+        second_snapshot.model_copy(
+            update={
+                "launch_ready_snapshot_id": None,
+                "captured_at": datetime(2026, 5, 2, 1, 26, 35, tzinfo=UTC),
+                "approved_snapshot": second_approved,
+            }
+        )
+    )
+
+    stabilities, detail = _list_ranked_stable_launch_ready_stabilities(
+        store=launch_ready_store,
+        max_snapshot_age_seconds=300,
+        min_snapshot_count=2,
+        min_stable_seconds=30.0,
+        now=datetime(2026, 5, 2, 1, 26, 45, tzinfo=UTC),
+        scan_limit=2,
+    )
+
+    assert detail is None
+    assert len(stabilities) == 1
+    assert stabilities[0].snapshot.launch_ready_snapshot_id == latest.launch_ready_snapshot_id
+    assert stabilities[0].consecutive_snapshots == 2
+    assert stabilities[0].stable_seconds == 40.0
+
+
 def test_launch_latest_stable_canary_once_honors_candidate_scan_limit(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary
- make stable launch-ready stability compare the route/live-readiness/notional envelope instead of exact repriced economics
- keep route, venue symbols, approval caps, and system-state changes as stability breakers
- cover the production failure where `S` launch-ready snapshots kept resetting on normal repricing before stable-launch could act

## Validation
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run pytest -q tests/test_worker.py::test_list_ranked_stable_launch_ready_stabilities_tolerates_repriced_same_route tests/test_api.py::test_latest_stable_launch_ready_canary_snapshot_endpoint_returns_stability`
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run ruff check apps/worker/src/carryme_worker/poller.py apps/api/src/carryme_api/app.py tests/test_worker.py tests/test_api.py`
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run pytest -q tests/test_worker.py -k 'stable_launch_ready_stabilities or stable_canary_launch' tests/test_api.py -k 'stable_launch_ready or latest_launch_ready' tests/test_canary_cycle_api.py -k 'latest_stable_launch_ready'`
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run mypy src apps packages tests`
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run ruff check .`
- `git diff --check`
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run pytest -q`
