### PR TITLE
fix: refresh stable launch snapshot time

### DIFF
--- a/apps/worker/src/carryme_worker/poller.py
+++ b/apps/worker/src/carryme_worker/poller.py
@@ -384,6 +384,16 @@ class StableCanaryLaunchLoopSummary:
     database_path: str
 
 
+def _utc_now() -> datetime:
+    """Return the current UTC timestamp.
+
+    Kept as a tiny seam so tests can model slow production cycles without
+    sleeping or monkeypatching the datetime type.
+    """
+
+    return datetime.now(UTC)
+
+
 def _list_blocking_live_executions_for_stable_launch(
     *,
     settings: WorkerSettings,
@@ -3040,7 +3050,7 @@ async def launch_latest_stable_canary_once(
     route_approval_service = RouteApprovalService(
         store=RouteApprovalStore(runtime_settings.database_path)
     )
-    timestamp = now or datetime.now(UTC)
+    timestamp = now or _utc_now()
 
     blocking_live_executions = _list_blocking_live_executions_for_stable_launch(
         settings=settings,
@@ -3124,12 +3134,17 @@ async def launch_latest_stable_canary_once(
             ),
         )
 
+    # Some production pre-checks intentionally touch live execution and balance
+    # history. Use a fresh timestamp for market-snapshot freshness so a slow
+    # pre-check cannot make a newly captured stable snapshot look future-dated.
+    snapshot_selection_timestamp = now or _utc_now()
+
     stable_candidates, no_candidate_detail = _list_ranked_stable_launch_ready_stabilities(
         store=launch_ready_store,
         max_snapshot_age_seconds=settings.launch_ready_canary_max_snapshot_age_seconds,
         min_snapshot_count=settings.stable_launch_ready_min_snapshot_count,
         min_stable_seconds=settings.stable_launch_ready_min_stable_seconds,
-        now=timestamp,
+        now=snapshot_selection_timestamp,
         scan_limit=settings.stable_canary_launch_candidate_scan_limit,
     )
     if not stable_candidates:
@@ -3150,7 +3165,7 @@ async def launch_latest_stable_canary_once(
                     approval_service=route_approval_service,
                     label=candidate_stability.snapshot.label,
                     max_snapshot_age_seconds=settings.launch_ready_canary_max_snapshot_age_seconds,
-                    now=timestamp,
+                    now=snapshot_selection_timestamp,
                 )
             )
         except HTTPException as exc:
@@ -3199,7 +3214,7 @@ async def launch_latest_stable_canary_once(
         label_cooldown_reason = _build_stable_launch_cooldown_reason(
             settings=settings,
             launch_store=stable_launch_store,
-            now=timestamp,
+            now=snapshot_selection_timestamp,
             label=candidate_snapshot.label,
         )
         if label_cooldown_reason is not None:
@@ -3216,7 +3231,7 @@ async def launch_latest_stable_canary_once(
         label_rate_cap_reason = _build_stable_launch_rate_cap_reason(
             settings=settings,
             launch_store=stable_launch_store,
-            now=timestamp,
+            now=snapshot_selection_timestamp,
             label=candidate_snapshot.label,
         )
         if label_rate_cap_reason is not None:

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -5260,6 +5260,136 @@ def test_list_ranked_stable_launch_ready_stabilities_reports_future_snapshot_det
     assert "future" in detail
 
 
+def test_launch_latest_stable_canary_once_refreshes_snapshot_time_after_prechecks(
+    tmp_path: Path,
+) -> None:
+    settings = WorkerSettings(database_path=str(tmp_path / "history.sqlite3"))
+    launch_ready_store = LaunchReadyCanaryStore(settings.database_path)
+    approved_store = ApprovedCanaryStore(settings.database_path)
+    route_approval_store = RouteApprovalStore(settings.database_path)
+    approval, _, snapshot, _ = _build_stable_launch_test_snapshot(
+        label="arb_extended_paradex",
+        launch_ready_snapshot_id=9,
+        approved_snapshot_id=8,
+    )
+    approved_snapshot = approved_store.append(snapshot.approved_snapshot)
+    route_approval_store.upsert(approval)
+    stable_snapshot = _append_stable_launch_ready_pair(
+        launch_ready_store,
+        snapshot,
+        approved_snapshot,
+        datetime(2026, 4, 4, 10, 0, 0, tzinfo=UTC),
+        datetime(2026, 4, 4, 10, 1, 0, tzinfo=UTC),
+    )
+    captured_snapshot_ids: list[int | None] = []
+
+    class StubLifecycleResult:
+        def __init__(self) -> None:
+            self.paper_trade = PaperTradeEntry(
+                entry_id=17,
+                created_at=datetime(2026, 4, 4, 10, 1, 45, tzinfo=UTC),
+                intent=FundingPairTradeIntent(
+                    label="arb_extended_paradex",
+                    canonical_symbol="ARB-USD-PERP",
+                    source_recorded_at=datetime(2026, 4, 4, 10, 1, 0, tzinfo=UTC),
+                    one_day_net_edge_after_entry=0.00355,
+                    break_even_days_entry=0.2,
+                    capacity_limit_notional=900.0,
+                    target_notional=20.0,
+                    capacity_fraction=20.0 / 900.0,
+                    max_target_notional=20.0,
+                    long_leg=TradeLegIntent(
+                        venue="paradex",
+                        symbol="ARB-USD-PERP",
+                        fee_profile="pro_fastfills",
+                        side="buy",
+                        target_notional=20.0,
+                    ),
+                    short_leg=TradeLegIntent(
+                        venue="extended",
+                        symbol="ARB-USD",
+                        fee_profile="default",
+                        side="sell",
+                        target_notional=20.0,
+                    ),
+                ),
+                note="worker launch",
+            )
+            self.final_pair_status = ExecutionPairStatus(
+                execution_entry_id=31,
+                paper_trade_id=17,
+                preview_hash="preview",
+                derived_state="closed",
+                recommended_action="no_action",
+                order_state=ExecutionOrderState(
+                    execution_entry_id=31,
+                    paper_trade_id=17,
+                    preview_hash="preview",
+                    legs=[],
+                    notes=[],
+                ),
+                reconciliation=ExecutionReconciliation(
+                    execution_entry_id=31,
+                    paper_trade_id=17,
+                    preview_hash="preview",
+                    status="accepted",
+                    recommended_action="no_action",
+                    matched_all_leg_symbols=True,
+                    venues=[],
+                    notes=[],
+                ),
+                notes=[],
+            )
+
+    async def run_stub_lifecycle(**kwargs: object) -> StubLifecycleResult:
+        lifecycle_note = cast(str, kwargs["lifecycle_note"])
+        assert f"snapshot {stable_snapshot.launch_ready_snapshot_id}" in lifecycle_note
+        captured_snapshot_ids.append(stable_snapshot.launch_ready_snapshot_id)
+        return StubLifecycleResult()
+
+    api_settings = ApiSettings(
+        database_path=settings.database_path,
+        watchlist_path=settings.watchlist_path,
+        environment=settings.environment,
+        extended_live_enabled=True,
+        extended_api_key="extended-key",
+        extended_stark_private_key="extended-secret",
+        paradex_live_enabled=True,
+        paradex_account_address="0x123",
+        paradex_private_key="0x456",
+    )
+    utc_now_calls = iter(
+        [
+            datetime(2026, 4, 4, 10, 0, 50, tzinfo=UTC),
+            datetime(2026, 4, 4, 10, 1, 45, tzinfo=UTC),
+        ]
+    )
+
+    with pytest.MonkeyPatch.context() as monkeypatch:
+        monkeypatch.setattr(
+            "carryme_worker.poller._utc_now",
+            lambda: next(utc_now_calls),
+        )
+        monkeypatch.setattr(
+            "carryme_worker.poller._run_guarded_canary_lifecycle",
+            run_stub_lifecycle,
+        )
+        summary = asyncio.run(
+            launch_latest_stable_canary_once(
+                settings,
+                api_settings=api_settings,
+                approved_store=approved_store,
+            )
+        )
+
+    assert summary.status == "launched", summary.detail
+    assert summary.label == "arb_extended_paradex"
+    assert summary.launch_ready_snapshot_id == stable_snapshot.launch_ready_snapshot_id
+    assert summary.approved_snapshot_id == approved_snapshot.snapshot_id
+    assert summary.paper_trade_id == 17
+    assert captured_snapshot_ids == [stable_snapshot.launch_ready_snapshot_id]
+
+
 def test_launch_latest_stable_canary_once_uses_proven_stable_snapshot_when_latest_reprices(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary
- refresh stable-launch snapshot selection time after slow live/risk pre-checks
- keep cooldown/rate-cap checks aligned to the refreshed selection time
- add a regression test for snapshots that are future-dated only relative to the stale cycle-start timestamp

## Root Cause
The stable-launch worker captured `now` once at cycle start. When live execution/balance pre-checks took long enough, newer launch-ready snapshots written by the scanners could be valid at selection time but still look future-dated against the stale cycle-start timestamp. Production then skipped `S` with `snapshot timestamp is in the future` even while the API showed a stable launch-ready route.

## Validation
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run pytest -q tests/test_worker.py -k 'refreshes_snapshot_time or future_snapshot_detail or launch_latest_stable_canary_once_uses_proven or launch_latest_stable_canary_once_uses_latest_equivalent'`
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run pytest -q tests/test_worker.py -k 'launch_latest_stable_canary_once or list_ranked_stable_launch_ready_stabilities or run_supervised_stable_canary_launch_loop'`
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run pytest -q tests/test_worker.py`
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run ruff check .`
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run mypy src apps packages tests`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved timestamp handling in canary launch logic by implementing separate timing for snapshot selection. This ensures that preliminary validation checks do not affect snapshot freshness calculations, resulting in more accurate snapshot selection during stable deployments.

* **Tests**
  * Added test coverage for canary launch snapshot selection behavior and timestamp handling improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->