### PR TITLE
fix: ignore stale flat review blockers

### DIFF
--- a/apps/api/src/carryme_api/app.py
+++ b/apps/api/src/carryme_api/app.py
@@ -123,6 +123,7 @@ from carryme_runtime import (
     build_venue_execution_preflights,
     reconcile_execution,
     require_confirmed_cleanup_preview,
+    review_required_pair_requires_continued_monitoring,
 )
 from carryme_runtime.execution_order_state import ExecutionLegOrderObserver
 from carryme_runtime.pair_close_preview import _pair_close_hash, select_pair_close_preview_venues
@@ -3189,6 +3190,11 @@ def _execution_requires_continued_monitoring(
                 break
         else:
             return True
+    if (
+        pair_status.derived_state == "review_required"
+        and not review_required_pair_requires_continued_monitoring(pair_status)
+    ):
+        return False
     return pair_status.derived_state in {
         "hedged",
         "cleanup_needed",

--- a/apps/worker/src/carryme_worker/poller.py
+++ b/apps/worker/src/carryme_worker/poller.py
@@ -83,6 +83,7 @@ from carryme_runtime import (
     build_venue_execution_preflights,
     filter_candidate_records,
     reconcile_execution,
+    review_required_pair_requires_continued_monitoring,
 )
 from carryme_runtime.balance_accounting import FUNDING_WINDOW_CHECKPOINT_STAGE
 from carryme_runtime.execution_order_state import ExecutionLegOrderObserver
@@ -5160,6 +5161,11 @@ def _execution_requires_continued_monitoring(
                 break
         else:
             return True
+    if (
+        pair_status.derived_state == "review_required"
+        and not review_required_pair_requires_continued_monitoring(pair_status)
+    ):
+        return False
     return pair_status.derived_state in {
         "hedged",
         "cleanup_needed",

--- a/packages/runtime/src/carryme_runtime/__init__.py
+++ b/packages/runtime/src/carryme_runtime/__init__.py
@@ -25,7 +25,10 @@ from carryme_runtime.execution_order_state import (
     HyperliquidOrderStateObserver,
     ParadexOrderStateObserver,
 )
-from carryme_runtime.execution_pair_status import build_execution_pair_status
+from carryme_runtime.execution_pair_status import (
+    build_execution_pair_status,
+    review_required_pair_requires_continued_monitoring,
+)
 from carryme_runtime.execution_quality import ExecutionQualityService
 from carryme_runtime.execution_reconciliation import reconcile_execution
 from carryme_runtime.extended_cleanup_preview import ExtendedCleanupPreviewService
@@ -82,6 +85,7 @@ __all__ = [
     "ExecutionQualityService",
     "ExecutionOrderStateService",
     "build_execution_pair_status",
+    "review_required_pair_requires_continued_monitoring",
     "ExtendedCleanupPreviewService",
     "ExtendedOrderStateObserver",
     "ExtendedLiveExecutionService",

--- a/packages/runtime/src/carryme_runtime/execution_pair_status.py
+++ b/packages/runtime/src/carryme_runtime/execution_pair_status.py
@@ -133,6 +133,33 @@ def build_execution_pair_status(
     )
 
 
+def review_required_pair_requires_continued_monitoring(
+    pair_status: ExecutionPairStatus,
+) -> bool:
+    """Return whether a review-required pair still has possible live exposure.
+
+    Some venues only expose open orders. After the observation window has elapsed,
+    a historic filled/unknown order-state combination should not block new
+    unattended launches if authenticated account reads show no route positions and
+    no venue reports an open or partially filled order.
+    """
+
+    if pair_status.derived_state != "review_required":
+        return True
+    reconciliation = pair_status.reconciliation
+    if any(
+        (not venue.authenticated) or (not venue.ready)
+        for venue in reconciliation.venues
+    ):
+        return True
+    if any(venue.position_symbols for venue in reconciliation.venues):
+        return True
+    return any(
+        leg.derived_state in {"open", "partial_fill"}
+        for leg in pair_status.order_state.legs
+    )
+
+
 def _position_presence_by_route(
     entry: ExecutionJournalEntry,
     reconciliation: ExecutionReconciliation,

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -98,6 +98,7 @@ from carryme_runtime import (
     reconcile_execution,
     require_confirmed_cleanup_preview,
     require_confirmed_preview,
+    review_required_pair_requires_continued_monitoring,
 )
 from carryme_runtime.account_preflight import (
     AUTH_READ_RETRY_ATTEMPTS,
@@ -11323,6 +11324,161 @@ def test_build_execution_pair_status_marks_single_leg_cleanup_as_closed_when_pos
     assert status.derived_state == "closed"
     assert status.recommended_action == "no_action"
     assert any("no live positions remaining" in note.lower() for note in status.notes)
+
+
+def test_review_required_pair_without_positions_does_not_require_continued_monitoring(
+) -> None:
+    order_state = ExecutionOrderState(
+        execution_entry_id=20,
+        paper_trade_id=10,
+        preview_hash="preview",
+        legs=[
+            ExecutionLegOrderState(
+                venue="paradex",
+                supported=True,
+                external_reference="paradex-order",
+                client_id="carryme-pt10-paradex-buy",
+                derived_state="filled",
+                order_status="CLOSED",
+                avg_fill_price="0.1639",
+                remaining_size="0",
+                size="152",
+            ),
+            ExecutionLegOrderState(
+                venue="extended",
+                supported=True,
+                external_reference="carryme-pt10-extended-sell",
+                client_id="carryme-pt10-extended-sell",
+                derived_state="unknown",
+                notes=[
+                    "Extended private API currently exposes open orders only; "
+                    "absence here does not distinguish filled from closed."
+                ],
+                raw_response={"orders": []},
+            ),
+        ],
+        notes=[],
+    )
+    reconciliation = ExecutionReconciliation(
+        execution_entry_id=20,
+        paper_trade_id=10,
+        preview_hash="preview",
+        status="submitted",
+        recommended_action="verify_fill_status",
+        matched_all_leg_symbols=False,
+        venues=[
+            ExecutionVenueReconciliation(
+                venue="paradex",
+                authenticated=True,
+                ready=True,
+                position_symbols=[],
+                unmatched_leg_symbols=["JUP-USD-PERP"],
+            ),
+            ExecutionVenueReconciliation(
+                venue="extended",
+                authenticated=True,
+                ready=True,
+                position_symbols=[],
+                unmatched_leg_symbols=["JUP-USD"],
+            ),
+        ],
+        notes=[],
+    )
+    pair_status = ExecutionPairStatus(
+        execution_entry_id=20,
+        paper_trade_id=10,
+        preview_hash="preview",
+        derived_state="review_required",
+        recommended_action="manual_review_required",
+        order_state=order_state,
+        reconciliation=reconciliation,
+        notes=[],
+    )
+
+    assert not review_required_pair_requires_continued_monitoring(pair_status)
+
+
+def test_review_required_pair_with_position_requires_continued_monitoring() -> None:
+    order_state = ExecutionOrderState(
+        execution_entry_id=20,
+        paper_trade_id=10,
+        preview_hash="preview",
+        legs=[],
+        notes=[],
+    )
+    pair_status = ExecutionPairStatus(
+        execution_entry_id=20,
+        paper_trade_id=10,
+        preview_hash="preview",
+        derived_state="review_required",
+        recommended_action="manual_review_required",
+        order_state=order_state,
+        reconciliation=ExecutionReconciliation(
+            execution_entry_id=20,
+            paper_trade_id=10,
+            preview_hash="preview",
+            status="submitted",
+            recommended_action="verify_fill_status",
+            matched_all_leg_symbols=False,
+            venues=[
+                ExecutionVenueReconciliation(
+                    venue="paradex",
+                    authenticated=True,
+                    ready=True,
+                    position_symbols=["JUP-USD-PERP"],
+                    matched_leg_symbols=["JUP-USD-PERP"],
+                )
+            ],
+            notes=[],
+        ),
+        notes=[],
+    )
+
+    assert review_required_pair_requires_continued_monitoring(pair_status)
+
+
+def test_review_required_pair_with_open_order_requires_continued_monitoring() -> None:
+    pair_status = ExecutionPairStatus(
+        execution_entry_id=20,
+        paper_trade_id=10,
+        preview_hash="preview",
+        derived_state="review_required",
+        recommended_action="manual_review_required",
+        order_state=ExecutionOrderState(
+            execution_entry_id=20,
+            paper_trade_id=10,
+            preview_hash="preview",
+            legs=[
+                ExecutionLegOrderState(
+                    venue="extended",
+                    supported=True,
+                    external_reference="extended-order",
+                    derived_state="open",
+                )
+            ],
+            notes=[],
+        ),
+        reconciliation=ExecutionReconciliation(
+            execution_entry_id=20,
+            paper_trade_id=10,
+            preview_hash="preview",
+            status="submitted",
+            recommended_action="verify_fill_status",
+            matched_all_leg_symbols=False,
+            venues=[
+                ExecutionVenueReconciliation(
+                    venue="extended",
+                    authenticated=True,
+                    ready=True,
+                    position_symbols=[],
+                )
+            ],
+            notes=[],
+        ),
+        notes=[],
+    )
+
+    assert review_required_pair_requires_continued_monitoring(pair_status)
 
 
 def test_extended_cleanup_preview_service_builds_reduce_only_close(

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -15072,6 +15072,134 @@ def test_execution_requires_continued_monitoring_uses_latest_non_null_pair_statu
     )
 
 
+def test_execution_requires_continued_monitoring_ignores_flat_review_required() -> None:
+    paper_trade = PaperTradeEntry(
+        entry_id=10,
+        created_at=datetime(2026, 4, 3, 22, 26, tzinfo=UTC),
+        intent=FundingPairTradeIntent(
+            label="jup_extended_paradex",
+            canonical_symbol="JUP-USD-PERP",
+            source_recorded_at=datetime(2026, 4, 3, 22, 25, tzinfo=UTC),
+            one_day_net_edge_after_entry=0.0017,
+            break_even_days_entry=0.18,
+            capacity_limit_notional=294.9,
+            target_notional=25.0,
+            capacity_fraction=0.1,
+            max_target_notional=25.0,
+            long_leg=TradeLegIntent(
+                venue="paradex",
+                symbol="JUP-USD-PERP",
+                fee_profile="pro_fastfills",
+                side="buy",
+                target_notional=25.0,
+            ),
+            short_leg=TradeLegIntent(
+                venue="extended",
+                symbol="JUP-USD",
+                fee_profile="default",
+                side="sell",
+                target_notional=25.0,
+            ),
+        ),
+    )
+    execution = ExecutionJournalEntry(
+        entry_id=20,
+        executed_at=datetime(2026, 4, 3, 22, 26, 34, tzinfo=UTC),
+        adapter="paired_live:paradex_then_extended",
+        mode="live",
+        status="submitted",
+        paper_trade_id=10,
+        preview_hash="preview-10",
+        paper_trade=paper_trade,
+        legs=[
+            ExecutionLegResult(
+                venue="paradex",
+                symbol="JUP-USD-PERP",
+                fee_profile="pro_fastfills",
+                side="buy",
+                target_notional=25.0,
+                status="submitted",
+                simulated=False,
+            )
+        ],
+    )
+    order_state = ExecutionOrderState(
+        execution_entry_id=20,
+        paper_trade_id=10,
+        preview_hash="preview-10",
+        legs=[
+            ExecutionLegOrderState(
+                venue="paradex",
+                supported=True,
+                external_reference="paradex-order",
+                client_id="carryme-pt10-paradex-buy",
+                derived_state="filled",
+                order_status="CLOSED",
+                remaining_size="0",
+                size="152",
+            ),
+            ExecutionLegOrderState(
+                venue="extended",
+                supported=True,
+                external_reference="carryme-pt10-extended-sell",
+                client_id="carryme-pt10-extended-sell",
+                derived_state="unknown",
+                raw_response={"orders": []},
+            ),
+        ],
+        notes=[],
+    )
+    reconciliation = ExecutionReconciliation(
+        execution_entry_id=20,
+        paper_trade_id=10,
+        preview_hash="preview-10",
+        status="submitted",
+        recommended_action="verify_fill_status",
+        matched_all_leg_symbols=False,
+        venues=[
+            ExecutionVenueReconciliation(
+                venue="paradex",
+                authenticated=True,
+                ready=True,
+                position_symbols=[],
+                unmatched_leg_symbols=["JUP-USD-PERP"],
+            ),
+            ExecutionVenueReconciliation(
+                venue="extended",
+                authenticated=True,
+                ready=True,
+                position_symbols=[],
+                unmatched_leg_symbols=["JUP-USD"],
+            ),
+        ],
+        notes=[],
+    )
+    observation = ExecutionObservationEntry(
+        observed_at=datetime(2026, 5, 2, 1, 39, tzinfo=UTC),
+        context="worker_execution_monitor",
+        execution_entry_id=20,
+        paper_trade_id=10,
+        preview_hash="preview-10",
+        order_state=order_state,
+        pair_status=ExecutionPairStatus(
+            execution_entry_id=20,
+            paper_trade_id=10,
+            preview_hash="preview-10",
+            derived_state="review_required",
+            recommended_action="manual_review_required",
+            order_state=order_state,
+            reconciliation=reconciliation,
+            notes=[],
+        ),
+    )
+
+    assert not _execution_requires_continued_monitoring(
+        cast(ExecutionObservationStore, object()),
+        execution=execution,
+        latest_observation=observation,
+    )
+
+
 def test_execution_requires_continued_monitoring_keeps_unknown_pair_status_history(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary
- stop stale `review_required` executions from blocking unattended launch when authenticated account reads show no route positions and no order leg is open/partial
- keep review-required executions blocking when account reads are unhealthy, positions exist, or open/partial orders remain
- apply the same stale-exposure rule to worker launch filtering and API automation readiness

## Validation
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run pytest -q tests/test_runtime.py -k 'review_required_pair' tests/test_worker.py -k 'execution_requires_continued_monitoring'`
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run ruff check apps/api/src/carryme_api/app.py apps/worker/src/carryme_worker/poller.py packages/runtime/src/carryme_runtime/__init__.py packages/runtime/src/carryme_runtime/execution_pair_status.py tests/test_runtime.py tests/test_worker.py`
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run mypy src apps packages tests`
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run pytest -q tests/test_worker.py -k 'stable_canary_launch or execution_requires_continued_monitoring or observe_live_executions' tests/test_runtime.py -k 'execution_pair_status or review_required_pair or execution_quality_service_reclassifies' tests/test_api.py -k 'automation_readiness or stable_launch_ready'`
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run ruff check .`
- `git diff --check`
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run pytest -q`
