### PR TITLE
fix: shortlist live canary candidate scans

### DIFF
--- a/apps/api/src/carryme_api/app.py
+++ b/apps/api/src/carryme_api/app.py
@@ -6803,6 +6803,7 @@ def create_app() -> FastAPI:
         limit: int = 10,
     ) -> list[FundingUniverseCanaryCandidate]:
         try:
+            limit = _validated_history_limit("limit", limit)
             selected_venues = venues or ["extended", "paradex", "hyperliquid"]
             candidates = await service.scan_canary_candidates(
                 venues=selected_venues,

--- a/packages/runtime/src/carryme_runtime/universe.py
+++ b/packages/runtime/src/carryme_runtime/universe.py
@@ -210,6 +210,7 @@ class OpportunityUniverseService:
             limit=limit,
             use_execution_quality=use_execution_quality,
             use_route_stability=use_route_stability,
+            force_snapshot_shortlist=True,
         )
         candidates: list[FundingUniverseCanaryCandidate] = []
         for opportunity in scan.opportunities:
@@ -249,6 +250,7 @@ class OpportunityUniverseService:
         limit: int = 20,
         use_execution_quality: bool = True,
         use_route_stability: bool = True,
+        force_snapshot_shortlist: bool = False,
     ) -> FundingUniverseScan:
         normalized_venues = _normalize_venues(venues)
         normalized_ranking = _normalize_ranking(ranking)
@@ -276,6 +278,7 @@ class OpportunityUniverseService:
             min_daily_volume=min_daily_volume,
             min_open_interest=min_open_interest,
             min_roundtrip_edge=min_roundtrip_edge,
+            force_snapshot_shortlist=force_snapshot_shortlist,
         )
         snapshots = await self._fetch_overlapping_snapshots(snapshot_overlaps)
         needs_execution_quality = (
@@ -469,6 +472,7 @@ class OpportunityUniverseService:
         min_daily_volume: float,
         min_open_interest: float,
         min_roundtrip_edge: float,
+        force_snapshot_shortlist: bool = False,
     ) -> list[FundingUniverseOverlap]:
         """Use lightweight market stats to choose which overlaps need full orderbooks."""
 
@@ -525,7 +529,10 @@ class OpportunityUniverseService:
         ranked = sorted(scored, key=lambda item: item[0], reverse=True)
         ordered = [overlap for _score, overlap in ranked]
         ordered.extend(unscored)
-        if shortlist_size <= 0 or ranking not in SHORTLIST_CAPPED_RANKINGS:
+        if (
+            shortlist_size <= 0
+            or (ranking not in SHORTLIST_CAPPED_RANKINGS and not force_snapshot_shortlist)
+        ):
             return ordered
         return ordered[:shortlist_size]
 

--- a/packages/runtime/src/carryme_runtime/universe.py
+++ b/packages/runtime/src/carryme_runtime/universe.py
@@ -531,11 +531,12 @@ class OpportunityUniverseService:
         ranked = sorted(scored, key=lambda item: item[0], reverse=True)
         ordered = [overlap for _score, overlap in ranked]
         ordered.extend(unscored)
-        if (
-            shortlist_size <= 0
-            or (ranking not in SHORTLIST_CAPPED_RANKINGS and not force_snapshot_shortlist)
-        ):
+        if ranking not in SHORTLIST_CAPPED_RANKINGS and not force_snapshot_shortlist:
             return ordered
+        if shortlist_size <= 0:
+            if not force_snapshot_shortlist:
+                return ordered
+            shortlist_size = max(self.snapshot_shortlist_min_overlaps, 1)
         return ordered[:shortlist_size]
 
     async def _fetch_overlapping_market_stats(

--- a/packages/runtime/src/carryme_runtime/universe.py
+++ b/packages/runtime/src/carryme_runtime/universe.py
@@ -190,6 +190,8 @@ class OpportunityUniverseService:
         use_execution_quality: bool = True,
         use_route_stability: bool = True,
     ) -> list[FundingUniverseCanaryCandidate]:
