### PR TITLE
fix: speed up launch-ready label discovery

### DIFF
--- a/packages/storage/src/carryme_storage/launch_ready_canaries.py
+++ b/packages/storage/src/carryme_storage/launch_ready_canaries.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import json
-import logging
 from pathlib import Path
 from typing import Any
 
@@ -11,9 +10,7 @@ from carryme_models import LaunchReadyCanarySnapshot
 
 from carryme_storage.db import Database
 
-logger = logging.getLogger(__name__)
 MAX_RECENT_LABEL_LIMIT = 250
-MAX_RECENT_LABEL_SCAN_ROWS = MAX_RECENT_LABEL_LIMIT * 20
 
 
 class LaunchReadyCanaryStore:
@@ -56,6 +53,12 @@ class LaunchReadyCanaryStore:
                 """
                 CREATE INDEX IF NOT EXISTS idx_launch_ready_canary_snapshots_label
                 ON launch_ready_canary_snapshots(label)
+                """
+            )
+            connection.execute(
+                """
+                CREATE INDEX IF NOT EXISTS idx_launch_ready_canary_snapshots_label_captured_at_id
+                ON launch_ready_canary_snapshots(label, captured_at DESC, id DESC)
                 """
             )
 
@@ -147,63 +150,29 @@ class LaunchReadyCanaryStore:
             raise ValueError(f"limit must be at most {MAX_RECENT_LABEL_LIMIT}")
 
         self.initialize()
-        labels: list[str] = []
-        seen_labels: set[str] = set()
-        batch_size = min(max(limit * 4, 50), MAX_RECENT_LABEL_LIMIT * 4)
-        cursor: tuple[str, int] | None = None
-        scanned_rows = 0
-
         with self.database.begin() as connection:
-            while len(labels) < limit and scanned_rows < MAX_RECENT_LABEL_SCAN_ROWS:
-                if cursor is None:
-                    rows = connection.execute(
-                        """
-                        SELECT label, captured_at, id
-                        FROM launch_ready_canary_snapshots
-                        ORDER BY captured_at DESC, id DESC
-                        LIMIT ?
-                        """,
-                        (batch_size,),
-                    ).fetchall()
-                else:
-                    rows = connection.execute(
-                        """
-                        SELECT label, captured_at, id
-                        FROM launch_ready_canary_snapshots
-                        WHERE captured_at < ? OR (captured_at = ? AND id < ?)
-                        ORDER BY captured_at DESC, id DESC
-                        LIMIT ?
-                        """,
-                        (cursor[0], cursor[0], cursor[1], batch_size),
-                    ).fetchall()
+            rows = connection.execute(
+                """
+                SELECT label
+                FROM (
+                    SELECT
+                        label,
+                        captured_at,
+                        id,
+                        ROW_NUMBER() OVER (
+                            PARTITION BY label
+                            ORDER BY captured_at DESC, id DESC
+                        ) AS label_rank
+                    FROM launch_ready_canary_snapshots
+                ) latest_label_rows
+                WHERE label_rank = 1
+                ORDER BY captured_at DESC, id DESC
+                LIMIT ?
+                """,
+                (limit,),
+            ).fetchall()
 
-                if not rows:
-                    break
-                scanned_rows += len(rows)
-
-                for label, _captured_at, _row_id in rows:
-                    if label in seen_labels:
-                        continue
-                    seen_labels.add(label)
-                    labels.append(label)
-                    if len(labels) >= limit:
-                        break
-
-                last_label, last_captured_at, last_row_id = rows[-1]
-                _ = last_label
-                cursor = (last_captured_at, last_row_id)
-
-        if len(labels) < limit and scanned_rows >= MAX_RECENT_LABEL_SCAN_ROWS:
-            logger.warning(
-                "list_recent_labels scan capped before collecting requested labels: "
-                "requested_limit=%s collected_labels=%s scanned_rows=%s scan_row_cap=%s",
-                limit,
-                len(labels),
-                scanned_rows,
-                MAX_RECENT_LABEL_SCAN_ROWS,
-            )
-
-        return labels
+        return [str(row[0]) for row in rows]
 
     def delete_label(self, label: str) -> int:
         """Delete all launch-ready canary snapshots for one label."""

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -3173,6 +3173,54 @@ def test_launch_ready_canary_store_list_recent_labels_paginates_duplicate_rows(
     ]
 
 
+def test_launch_ready_canary_store_list_recent_labels_handles_deep_duplicate_history(
+    tmp_path: Path,
+) -> None:
+    store = LaunchReadyCanaryStore(tmp_path / "history.sqlite3")
+    store.initialize()
+    base_time = datetime(2026, 3, 29, 14, 11, tzinfo=UTC)
+
+    with store.database.begin() as connection:
+        for offset in range(5050):
+            connection.execute(
+                """
+                INSERT INTO launch_ready_canary_snapshots (
+                    captured_at,
+                    label,
+                    approved_snapshot_id,
+                    snapshot_json
+                ) VALUES (?, ?, ?, ?)
+                """,
+                (
+                    (base_time - timedelta(seconds=offset)).isoformat(),
+                    "arb_extended_paradex",
+                    7,
+                    "{}",
+                ),
+            )
+        connection.execute(
+            """
+            INSERT INTO launch_ready_canary_snapshots (
+                captured_at,
+                label,
+                approved_snapshot_id,
+                snapshot_json
+            ) VALUES (?, ?, ?, ?)
+            """,
+            (
+                (base_time - timedelta(seconds=5051)).isoformat(),
+                "bera_extended_paradex",
+                8,
+                "{}",
+            ),
+        )
+
+    assert store.list_recent_labels(limit=2) == [
+        "arb_extended_paradex",
+        "bera_extended_paradex",
+    ]
+
+
 def test_launch_ready_canary_store_list_recent_labels_rejects_invalid_limits(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary
- replace paged duplicate-row scanning in launch-ready label discovery with a single latest-row-per-label query
- add a covering index for label/captured_at/id lookups
- add a regression test for deep duplicate history beyond the old scan cap

## Root Cause
`LaunchReadyCanaryStore.list_recent_labels()` paged through recent rows until it found enough distinct labels. In production, one hot label can dominate thousands of launch-ready rows, causing the stable-launch worker to scan 5,200 rows, hit the cap, log warnings, and spend too long before making launch decisions.

## Validation
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run pytest -q tests/test_storage.py -k 'launch_ready_canary_store_list_recent_labels'`
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run pytest -q tests/test_storage.py`
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run ruff check packages/storage/src/carryme_storage/launch_ready_canaries.py tests/test_storage.py`
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run mypy packages/storage tests/test_storage.py`
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run ruff check .`
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run mypy src apps packages tests`
- `git diff --check`
