### PR TITLE
fix: launch from proven stable canary snapshots

### DIFF
--- a/apps/worker/src/carryme_worker/poller.py
+++ b/apps/worker/src/carryme_worker/poller.py
@@ -1387,6 +1387,56 @@ def _approved_snapshot_route_key(
     )
 
 
+def _normalized_approved_snapshot_launch_payload(
+    snapshot: ApprovedCanarySnapshot,
+) -> dict[str, object]:
+    """Return the approved-snapshot fields that must stay fixed for launch safety."""
+
+    candidate = snapshot.candidate
+    opportunity = candidate.opportunity.opportunity
+    approval = snapshot.approval
+    venue_markets = candidate.opportunity.venue_markets
+    return {
+        "label": snapshot.label,
+        "suggested_canary_notional": candidate.suggested_canary_notional,
+        "route": {
+            "canonical_symbol": opportunity.canonical_symbol,
+            "long_venue": opportunity.long_venue,
+            "short_venue": opportunity.short_venue,
+            "long_fee_profile": opportunity.long_fee_profile,
+            "short_fee_profile": opportunity.short_fee_profile,
+            "venue_markets": tuple(
+                sorted(
+                    (venue, market.symbol)
+                    for venue, market in venue_markets.items()
+                )
+            ),
+        },
+        "approval": {
+            "label": approval.label,
+            "canonical_symbol": approval.canonical_symbol,
+            "short_venue": approval.short_venue,
+            "long_venue": approval.long_venue,
+            "short_fee_profile": approval.short_fee_profile,
+            "long_fee_profile": approval.long_fee_profile,
+            "approved": approval.approved,
+            "max_live_notional": approval.max_live_notional,
+        },
+    }
+
+
+def _approved_snapshot_launch_payload_changed(
+    previous_snapshot: ApprovedCanarySnapshot,
+    current_snapshot: ApprovedCanarySnapshot,
+) -> bool:
+    """Return whether a newer approved snapshot invalidates stable launch evidence."""
+
+    return (
+        _normalized_approved_snapshot_launch_payload(previous_snapshot)
+        != _normalized_approved_snapshot_launch_payload(current_snapshot)
+    )
+
+
 def _effective_funding_window_hours(snapshot: ApprovedCanarySnapshot) -> float:
     """Return the fastest relevant funding interval across the route venues."""
 