+        if limit < 1:
+            raise ValueError("limit must be at least 1")
         scan = await self.scan(
             venues=venues,
             ranking="route_adjusted_quality_pnl",

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -736,6 +736,32 @@ def test_funding_universe_canary_endpoint_uses_policy_defaults() -> None:
     assert captured["exclude_tags"] is None
 
 
+def test_funding_universe_canary_endpoint_rejects_unbounded_limit() -> None:
+    called = False
+
+    class StubUniverseService:
+        async def scan_canary_candidates(
+            self, **_: object
+        ) -> list[FundingUniverseCanaryCandidate]:
+            nonlocal called
+            called = True
+            return []
+
+    app.dependency_overrides[get_opportunity_universe_service] = lambda: StubUniverseService()
+    try:
+        client = TestClient(app)
+        response = client.get(
+            "/v1/opportunities/funding-universe/canary",
+            params={"limit": "0"},
+        )
+    finally:
+        app.dependency_overrides.clear()
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "limit must be at least 1"
+    assert called is False
+
+
 def test_funding_universe_canary_endpoint_can_filter_approved_routes() -> None:
     candidate = FundingUniverseCanaryCandidate(
         opportunity=FundingUniverseOpportunity(

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -1383,6 +1383,18 @@ def test_opportunity_universe_service_canary_candidates_force_snapshot_shortlist
     asyncio.run(run())
 
 
+def test_opportunity_universe_service_canary_candidates_rejects_unbounded_limit() -> None:
+    async def run() -> None:
+        service = OpportunityUniverseService()
+        with pytest.raises(ValueError, match="limit must be at least 1"):
+            await service.scan_canary_candidates(
+                venues=["extended", "paradex"],
+                limit=0,
+            )
+
+    asyncio.run(run())
+
+
 def test_opportunity_universe_service_preserves_non_edge_ranking_correctness() -> None:
     symbol_lists = {
         "extended": ["HIGHEDGE-USD", "BIG-USD"],

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -1307,6 +1307,82 @@ def test_opportunity_universe_service_orders_unbounded_scans_with_market_stats()
     asyncio.run(run())
 
 
+def test_opportunity_universe_service_canary_candidates_force_snapshot_shortlist() -> None:
+    symbol_lists = {
+        "extended": ["TOP-USD", "MID-USD", "LOW-USD"],
+        "paradex": ["TOP-USD-PERP", "MID-USD-PERP", "LOW-USD-PERP"],
+    }
+    summary_snapshots = {
+        ("extended", "TOP-USD"): _snapshot(
+            "extended", "TOP-USD", 0.0005, 1.0, 10_000, 1.001, 10_000
+        ),
+        ("paradex", "TOP-USD-PERP"): _snapshot(
+            "paradex", "TOP-USD-PERP", -0.0005, 1.0, 10_000, 1.001, 10_000
+        ),
+        ("extended", "MID-USD"): _snapshot(
+            "extended", "MID-USD", 0.0003, 1.0, 10_000, 1.001, 10_000
+        ),
+        ("paradex", "MID-USD-PERP"): _snapshot(
+            "paradex", "MID-USD-PERP", -0.0002, 1.0, 10_000, 1.001, 10_000
+        ),
+        ("extended", "LOW-USD"): _snapshot(
+            "extended", "LOW-USD", 0.00001, 1.0, 10_000, 1.001, 10_000
+        ),
+        ("paradex", "LOW-USD-PERP"): _snapshot(
+            "paradex", "LOW-USD-PERP", 0.0, 1.0, 10_000, 1.001, 10_000
+        ),
+    }
+    full_snapshots = {
+        ("extended", "TOP-USD"): summary_snapshots[("extended", "TOP-USD")],
+        ("paradex", "TOP-USD-PERP"): summary_snapshots[("paradex", "TOP-USD-PERP")],
+    }
+    fetched_full_snapshots: list[tuple[str, str]] = []
+
+    async def list_symbols(venue: str) -> list[str]:
+        return symbol_lists[venue]
+
+    async def fetch_market_stats(venue: str, symbol: str) -> MarketStats:
+        return summary_snapshots[(venue, symbol)].market.model_copy(
+            update={"top_of_book": None}
+        )
+
+    async def fetch_snapshot(venue: str, symbol: str) -> NormalizedMarketSnapshot:
+        fetched_full_snapshots.append((venue, symbol))
+        try:
+            return full_snapshots[(venue, symbol)]
+        except KeyError as exc:
+            raise AssertionError(
+                f"unexpected full canary snapshot for non-shortlisted symbol: {(venue, symbol)}"
+            ) from exc
+
+    async def run() -> None:
+        service = OpportunityUniverseService(
+            list_symbols=list_symbols,
+            fetch_market_stats=fetch_market_stats,
+            fetch_snapshot=fetch_snapshot,
+            snapshot_shortlist_min_overlaps=1,
+            snapshot_shortlist_multiplier=1,
+        )
+        candidates = await service.scan_canary_candidates(
+            venues=["extended", "paradex"],
+            min_execution_quality_score=0.0,
+            min_route_stability_weight=0.0,
+            min_route_presence_ratio=0.0,
+            min_route_samples=0,
+            limit=1,
+        )
+
+        assert [item.opportunity.opportunity.canonical_symbol for item in candidates] == [
+            "TOP-USD-PERP"
+        ]
+        assert set(fetched_full_snapshots) == {
+            ("extended", "TOP-USD"),
+            ("paradex", "TOP-USD-PERP"),
+        }
+
+    asyncio.run(run())
+
+
 def test_opportunity_universe_service_preserves_non_edge_ranking_correctness() -> None:
     symbol_lists = {
         "extended": ["HIGHEDGE-USD", "BIG-USD"],

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -1395,6 +1395,80 @@ def test_opportunity_universe_service_canary_candidates_rejects_unbounded_limit(
     asyncio.run(run())
 
 
+def test_opportunity_universe_service_forced_snapshot_shortlist_clamps_non_positive_limit() -> None:
+    symbol_lists = {
+        "extended": ["TOP-USD", "MID-USD", "LOW-USD"],
+        "paradex": ["TOP-USD-PERP", "MID-USD-PERP", "LOW-USD-PERP"],
+    }
+    summary_snapshots = {
+        ("extended", "TOP-USD"): _snapshot(
+            "extended", "TOP-USD", 0.0005, 1.0, 10_000, 1.001, 10_000
+        ),
+        ("paradex", "TOP-USD-PERP"): _snapshot(
+            "paradex", "TOP-USD-PERP", -0.0005, 1.0, 10_000, 1.001, 10_000
+        ),
+        ("extended", "MID-USD"): _snapshot(
+            "extended", "MID-USD", 0.0003, 1.0, 10_000, 1.001, 10_000
+        ),
+        ("paradex", "MID-USD-PERP"): _snapshot(
+            "paradex", "MID-USD-PERP", -0.0002, 1.0, 10_000, 1.001, 10_000
+        ),
+        ("extended", "LOW-USD"): _snapshot(
+            "extended", "LOW-USD", 0.00001, 1.0, 10_000, 1.001, 10_000
+        ),
+        ("paradex", "LOW-USD-PERP"): _snapshot(
+            "paradex", "LOW-USD-PERP", 0.0, 1.0, 10_000, 1.001, 10_000
+        ),
+    }
+    full_snapshots = {
+        ("extended", "TOP-USD"): summary_snapshots[("extended", "TOP-USD")],
+        ("paradex", "TOP-USD-PERP"): summary_snapshots[("paradex", "TOP-USD-PERP")],
+    }
+    fetched_full_snapshots: list[tuple[str, str]] = []
+
+    async def list_symbols(venue: str) -> list[str]:
+        return symbol_lists[venue]
+
+    async def fetch_market_stats(venue: str, symbol: str) -> MarketStats:
+        return summary_snapshots[(venue, symbol)].market.model_copy(
+            update={"top_of_book": None}
+        )
+
+    async def fetch_snapshot(venue: str, symbol: str) -> NormalizedMarketSnapshot:
+        fetched_full_snapshots.append((venue, symbol))
+        try:
+            return full_snapshots[(venue, symbol)]
+        except KeyError as exc:
+            raise AssertionError(
+                f"unexpected full snapshot for non-shortlisted symbol: {(venue, symbol)}"
+            ) from exc
+
+    async def run() -> None:
+        service = OpportunityUniverseService(
+            list_symbols=list_symbols,
+            fetch_market_stats=fetch_market_stats,
+            fetch_snapshot=fetch_snapshot,
+            snapshot_shortlist_min_overlaps=1,
+            snapshot_shortlist_multiplier=1,
+        )
+        scan = await service.scan(
+            venues=["extended", "paradex"],
+            ranking="roundtrip_pnl",
+            limit=0,
+            force_snapshot_shortlist=True,
+        )
+
+        assert [item.opportunity.canonical_symbol for item in scan.opportunities] == [
+            "TOP-USD-PERP"
+        ]
+        assert set(fetched_full_snapshots) == {
+            ("extended", "TOP-USD"),
+            ("paradex", "TOP-USD-PERP"),
+        }
+
+    asyncio.run(run())
+
+
 def test_opportunity_universe_service_preserves_non_edge_ranking_correctness() -> None:
     symbol_lists = {
         "extended": ["HIGHEDGE-USD", "BIG-USD"],


### PR DESCRIPTION
## Summary
- force live canary candidate discovery through the existing lightweight market-stats shortlist before full snapshot/orderbook fetches
- keep exact non-edge `scan()` behavior unchanged unless explicitly requested by the caller
- add regression coverage proving canary scans do not fetch full snapshots for non-shortlisted symbols

## Production context
The live `/v1/opportunities/funding-universe/canary` endpoint timed out after 45s while trying to discover better routes. This keeps dynamic canary discovery fast without widening live-money launch guards or bypassing route approvals.

## Validation
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run pytest -q tests/test_runtime.py -k 'shortlist or preserves_non_edge_ranking_correctness or scan_canary_candidates_uses_policy_defaults'`
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run pytest -q tests/test_runtime.py`
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run ruff check .`
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run mypy src apps packages tests`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configuration flag to enforce snapshot shortlist selection during canary candidate scanning, enabling stricter capping of market candidate lists.

* **Tests**
  * Added test coverage to verify that canary candidate scanning properly applies snapshot shortlist restrictions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->