### PR TITLE
fix: protect api from universe scan starvation

### DIFF
--- a/apps/api/src/carryme_api/app.py
+++ b/apps/api/src/carryme_api/app.py
@@ -183,8 +183,40 @@ AUTOMATION_READINESS_MAX_ACTIVE_LIVE_EXECUTIONS = 0
 AUTOMATION_READINESS_ACTIVE_EXECUTION_SCAN_LIMIT = 200
 AUTOMATION_READINESS_MAX_OBSERVATION_AGE_SECONDS = 1800
 PAIR_STATUS_POLL_CALL_TIMEOUT_SECONDS = 10.0
+UNIVERSE_SCAN_TIMEOUT_SECONDS = 20.0
+UNIVERSE_SCAN_ACQUIRE_TIMEOUT_SECONDS = 0.25
 MUTATING_HTTP_METHODS = frozenset({"POST", "PUT", "PATCH", "DELETE"})
 logger = logging.getLogger(__name__)
+_UNIVERSE_SCAN_SEMAPHORE = asyncio.Semaphore(1)
+
+
+async def _run_bounded_universe_scan[UniverseScanResultT](
+    name: str,
+    call: Callable[[], Awaitable[UniverseScanResultT]],
+) -> UniverseScanResultT:
+    """Run one expensive live-universe scan without starving normal API traffic."""
+
+    acquired = False
+    try:
+        await asyncio.wait_for(
+            _UNIVERSE_SCAN_SEMAPHORE.acquire(),
+            timeout=UNIVERSE_SCAN_ACQUIRE_TIMEOUT_SECONDS,
+        )
+        acquired = True
+        return await asyncio.wait_for(call(), timeout=UNIVERSE_SCAN_TIMEOUT_SECONDS)
+    except TimeoutError as exc:
+        if not acquired:
+            raise HTTPException(
+                status_code=429,
+                detail=f"{name} is already running; retry shortly",
+            ) from exc
+        raise HTTPException(
+            status_code=504,
+            detail=f"{name} exceeded {UNIVERSE_SCAN_TIMEOUT_SECONDS:g}s timeout",
+        ) from exc
+    finally:
+        if acquired:
+            _UNIVERSE_SCAN_SEMAPHORE.release()
 
 
 def _rank_approved_canary_candidate(
@@ -2589,24 +2621,27 @@ async def _select_approved_canary_candidate(
             status_code=404,
             detail="No approved canary candidate matched the requested filters",
         )
-    candidates = await universe_service.scan_canary_candidates(
-        venues=selected_venues,
-        fee_profile_overrides=fee_profile_overrides,
-        target_notional=target_notional,
-        canary_max_notional=canary_max_notional,
-        min_capacity_notional=min_capacity_notional,
-        min_daily_volume=min_daily_volume,
-        min_open_interest=min_open_interest,
-        min_roundtrip_edge=min_roundtrip_edge,
-        min_execution_quality_score=min_execution_quality_score,
-        min_execution_samples=min_execution_samples,
-        min_route_stability_weight=min_route_stability_weight,
-        min_route_presence_ratio=min_route_presence_ratio,
-        min_route_samples=min_route_samples,
-        include_symbols=include_symbols,
-        exclude_symbols=exclude_symbols,
-        exclude_tags=exclude_tags,
-        limit=limit,
+    candidates = await _run_bounded_universe_scan(
+        "approved canary candidate scan",
+        lambda: universe_service.scan_canary_candidates(
+            venues=selected_venues,
+            fee_profile_overrides=fee_profile_overrides,
+            target_notional=target_notional,
+            canary_max_notional=canary_max_notional,
+            min_capacity_notional=min_capacity_notional,
+            min_daily_volume=min_daily_volume,
+            min_open_interest=min_open_interest,
+            min_roundtrip_edge=min_roundtrip_edge,
+            min_execution_quality_score=min_execution_quality_score,
+            min_execution_samples=min_execution_samples,
+            min_route_stability_weight=min_route_stability_weight,
+            min_route_presence_ratio=min_route_presence_ratio,
+            min_route_samples=min_route_samples,
+            include_symbols=include_symbols,
+            exclude_symbols=exclude_symbols,
+            exclude_tags=exclude_tags,
+            limit=limit,
+        ),
     )
     approved_candidates = approval_service.filter_approved_canary_candidates(candidates)
     if label is not None:
@@ -2675,24 +2710,27 @@ async def _scan_approved_canary_basket_plan(
         fee_profile_overrides=fee_profile_overrides,
     )
     resolved_venues = list(resolved_fee_profiles)
-    candidates = await universe_service.scan_canary_candidates(
-        venues=resolved_venues,
-        fee_profile_overrides=fee_profile_overrides or None,
-        target_notional=target_notional,
-        canary_max_notional=canary_max_notional,
-        min_capacity_notional=min_capacity_notional,
-        min_daily_volume=min_daily_volume,
-        min_open_interest=min_open_interest,
-        min_roundtrip_edge=min_roundtrip_edge,
-        min_execution_quality_score=min_execution_quality_score,
-        min_execution_samples=min_execution_samples,
-        min_route_stability_weight=min_route_stability_weight,
-        min_route_presence_ratio=min_route_presence_ratio,
-        min_route_samples=min_route_samples,
-        include_symbols=include_symbols,
-        exclude_symbols=exclude_symbols,
-        exclude_tags=exclude_tags,
-        limit=limit,
+    candidates = await _run_bounded_universe_scan(
+        "funding universe approved basket scan",
+        lambda: universe_service.scan_canary_candidates(
+            venues=resolved_venues,
+            fee_profile_overrides=fee_profile_overrides or None,
+            target_notional=target_notional,
+            canary_max_notional=canary_max_notional,
+            min_capacity_notional=min_capacity_notional,
+            min_daily_volume=min_daily_volume,
+            min_open_interest=min_open_interest,
+            min_roundtrip_edge=min_roundtrip_edge,
+            min_execution_quality_score=min_execution_quality_score,
+            min_execution_samples=min_execution_samples,
+            min_route_stability_weight=min_route_stability_weight,
+            min_route_presence_ratio=min_route_presence_ratio,
+            min_route_samples=min_route_samples,
+            include_symbols=include_symbols,
+            exclude_symbols=exclude_symbols,
+            exclude_tags=exclude_tags,
+            limit=limit,
+        ),
     )
     return approval_service.build_approved_canary_basket_plan(
         candidates=candidates,
@@ -4988,28 +5026,31 @@ def create_app() -> FastAPI:
         limit: int = 10,
     ) -> PaperTradeEntry:
         selected_venues = venues or ["extended", "paradex", "hyperliquid"]
-        candidates = await universe_service.scan_canary_candidates(
-            venues=selected_venues,
-            fee_profile_overrides=_build_fee_profile_overrides(
-                extended_fee_profile=extended_fee_profile,
-                paradex_fee_profile=paradex_fee_profile,
-                hyperliquid_fee_profile=hyperliquid_fee_profile,
+        candidates = await _run_bounded_universe_scan(
+            "paper trade approved canary scan",
+            lambda: universe_service.scan_canary_candidates(
+                venues=selected_venues,
+                fee_profile_overrides=_build_fee_profile_overrides(
+                    extended_fee_profile=extended_fee_profile,
+                    paradex_fee_profile=paradex_fee_profile,
+                    hyperliquid_fee_profile=hyperliquid_fee_profile,
+                ),
+                target_notional=target_notional,
+                canary_max_notional=canary_max_notional,
+                min_capacity_notional=min_capacity_notional,
+                min_daily_volume=min_daily_volume,
+                min_open_interest=min_open_interest,
+                min_roundtrip_edge=min_roundtrip_edge,
+                min_execution_quality_score=min_execution_quality_score,
+                min_execution_samples=min_execution_samples,
+                min_route_stability_weight=min_route_stability_weight,
+                min_route_presence_ratio=min_route_presence_ratio,
+                min_route_samples=min_route_samples,
+                include_symbols=include_symbols,
+                exclude_symbols=exclude_symbols,
+                exclude_tags=exclude_tags,
+                limit=limit,
             ),
-            target_notional=target_notional,
-            canary_max_notional=canary_max_notional,
-            min_capacity_notional=min_capacity_notional,
-            min_daily_volume=min_daily_volume,
-            min_open_interest=min_open_interest,
-            min_roundtrip_edge=min_roundtrip_edge,
-            min_execution_quality_score=min_execution_quality_score,
-            min_execution_samples=min_execution_samples,
-            min_route_stability_weight=min_route_stability_weight,
-            min_route_presence_ratio=min_route_presence_ratio,
-            min_route_samples=min_route_samples,
-            include_symbols=include_symbols,
-            exclude_symbols=exclude_symbols,
-            exclude_tags=exclude_tags,
-            limit=limit,
         )
         approved_candidates = approval_service.filter_approved_canary_candidates(candidates)
         if label is not None:
@@ -6783,28 +6824,31 @@ def create_app() -> FastAPI:
                 min_route_presence_ratio=min_route_presence_ratio,
                 min_route_samples=min_route_samples,
             )
-            return await service.scan(
-                venues=selected_venues,
-                ranking=ranking,  # type: ignore[arg-type]
-                fee_profile_overrides=_build_fee_profile_overrides(
-                    extended_fee_profile=extended_fee_profile,
-                    paradex_fee_profile=paradex_fee_profile,
-                    hyperliquid_fee_profile=hyperliquid_fee_profile,
+            return await _run_bounded_universe_scan(
+                "funding universe scan",
+                lambda: service.scan(
+                    venues=selected_venues,
+                    ranking=ranking,  # type: ignore[arg-type]
+                    fee_profile_overrides=_build_fee_profile_overrides(
+                        extended_fee_profile=extended_fee_profile,
+                        paradex_fee_profile=paradex_fee_profile,
+                        hyperliquid_fee_profile=hyperliquid_fee_profile,
+                    ),
+                    target_notional=target_notional,
+                    min_capacity_notional=min_capacity_notional,
+                    min_daily_volume=min_daily_volume,
+                    min_open_interest=min_open_interest,
+                    min_roundtrip_edge=min_roundtrip_edge,
+                    min_execution_quality_score=min_execution_quality_score,
+                    min_execution_samples=min_execution_samples,
+                    min_route_stability_weight=min_route_stability_weight,
+                    min_route_presence_ratio=min_route_presence_ratio,
+                    min_route_samples=min_route_samples,
+                    include_symbols=include_symbols,
+                    exclude_symbols=exclude_symbols,
+                    exclude_tags=exclude_tags,
+                    limit=limit,
                 ),
-                target_notional=target_notional,
-                min_capacity_notional=min_capacity_notional,
-                min_daily_volume=min_daily_volume,
-                min_open_interest=min_open_interest,
-                min_roundtrip_edge=min_roundtrip_edge,
-                min_execution_quality_score=min_execution_quality_score,
-                min_execution_samples=min_execution_samples,
-                min_route_stability_weight=min_route_stability_weight,
-                min_route_presence_ratio=min_route_presence_ratio,
-                min_route_samples=min_route_samples,
-                include_symbols=include_symbols,
-                exclude_symbols=exclude_symbols,
-                exclude_tags=exclude_tags,
-                limit=limit,
             )
         except ValueError as exc:
             raise HTTPException(status_code=400, detail=str(exc)) from exc
@@ -6845,28 +6889,31 @@ def create_app() -> FastAPI:
         try:
             limit = _validated_history_limit("limit", limit)
             selected_venues = venues or ["extended", "paradex", "hyperliquid"]
-            candidates = await service.scan_canary_candidates(
-                venues=selected_venues,
-                fee_profile_overrides=_build_fee_profile_overrides(
-                    extended_fee_profile=extended_fee_profile,
-                    paradex_fee_profile=paradex_fee_profile,
-                    hyperliquid_fee_profile=hyperliquid_fee_profile,
+            candidates = await _run_bounded_universe_scan(
+                "funding universe canary scan",
+                lambda: service.scan_canary_candidates(
+                    venues=selected_venues,
+                    fee_profile_overrides=_build_fee_profile_overrides(
+                        extended_fee_profile=extended_fee_profile,
+                        paradex_fee_profile=paradex_fee_profile,
+                        hyperliquid_fee_profile=hyperliquid_fee_profile,
+                    ),
+                    target_notional=target_notional,
+                    canary_max_notional=canary_max_notional,
+                    min_capacity_notional=min_capacity_notional,
+                    min_daily_volume=min_daily_volume,
+                    min_open_interest=min_open_interest,
+                    min_roundtrip_edge=min_roundtrip_edge,
+                    min_execution_quality_score=min_execution_quality_score,
+                    min_execution_samples=min_execution_samples,
+                    min_route_stability_weight=min_route_stability_weight,
+                    min_route_presence_ratio=min_route_presence_ratio,
+                    min_route_samples=min_route_samples,
+                    include_symbols=include_symbols,
+                    exclude_symbols=exclude_symbols,
+                    exclude_tags=exclude_tags,
+                    limit=limit,
                 ),
-                target_notional=target_notional,
-                canary_max_notional=canary_max_notional,
-                min_capacity_notional=min_capacity_notional,
-                min_daily_volume=min_daily_volume,
-                min_open_interest=min_open_interest,
-                min_roundtrip_edge=min_roundtrip_edge,
-                min_execution_quality_score=min_execution_quality_score,
-                min_execution_samples=min_execution_samples,
-                min_route_stability_weight=min_route_stability_weight,
-                min_route_presence_ratio=min_route_presence_ratio,
-                min_route_samples=min_route_samples,
-                include_symbols=include_symbols,
-                exclude_symbols=exclude_symbols,
-                exclude_tags=exclude_tags,
-                limit=limit,
             )
             if approved_only:
                 return approval_service.filter_approved_canary_candidates(candidates)[:limit]
@@ -6915,29 +6962,32 @@ def create_app() -> FastAPI:
             )
             selected_venues = venues or list(SUPPORTED_UNIVERSE_VENUES)
             generated_at = datetime.now(UTC)
-            candidates = await service.scan_canary_candidates(
-                venues=selected_venues,
-                fee_profile_overrides=_build_fee_profile_overrides(
-                    extended_fee_profile=extended_fee_profile,
-                    paradex_fee_profile=paradex_fee_profile,
-                    hyperliquid_fee_profile=hyperliquid_fee_profile,
-                    selected_venues=selected_venues,
+            candidates = await _run_bounded_universe_scan(
+                "funding universe canary approval proposal scan",
+                lambda: service.scan_canary_candidates(
+                    venues=selected_venues,
+                    fee_profile_overrides=_build_fee_profile_overrides(
+                        extended_fee_profile=extended_fee_profile,
+                        paradex_fee_profile=paradex_fee_profile,
+                        hyperliquid_fee_profile=hyperliquid_fee_profile,
+                        selected_venues=selected_venues,
+                    ),
+                    target_notional=target_notional,
+                    canary_max_notional=canary_max_notional,
+                    min_capacity_notional=min_capacity_notional,
+                    min_daily_volume=min_daily_volume,
+                    min_open_interest=min_open_interest,
+                    min_roundtrip_edge=min_roundtrip_edge,
+                    min_execution_quality_score=min_execution_quality_score,
+                    min_execution_samples=min_execution_samples,
+                    min_route_stability_weight=min_route_stability_weight,
+                    min_route_presence_ratio=min_route_presence_ratio,
+                    min_route_samples=min_route_samples,
+                    include_symbols=include_symbols,
+                    exclude_symbols=exclude_symbols,
+                    exclude_tags=exclude_tags,
+                    limit=candidate_sample,
                 ),
-                target_notional=target_notional,
-                canary_max_notional=canary_max_notional,
-                min_capacity_notional=min_capacity_notional,
-                min_daily_volume=min_daily_volume,
-                min_open_interest=min_open_interest,
-                min_roundtrip_edge=min_roundtrip_edge,
-                min_execution_quality_score=min_execution_quality_score,
-                min_execution_samples=min_execution_samples,
-                min_route_stability_weight=min_route_stability_weight,
-                min_route_presence_ratio=min_route_presence_ratio,
-                min_route_samples=min_route_samples,
-                include_symbols=include_symbols,
-                exclude_symbols=exclude_symbols,
-                exclude_tags=exclude_tags,
-                limit=candidate_sample,
             )
             proposals = approval_service.propose_canary_route_approvals(
                 candidates,
@@ -7960,28 +8010,31 @@ def create_app() -> FastAPI:
                 min_route_presence_ratio=min_route_presence_ratio,
                 min_route_samples=min_route_samples,
             )
-            scan = await service.scan(
-                venues=selected_venues,
-                ranking=ranking,  # type: ignore[arg-type]
-                fee_profile_overrides=_build_fee_profile_overrides(
-                    extended_fee_profile=extended_fee_profile,
-                    paradex_fee_profile=paradex_fee_profile,
-                    hyperliquid_fee_profile=hyperliquid_fee_profile,
+            scan = await _run_bounded_universe_scan(
+                "funding universe portfolio scan",
+                lambda: service.scan(
+                    venues=selected_venues,
+                    ranking=ranking,  # type: ignore[arg-type]
+                    fee_profile_overrides=_build_fee_profile_overrides(
+                        extended_fee_profile=extended_fee_profile,
+                        paradex_fee_profile=paradex_fee_profile,
+                        hyperliquid_fee_profile=hyperliquid_fee_profile,
+                    ),
+                    target_notional=target_notional,
+                    min_capacity_notional=min_capacity_notional,
+                    min_daily_volume=min_daily_volume,
+                    min_open_interest=min_open_interest,
+                    min_roundtrip_edge=min_roundtrip_edge,
+                    min_execution_quality_score=min_execution_quality_score,
+                    min_execution_samples=min_execution_samples,
+                    min_route_stability_weight=min_route_stability_weight,
+                    min_route_presence_ratio=min_route_presence_ratio,
+                    min_route_samples=min_route_samples,
+                    include_symbols=include_symbols,
+                    exclude_symbols=exclude_symbols,
+                    exclude_tags=exclude_tags,
+                    limit=max_positions * 5,
                 ),
-                target_notional=target_notional,
-                min_capacity_notional=min_capacity_notional,
-                min_daily_volume=min_daily_volume,
-                min_open_interest=min_open_interest,
-                min_roundtrip_edge=min_roundtrip_edge,
-                min_execution_quality_score=min_execution_quality_score,
-                min_execution_samples=min_execution_samples,
-                min_route_stability_weight=min_route_stability_weight,
-                min_route_presence_ratio=min_route_presence_ratio,
-                min_route_samples=min_route_samples,
-                include_symbols=include_symbols,
-                exclude_symbols=exclude_symbols,
-                exclude_tags=exclude_tags,
-                limit=max_positions * 5,
             )
             return build_portfolio_plan(
                 scan,

--- a/packages/runtime/src/carryme_runtime/universe.py
+++ b/packages/runtime/src/carryme_runtime/universe.py
@@ -6,6 +6,7 @@ import asyncio
 import itertools
 import math
 import random
+from collections.abc import Iterable
 from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Literal, Protocol
@@ -101,6 +102,16 @@ UNIVERSE_RANKINGS: tuple[UniverseRanking, ...] = (
     "route_adjusted_quality_pnl",
 )
 SHORTLIST_CAPPED_RANKINGS = frozenset({"roundtrip_edge", "entry_edge"})
+
+
+async def _cancel_pending_snapshot_tasks(
+    tasks: Iterable[asyncio.Task[NormalizedMarketSnapshot]],
+) -> None:
+    pending = [task for task in tasks if not task.done()]
+    for task in pending:
+        task.cancel()
+    if pending:
+        await asyncio.gather(*pending, return_exceptions=True)
 
 
 def _default_universe_fee_profiles() -> dict[str, str]:
@@ -566,17 +577,20 @@ class OpportunityUniverseService:
                 )
                 for venue, symbol in batch
             }
-            for key, task in tasks.items():
-                try:
-                    snapshots[key] = await task
-                except (
-                    ValueError,
-                    NormalizationError,
-                    UpstreamDataError,
-                    ConnectorError,
-                    httpx.HTTPError,
-                ):
-                    continue
+            try:
+                for key, task in tasks.items():
+                    try:
+                        snapshots[key] = await task
+                    except (
+                        ValueError,
+                        NormalizationError,
+                        UpstreamDataError,
+                        ConnectorError,
+                        httpx.HTTPError,
+                    ):
+                        continue
+            finally:
+                await _cancel_pending_snapshot_tasks(tasks.values())
         return snapshots
 
     async def _fetch_overlapping_snapshots(
@@ -606,11 +620,14 @@ class OpportunityUniverseService:
                 )
                 for venue, symbol in batch
             }
-            for key, task in tasks.items():
-                try:
-                    snapshots[key] = await task
-                except (ValueError, UpstreamDataError, ConnectorError, httpx.HTTPError):
-                    continue
+            try:
+                for key, task in tasks.items():
+                    try:
+                        snapshots[key] = await task
+                    except (ValueError, UpstreamDataError, ConnectorError, httpx.HTTPError):
+                        continue
+            finally:
+                await _cancel_pending_snapshot_tasks(tasks.values())
         return snapshots
 
     def _effective_snapshot_batch_size(self) -> int:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -809,6 +809,95 @@ def test_funding_universe_endpoint_passes_route_stability_filters() -> None:
     assert captured["min_route_samples"] == 4
 
 
+def test_bounded_universe_scan_times_out(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(app_module, "UNIVERSE_SCAN_TIMEOUT_SECONDS", 0.1)
+    monkeypatch.setattr(app_module, "_UNIVERSE_SCAN_SEMAPHORE", asyncio.Semaphore(1))
+
+    async def slow_scan() -> list[object]:
+        await asyncio.sleep(1)
+        return []
+
+    async def run() -> None:
+        with pytest.raises(HTTPException) as exc_info:
+            await app_module._run_bounded_universe_scan("test scan", slow_scan)
+        assert exc_info.value.status_code == 504
+        assert exc_info.value.detail == "test scan exceeded 0.1s timeout"
+        await asyncio.wait_for(app_module._UNIVERSE_SCAN_SEMAPHORE.acquire(), timeout=0.1)
+        app_module._UNIVERSE_SCAN_SEMAPHORE.release()
+
+    asyncio.run(run())
+
+
+def test_bounded_universe_scan_rejects_concurrent_calls(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    semaphore = asyncio.Semaphore(1)
+    monkeypatch.setattr(app_module, "_UNIVERSE_SCAN_SEMAPHORE", semaphore)
+    monkeypatch.setattr(app_module, "UNIVERSE_SCAN_ACQUIRE_TIMEOUT_SECONDS", 0.01)
+
+    async def fast_scan() -> list[object]:
+        return []
+
+    async def run() -> None:
+        await semaphore.acquire()
+        try:
+            with pytest.raises(HTTPException) as exc_info:
+                await app_module._run_bounded_universe_scan("test scan", fast_scan)
+        finally:
+            semaphore.release()
+        assert exc_info.value.status_code == 429
+        assert exc_info.value.detail == "test scan is already running; retry shortly"
+
+    asyncio.run(run())
+
+
+def test_approved_canary_basket_endpoint_uses_bounded_scan_guard(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    called = False
+
+    class StubUniverseService:
+        def resolve_fee_profiles(
+            self,
+            *,
+            venues: list[str],
+            fee_profile_overrides: dict[str, str] | None = None,
+        ) -> dict[str, str]:
+            return {
+                venue: (fee_profile_overrides or {}).get(venue, "default")
+                for venue in venues
+            }
+
+        async def scan_canary_candidates(
+            self, **_: object
+        ) -> list[FundingUniverseCanaryCandidate]:
+            nonlocal called
+            called = True
+            return []
+
+    monkeypatch.setattr(app_module, "_UNIVERSE_SCAN_SEMAPHORE", asyncio.Semaphore(0))
+    monkeypatch.setattr(app_module, "UNIVERSE_SCAN_ACQUIRE_TIMEOUT_SECONDS", 0.01)
+    app.dependency_overrides[get_opportunity_universe_service] = lambda: StubUniverseService()
+    app.dependency_overrides[get_route_approval_service] = lambda: object()
+    try:
+        client = TestClient(app)
+        response = client.get(
+            "/v1/opportunities/funding-universe/canary/approved-basket",
+            params=[
+                ("venues", "extended"),
+                ("venues", "paradex"),
+            ],
+        )
+    finally:
+        app.dependency_overrides.clear()
+
+    assert response.status_code == 429
+    assert response.json()["detail"] == (
+        "funding universe approved basket scan is already running; retry shortly"
+    )
+    assert called is False
+
+
 def test_funding_universe_canary_endpoint_uses_policy_defaults() -> None:
     captured: dict[str, object] = {}
 

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -298,6 +298,116 @@ def test_opportunity_universe_service_ranks_by_deployable_round_trip_pnl() -> No
     asyncio.run(run())
 
 
+def test_opportunity_universe_service_cancels_pending_market_stat_tasks() -> None:
+    symbol_lists = {
+        "extended": ["AAA-USD", "BBB-USD"],
+        "paradex": ["AAA-USD-PERP", "BBB-USD-PERP"],
+    }
+    started = 0
+    cancelled = 0
+    all_started: asyncio.Event | None = None
+
+    async def list_symbols(venue: str) -> list[str]:
+        return symbol_lists[venue]
+
+    async def fetch_market_stats(venue: str, symbol: str) -> MarketStats:
+        nonlocal started, cancelled
+        started += 1
+        if started == 4:
+            assert all_started is not None
+            all_started.set()
+        try:
+            await asyncio.sleep(60)
+        except asyncio.CancelledError:
+            cancelled += 1
+            raise
+        raise AssertionError(f"market stat task was not cancelled: {venue}:{symbol}")
+
+    async def fetch_snapshot(venue: str, symbol: str) -> NormalizedMarketSnapshot:
+        raise AssertionError(f"snapshot task should not start: {venue}:{symbol}")
+
+    async def run() -> None:
+        nonlocal all_started
+        all_started = asyncio.Event()
+        service = OpportunityUniverseService(
+            list_symbols=cast(Any, list_symbols),
+            fetch_market_stats=cast(Any, fetch_market_stats),
+            fetch_snapshot=cast(Any, fetch_snapshot),
+            snapshot_batch_size=4,
+            snapshot_retry_attempts=1,
+        )
+        task = asyncio.create_task(
+            service.scan(
+                venues=["extended", "paradex"],
+                ranking="roundtrip_edge",
+                limit=1,
+            )
+        )
+        await asyncio.wait_for(all_started.wait(), timeout=1)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+    async def run_and_assert() -> None:
+        await run()
+        assert cancelled == 4
+
+    asyncio.run(run_and_assert())
+
+
+def test_opportunity_universe_service_cancels_pending_snapshot_tasks() -> None:
+    symbol_lists = {
+        "extended": ["AAA-USD"],
+        "paradex": ["AAA-USD-PERP"],
+    }
+    started = 0
+    cancelled = 0
+    all_started: asyncio.Event | None = None
+
+    async def list_symbols(venue: str) -> list[str]:
+        return symbol_lists[venue]
+
+    async def fetch_snapshot(venue: str, symbol: str) -> NormalizedMarketSnapshot:
+        nonlocal started, cancelled
+        started += 1
+        if started == 2:
+            assert all_started is not None
+            all_started.set()
+        try:
+            await asyncio.sleep(60)
+        except asyncio.CancelledError:
+            cancelled += 1
+            raise
+        raise AssertionError(f"snapshot task was not cancelled: {venue}:{symbol}")
+
+    async def run() -> None:
+        nonlocal all_started
+        all_started = asyncio.Event()
+        service = OpportunityUniverseService(
+            list_symbols=cast(Any, list_symbols),
+            fetch_snapshot=cast(Any, fetch_snapshot),
+            snapshot_batch_size=2,
+            snapshot_retry_attempts=1,
+        )
+        task = asyncio.create_task(
+            service.scan(
+                venues=["extended", "paradex"],
+                ranking="roundtrip_edge",
+                limit=1,
+            )
+        )
+        await asyncio.wait_for(all_started.wait(), timeout=1)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+    async def run_and_assert() -> None:
+        await run()
+        assert cancelled == 2
+
+    asyncio.run(run_and_assert())
+
+
 def test_opportunity_universe_service_filters_thin_markets_for_quality_scan() -> None:
     symbol_lists = {
         "extended": ["MON-USD", "ZEN-USD", "LIT-USD"],


### PR DESCRIPTION
## Summary
- bound expensive live funding-universe API scans to one in-flight request at a time
- return fast 429 responses when another broad scan is already running
- return bounded 504 responses when a broad scan exceeds the API timeout instead of tying up the worker
- apply the guard to universe, canary, approval proposal, approved basket, paper-trade canary, and portfolio scan paths
- cancel pending market-stat and snapshot fetch tasks when a scan is cancelled or times out

## Root Cause
Broad funding-universe, canary, approved-basket, paper-trade canary, and portfolio scan endpoints can fan out live venue requests across many markets. If a caller waits until the public request times out or starts another scan concurrently, the API process can keep in-flight scan tasks alive and starve normal endpoints, which matches the production 502 behavior we saw while probing current opportunities.

## Safety
- Does not widen route approvals, live notional caps, cooldowns, or venue scope.
- Does not bypass live launch or execution-monitor guards.
- Fails closed for overloaded scan endpoints with 429/504 while preserving lightweight API availability.

## Validation
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run pytest -q tests/test_api.py -k 'bounded_universe_scan or approved_canary_basket_endpoint_uses_bounded_scan_guard or approved_canary_basket_endpoint_uses_service_dependency'`
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run pytest -q tests/test_api.py tests/test_runtime.py`
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run ruff check .`
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run mypy src apps packages tests`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added execution timeout and single-process concurrency guard for expensive universe scans; endpoints return 429 when concurrent scan rejected and 504 when execution times out.

* **Bug Fixes**
  * Ensured pending snapshot and market-stat fetch tasks are reliably canceled and drained on interruption.

* **Tests**
  * Added unit and integration tests covering bounded scan timeouts, concurrent-scan rejection, and task cancellation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->