@@ -3092,8 +3142,9 @@ async def launch_latest_stable_canary_once(
     skipped_candidates: list[_StableCanaryCandidateSkip] = []
 
     for candidate_stability in stable_candidates:
+        candidate_snapshot = candidate_stability.snapshot
         try:
-            candidate_snapshot, candidate_selected, candidate_approval = (
+            latest_launch_ready_snapshot, candidate_selected, candidate_approval = (
                 _select_latest_launch_ready_canary_snapshot(
                     store=launch_ready_store,
                     approval_service=route_approval_service,
@@ -3119,31 +3170,13 @@ async def launch_latest_stable_canary_once(
                 continue
             raise
 
-        try:
-            revalidated_stability = _build_launch_ready_canary_stability(
-                store=launch_ready_store,
-                label=candidate_snapshot.label,
-                max_snapshot_age_seconds=settings.launch_ready_canary_max_snapshot_age_seconds,
-                min_snapshot_count=settings.stable_launch_ready_min_snapshot_count,
-                min_stable_seconds=settings.stable_launch_ready_min_stable_seconds,
-                now=timestamp,
-            )
-        except HTTPException as exc:
-            detail = str(exc.detail) or (
-                "Launch-ready canary snapshot no longer satisfies stability requirements"
-            )
-            skipped_candidates.append(
-                _StableCanaryCandidateSkip(
-                    label=candidate_snapshot.label,
-                    launch_ready_snapshot_id=candidate_snapshot.launch_ready_snapshot_id,
-                    approved_snapshot_id=candidate_snapshot.approved_snapshot.snapshot_id,
-                    detail=detail,
-                )
-            )
-            continue
         if (
-            revalidated_stability.snapshot.launch_ready_snapshot_id
+            latest_launch_ready_snapshot.launch_ready_snapshot_id
             != candidate_snapshot.launch_ready_snapshot_id
+            and _launch_ready_snapshot_payload_changed(
+                candidate_snapshot,
+                latest_launch_ready_snapshot,
+            )
         ):
             skipped_candidates.append(
                 _StableCanaryCandidateSkip(
@@ -3151,11 +3184,17 @@ async def launch_latest_stable_canary_once(
                     launch_ready_snapshot_id=candidate_snapshot.launch_ready_snapshot_id,
                     approved_snapshot_id=candidate_snapshot.approved_snapshot.snapshot_id,
                     detail=(
-                        "Launch-ready canary snapshot changed before stability could be revalidated"
+                        "Latest launch-ready canary snapshot changed route or readiness "
+                        "after stable evidence was collected"
                     ),
                 )
             )
             continue
+
+        launch_approved_snapshot_id = (
+            latest_launch_ready_snapshot.approved_snapshot.snapshot_id
+            or candidate_snapshot.approved_snapshot.snapshot_id
+        )
 
         label_cooldown_reason = _build_stable_launch_cooldown_reason(
             settings=settings,
@@ -3203,6 +3242,62 @@ async def launch_latest_stable_canary_once(
             )
             continue
         if latest_approved_snapshot.snapshot_id != candidate_snapshot.approved_snapshot.snapshot_id:
+            if _approved_snapshot_launch_payload_changed(
+                candidate_snapshot.approved_snapshot,
+                latest_approved_snapshot,
+            ):
+                skipped_candidates.append(
+                    _StableCanaryCandidateSkip(
+                        label=candidate_snapshot.label,
+                        launch_ready_snapshot_id=candidate_snapshot.launch_ready_snapshot_id,
+                        approved_snapshot_id=candidate_snapshot.approved_snapshot.snapshot_id,
+                        detail=(
+                            "Launch-ready canary snapshot is stale relative to the latest "
+                            "approved snapshot"
+                        ),
+                    )
+                )
+                continue
+            latest_approval = route_approval_service.get_for_candidate(
+                latest_approved_snapshot.candidate
+            )
+            if latest_approval is None or not latest_approval.approved:
+                skipped_candidates.append(
+                    _StableCanaryCandidateSkip(
+                        label=candidate_snapshot.label,
+                        launch_ready_snapshot_id=candidate_snapshot.launch_ready_snapshot_id,
+                        approved_snapshot_id=candidate_snapshot.approved_snapshot.snapshot_id,
+                        detail=(
+                            "Latest approved snapshot is no longer approved for live execution"
+                        ),
+                    )
+                )
+                continue
+            capped_notional = min(
+                latest_approved_snapshot.candidate.suggested_canary_notional,
+                latest_approval.max_live_notional,
+            )
+            if capped_notional <= 0:
+                skipped_candidates.append(
+                    _StableCanaryCandidateSkip(
+                        label=candidate_snapshot.label,
+                        launch_ready_snapshot_id=candidate_snapshot.launch_ready_snapshot_id,
+                        approved_snapshot_id=candidate_snapshot.approved_snapshot.snapshot_id,
+                        detail=(
+                            "Latest approved snapshot no longer permits a positive live notional"
+                        ),
+                    )
+                )
+                continue
+            candidate_selected = latest_approved_snapshot.candidate.model_copy(
+                update={"suggested_canary_notional": capped_notional}
+            )
+            candidate_approval = latest_approval
+            launch_approved_snapshot_id = latest_approved_snapshot.snapshot_id
+        elif (
+            latest_launch_ready_snapshot.approved_snapshot.snapshot_id
+            != candidate_snapshot.approved_snapshot.snapshot_id
+        ):
             skipped_candidates.append(
                 _StableCanaryCandidateSkip(
                     label=candidate_snapshot.label,
@@ -3341,9 +3436,7 @@ async def launch_latest_stable_canary_once(
                             launch_ready_snapshot_id=(
                                 candidate_snapshot.launch_ready_snapshot_id
                             ),
-                            approved_snapshot_id=(
-                                candidate_snapshot.approved_snapshot.snapshot_id
-                            ),
+                            approved_snapshot_id=launch_approved_snapshot_id,
                             paper_trade_id=previous_launch.paper_trade_id,
                             final_pair_state=previous_launch.final_pair_state,
                             detail=(
@@ -3388,7 +3481,7 @@ async def launch_latest_stable_canary_once(
                     status="shadowed",
                     label=candidate_snapshot.label,
                     launch_ready_snapshot_id=candidate_snapshot.launch_ready_snapshot_id or 0,
-                    approved_snapshot_id=candidate_snapshot.approved_snapshot.snapshot_id or 0,
+                    approved_snapshot_id=launch_approved_snapshot_id or 0,
                     paper_trade_id=0,
                     final_pair_state="shadowed",
                     detail="Shadow mode launch marker",
@@ -3399,7 +3492,7 @@ async def launch_latest_stable_canary_once(
                 database_path=settings.database_target,
                 label=candidate_snapshot.label,
                 launch_ready_snapshot_id=candidate_snapshot.launch_ready_snapshot_id,
-                approved_snapshot_id=candidate_snapshot.approved_snapshot.snapshot_id,
+                approved_snapshot_id=launch_approved_snapshot_id,
                 detail=(
                     "Shadow mode: would launch stable canary from launch-ready snapshot "
                     f"{candidate_snapshot.launch_ready_snapshot_id}"
@@ -3413,7 +3506,7 @@ async def launch_latest_stable_canary_once(
                 database_path=settings.database_target,
                 label=candidate_snapshot.label,
                 launch_ready_snapshot_id=candidate_snapshot.launch_ready_snapshot_id,
-                approved_snapshot_id=candidate_snapshot.approved_snapshot.snapshot_id,
+                approved_snapshot_id=launch_approved_snapshot_id,
                 detail=hold_mode_blocker,
             )
 
@@ -3435,7 +3528,7 @@ async def launch_latest_stable_canary_once(
                 _StableCanaryCandidateSkip(
                     label=candidate_snapshot.label,
                     launch_ready_snapshot_id=candidate_snapshot.launch_ready_snapshot_id,
-                    approved_snapshot_id=candidate_snapshot.approved_snapshot.snapshot_id,
+                    approved_snapshot_id=launch_approved_snapshot_id,
                     detail=(
                         "Latest launch-ready snapshot no longer satisfies live execution "
                         f"readiness: {'; '.join(execution_preflight.blocking_reasons)}"
@@ -3462,7 +3555,7 @@ async def launch_latest_stable_canary_once(
                     _StableCanaryCandidateSkip(
                         label=candidate_snapshot.label,
                         launch_ready_snapshot_id=candidate_snapshot.launch_ready_snapshot_id,
-                        approved_snapshot_id=candidate_snapshot.approved_snapshot.snapshot_id,
+                        approved_snapshot_id=launch_approved_snapshot_id,
                         detail=(
                             "Launch-ready canary snapshot is already reserved for launch "
                             "by worker"
@@ -3497,8 +3590,8 @@ async def launch_latest_stable_canary_once(
                 lifecycle_note=(
                     "Launched by carryme-worker from stable launch-ready snapshot "
                     f"{candidate_snapshot.launch_ready_snapshot_id} after "
-                    f"{revalidated_stability.consecutive_snapshots} stable snapshots over "
-                    f"{revalidated_stability.stable_seconds:.1f}s."
+                    f"{candidate_stability.consecutive_snapshots} stable snapshots over "
+                    f"{candidate_stability.stable_seconds:.1f}s."
                 ),
                 paper_store=PaperTradeStore(runtime_settings.database_path),
                 confirmation_store=PreviewConfirmationStore(runtime_settings.database_path),
@@ -3556,7 +3649,7 @@ async def launch_latest_stable_canary_once(
                     _StableCanaryCandidateSkip(
                         label=candidate_snapshot.label,
                         launch_ready_snapshot_id=candidate_snapshot.launch_ready_snapshot_id,
-                        approved_snapshot_id=candidate_snapshot.approved_snapshot.snapshot_id,
+                        approved_snapshot_id=launch_approved_snapshot_id,
                         detail=exc.detail,
                     )
                 )
@@ -3580,7 +3673,7 @@ async def launch_latest_stable_canary_once(
                 status="launched",
                 label=candidate_snapshot.label,
                 launch_ready_snapshot_id=candidate_snapshot.launch_ready_snapshot_id or 0,
-                approved_snapshot_id=candidate_snapshot.approved_snapshot.snapshot_id or 0,
+                approved_snapshot_id=launch_approved_snapshot_id or 0,
                 paper_trade_id=paper_trade_id,
                 final_pair_state=lifecycle.final_pair_status.derived_state,
             )
@@ -3590,7 +3683,7 @@ async def launch_latest_stable_canary_once(
             database_path=settings.database_target,
             label=candidate_snapshot.label,
             launch_ready_snapshot_id=candidate_snapshot.launch_ready_snapshot_id,
-            approved_snapshot_id=candidate_snapshot.approved_snapshot.snapshot_id,
+            approved_snapshot_id=launch_approved_snapshot_id,
             paper_trade_id=paper_trade_id,
             final_pair_state=lifecycle.final_pair_status.derived_state,
             detail=None,
@@ -3640,9 +3733,17 @@ async def run_supervised_stable_canary_launch_loop(
             else:
                 skipped += 1
             loop_logger.info(
-                "completed supervised stable canary launch cycle %s with status=%s",
+                "completed supervised stable canary launch cycle %s with status=%s "
+                "label=%s launch_ready_snapshot_id=%s approved_snapshot_id=%s "
+                "paper_trade_id=%s final_pair_state=%s detail=%s",
                 attempts,
                 summary.status,
+                summary.label,
+                summary.launch_ready_snapshot_id,
+                summary.approved_snapshot_id,
+                summary.paper_trade_id,
+                summary.final_pair_state,
+                summary.detail,
             )
             if max_iterations is not None and attempts >= max_iterations:
                 break

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -5260,7 +5260,7 @@ def test_list_ranked_stable_launch_ready_stabilities_reports_future_snapshot_det
     assert "future" in detail
 
 
-def test_launch_latest_stable_canary_once_skips_when_selected_snapshot_lacks_revalidated_stability(
+def test_launch_latest_stable_canary_once_uses_proven_stable_snapshot_when_latest_reprices(
     tmp_path: Path,
 ) -> None:
     settings = WorkerSettings(database_path=str(tmp_path / "history.sqlite3"))
@@ -5274,7 +5274,7 @@ def test_launch_latest_stable_canary_once_skips_when_selected_snapshot_lacks_rev
     )
     approved_snapshot = approved_store.append(snapshot.approved_snapshot)
     route_approval_store.upsert(approval)
-    stable_snapshot = launch_ready_store.append(
+    launch_ready_store.append(
         snapshot.model_copy(
             update={
                 "launch_ready_snapshot_id": None,
@@ -5283,7 +5283,7 @@ def test_launch_latest_stable_canary_once_skips_when_selected_snapshot_lacks_rev
             }
         )
     )
-    launch_ready_store.append(
+    stable_snapshot = launch_ready_store.append(
         snapshot.model_copy(
             update={
                 "launch_ready_snapshot_id": None,
@@ -5298,6 +5298,83 @@ def test_launch_latest_stable_canary_once_skips_when_selected_snapshot_lacks_rev
             "captured_at": datetime(2026, 4, 4, 10, 1, 20, tzinfo=UTC),
         }
     )
+    launched_snapshot_ids: list[int | None] = []
+
+    class StubLifecycleResult:
+        def __init__(self) -> None:
+            self.paper_trade = PaperTradeEntry(
+                entry_id=17,
+                created_at=datetime(2026, 4, 4, 10, 1, 40, tzinfo=UTC),
+                intent=FundingPairTradeIntent(
+                    label="arb_extended_paradex",
+                    canonical_symbol="ARB-USD-PERP",
+                    source_recorded_at=datetime(2026, 4, 4, 10, 1, tzinfo=UTC),
+                    one_day_net_edge_after_entry=0.00355,
+                    break_even_days_entry=0.2,
+                    capacity_limit_notional=900.0,
+                    target_notional=20.0,
+                    capacity_fraction=20.0 / 900.0,
+                    max_target_notional=20.0,
+                    long_leg=TradeLegIntent(
+                        venue="paradex",
+                        symbol="ARB-USD-PERP",
+                        fee_profile="pro_fastfills",
+                        side="buy",
+                        target_notional=20.0,
+                    ),
+                    short_leg=TradeLegIntent(
+                        venue="extended",
+                        symbol="ARB-USD",
+                        fee_profile="default",
+                        side="sell",
+                        target_notional=20.0,
+                    ),
+                ),
+                note="worker launch",
+            )
+            self.final_pair_status = ExecutionPairStatus(
+                execution_entry_id=31,
+                paper_trade_id=17,
+                preview_hash="preview",
+                derived_state="closed",
+                recommended_action="no_action",
+                order_state=ExecutionOrderState(
+                    execution_entry_id=31,
+                    paper_trade_id=17,
+                    preview_hash="preview",
+                    legs=[],
+                    notes=[],
+                ),
+                reconciliation=ExecutionReconciliation(
+                    execution_entry_id=31,
+                    paper_trade_id=17,
+                    preview_hash="preview",
+                    status="accepted",
+                    recommended_action="no_action",
+                    matched_all_leg_symbols=True,
+                    venues=[],
+                    notes=[],
+                ),
+                notes=[],
+            )
+
+    async def run_stub_lifecycle(**kwargs: object) -> StubLifecycleResult:
+        lifecycle_note = cast(str, kwargs["lifecycle_note"])
+        assert f"snapshot {stable_snapshot.launch_ready_snapshot_id}" in lifecycle_note
+        launched_snapshot_ids.append(stable_snapshot.launch_ready_snapshot_id)
+        return StubLifecycleResult()
+
+    api_settings = ApiSettings(
+        database_path=settings.database_path,
+        watchlist_path=settings.watchlist_path,
+        environment=settings.environment,
+        extended_live_enabled=True,
+        extended_api_key="extended-key",
+        extended_stark_private_key="extended-secret",
+        paradex_live_enabled=True,
+        paradex_account_address="0x123",
+        paradex_private_key="0x456",
+    )
 
     with pytest.MonkeyPatch.context() as monkeypatch:
         monkeypatch.setattr(
@@ -5306,24 +5383,165 @@ def test_launch_latest_stable_canary_once_skips_when_selected_snapshot_lacks_rev
         )
         monkeypatch.setattr(
             "carryme_worker.poller._run_guarded_canary_lifecycle",
-            lambda **_: (_ for _ in ()).throw(
-                AssertionError("launch should skip before lifecycle when stability changed")
-            ),
+            run_stub_lifecycle,
         )
         summary = asyncio.run(
             launch_latest_stable_canary_once(
                 settings,
+                api_settings=api_settings,
                 approved_store=approved_store,
                 now=datetime(2026, 4, 4, 10, 1, 40, tzinfo=UTC),
             )
         )
 
-    assert summary.status == "skipped"
+    assert summary.status == "launched"
     assert summary.label == "arb_extended_paradex"
-    assert summary.launch_ready_snapshot_id == 999
-    assert summary.detail == (
-        "Launch-ready canary snapshot changed before stability could be revalidated"
+    assert summary.launch_ready_snapshot_id == stable_snapshot.launch_ready_snapshot_id
+    assert summary.approved_snapshot_id == approved_snapshot.snapshot_id
+    assert summary.paper_trade_id == 17
+    assert launched_snapshot_ids == [stable_snapshot.launch_ready_snapshot_id]
+
+
+def test_launch_latest_stable_canary_once_uses_latest_equivalent_approved_snapshot(
+    tmp_path: Path,
+) -> None:
+    settings = WorkerSettings(database_path=str(tmp_path / "history.sqlite3"))
+    launch_ready_store = LaunchReadyCanaryStore(settings.database_path)
+    approved_store = ApprovedCanaryStore(settings.database_path)
+    route_approval_store = RouteApprovalStore(settings.database_path)
+    approval, candidate, snapshot, _ = _build_stable_launch_test_snapshot(
+        label="arb_extended_paradex",
+        launch_ready_snapshot_id=9,
+        approved_snapshot_id=8,
     )
+    stable_approved = approved_store.append(snapshot.approved_snapshot)
+    route_approval_store.upsert(approval)
+    stable_snapshot = _append_stable_launch_ready_pair(
+        launch_ready_store,
+        snapshot,
+        stable_approved,
+        datetime(2026, 4, 4, 10, 0, 30, tzinfo=UTC),
+        datetime(2026, 4, 4, 10, 1, 0, tzinfo=UTC),
+    )
+    repriced_route = candidate.opportunity.opportunity.model_copy(
+        update={
+            "gross_daily_edge": 0.005,
+            "one_day_net_edge_after_entry": 0.00455,
+            "one_day_net_edge_after_round_trip": 0.0041,
+        }
+    )
+    repriced_opportunity = candidate.opportunity.model_copy(
+        update={
+            "opportunity": repriced_route,
+            "estimated_one_day_pnl_after_round_trip": 3.69,
+        }
+    )
+    repriced_candidate = candidate.model_copy(update={"opportunity": repriced_opportunity})
+    latest_approved = approved_store.append(
+        snapshot.approved_snapshot.model_copy(
+            update={
+                "snapshot_id": None,
+                "captured_at": datetime(2026, 4, 4, 10, 1, 25, tzinfo=UTC),
+                "candidate": repriced_candidate,
+            }
+        )
+    )
+    captured_edges: list[float] = []
+
+    class StubLifecycleResult:
+        def __init__(self) -> None:
+            self.paper_trade = PaperTradeEntry(
+                entry_id=17,
+                created_at=datetime(2026, 4, 4, 10, 1, 40, tzinfo=UTC),
+                intent=FundingPairTradeIntent(
+                    label="arb_extended_paradex",
+                    canonical_symbol="ARB-USD-PERP",
+                    source_recorded_at=datetime(2026, 4, 4, 10, 1, tzinfo=UTC),
+                    one_day_net_edge_after_entry=0.00455,
+                    break_even_days_entry=0.2,
+                    capacity_limit_notional=900.0,
+                    target_notional=20.0,
+                    capacity_fraction=20.0 / 900.0,
+                    max_target_notional=20.0,
+                    long_leg=TradeLegIntent(
+                        venue="paradex",
+                        symbol="ARB-USD-PERP",
+                        fee_profile="pro_fastfills",
+                        side="buy",
+                        target_notional=20.0,
+                    ),
+                    short_leg=TradeLegIntent(
+                        venue="extended",
+                        symbol="ARB-USD",
+                        fee_profile="default",
+                        side="sell",
+                        target_notional=20.0,
+                    ),
+                ),
+                note="worker launch",
+            )
+            self.final_pair_status = ExecutionPairStatus(
+                execution_entry_id=31,
+                paper_trade_id=17,
+                preview_hash="preview",
+                derived_state="closed",
+                recommended_action="no_action",
+                order_state=ExecutionOrderState(
+                    execution_entry_id=31,
+                    paper_trade_id=17,
+                    preview_hash="preview",
+                    legs=[],
+                    notes=[],
+                ),
+                reconciliation=ExecutionReconciliation(
+                    execution_entry_id=31,
+                    paper_trade_id=17,
+                    preview_hash="preview",
+                    status="accepted",
+                    recommended_action="no_action",
+                    matched_all_leg_symbols=True,
+                    venues=[],
+                    notes=[],
+                ),
+                notes=[],
+            )
+
+    async def run_stub_lifecycle(**kwargs: object) -> StubLifecycleResult:
+        launched_candidate = cast(FundingUniverseCanaryCandidate, kwargs["candidate"])
+        captured_edges.append(
+            launched_candidate.opportunity.opportunity.one_day_net_edge_after_round_trip
+        )
+        return StubLifecycleResult()
+
+    api_settings = ApiSettings(
+        database_path=settings.database_path,
+        watchlist_path=settings.watchlist_path,
+        environment=settings.environment,
+        extended_live_enabled=True,
+        extended_api_key="extended-key",
+        extended_stark_private_key="extended-secret",
+        paradex_live_enabled=True,
+        paradex_account_address="0x123",
+        paradex_private_key="0x456",
+    )
+    with pytest.MonkeyPatch.context() as monkeypatch:
+        monkeypatch.setattr(
+            "carryme_worker.poller._run_guarded_canary_lifecycle",
+            run_stub_lifecycle,
+        )
+        summary = asyncio.run(
+            launch_latest_stable_canary_once(
+                settings,
+                api_settings=api_settings,
+                approved_store=approved_store,
+                now=datetime(2026, 4, 4, 10, 1, 40, tzinfo=UTC),
+            )
+        )
+
+    assert summary.status == "launched"
+    assert summary.launch_ready_snapshot_id == stable_snapshot.launch_ready_snapshot_id
+    assert summary.approved_snapshot_id == latest_approved.snapshot_id
+    assert captured_edges == [0.0041]
 
 
 def test_launch_latest_stable_canary_once_falls_through_label_cooldown(
@@ -9100,6 +9318,9 @@ def test_launch_latest_stable_canary_once_skips_stale_latest_approved_snapshot(
             update={
                 "snapshot_id": None,
                 "captured_at": datetime(2026, 3, 29, 20, 1, tzinfo=UTC),
+                "candidate": older_snapshot.candidate.model_copy(
+                    update={"suggested_canary_notional": 20.0}
+                ),
             }
         )
     )
@@ -11987,6 +12208,7 @@ def test_maybe_auto_close_open_hedged_execution_revalidates_without_active_appro
 
 def test_run_supervised_stable_canary_launch_loop_honors_max_iterations(
     tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     settings = WorkerSettings(
         database_path=str(tmp_path / "history.sqlite3"),
@@ -12034,6 +12256,7 @@ def test_run_supervised_stable_canary_launch_loop_honors_max_iterations(
             "carryme_worker.poller.launch_latest_stable_canary_once",
             fake_launch_latest_stable_canary_once,
         )
+        caplog.set_level(logging.INFO, logger="carryme.worker")
         summary = asyncio.run(
             run_supervised_stable_canary_launch_loop(
                 settings,
@@ -12049,6 +12272,9 @@ def test_run_supervised_stable_canary_launch_loop_honors_max_iterations(
     assert summary.launched == 1
     assert summary.skipped == 1
     assert sleeps == [6]
+    assert "label=arb_extended_paradex" in caplog.text
+    assert "paper_trade_id=17" in caplog.text
+    assert "detail=No launch-ready canary snapshot found" in caplog.text
 
 
 def test_run_production_supervisor_cycle_once_orders_stages(


### PR DESCRIPTION
## Summary
- keep the launch candidate tied to the already proven stable launch-ready snapshot instead of reselecting a newer snapshot that can reset the stability window mid-cycle
- allow repriced equivalent approved snapshots to refresh execution economics while still failing closed on route, approval, notional, readiness, or approval-scope changes
- include stable-launch skip/launch details in supervised worker logs for production debugging

## Validation
- UV_PROJECT_ENVIRONMENT=.venv-codex uv run pytest -q tests/test_worker.py -k 'launch_latest_stable_canary_once_uses_proven or launch_latest_stable_canary_once_uses_latest_equivalent or run_supervised_stable_canary_launch_loop_honors'
- UV_PROJECT_ENVIRONMENT=.venv-codex uv run pytest -q tests/test_worker.py -k 'launch_latest_stable_canary_once or list_ranked_stable_launch_ready_stabilities or run_supervised_stable_canary_launch_loop'
- UV_PROJECT_ENVIRONMENT=.venv-codex uv run pytest -q tests/test_worker.py
- UV_PROJECT_ENVIRONMENT=.venv-codex uv run ruff check .
- UV_PROJECT_ENVIRONMENT=.venv-codex uv run mypy src apps packages tests
- git diff --check