### PR TITLE
fix: bound active execution readiness scans

### DIFF
--- a/apps/api/src/carryme_api/app.py
+++ b/apps/api/src/carryme_api/app.py
@@ -3258,12 +3258,12 @@ def _execution_requires_continued_monitoring(
         return False
     pair_status = latest.pair_status
     if pair_status is None:
-        for observation in observation_store.list_recent(limit=None, paper_trade_id=paper_trade_id):
-            if observation.pair_status is not None:
-                pair_status = observation.pair_status
-                break
-        else:
+        latest_with_pair_status = observation_store.latest_with_pair_status_for_paper_trade(
+            paper_trade_id
+        )
+        if latest_with_pair_status is None or latest_with_pair_status.pair_status is None:
             return True
+        pair_status = latest_with_pair_status.pair_status
     if (
         pair_status.derived_state == "review_required"
         and not review_required_pair_requires_continued_monitoring(pair_status)

--- a/apps/worker/src/carryme_worker/poller.py
+++ b/apps/worker/src/carryme_worker/poller.py
@@ -5338,12 +5338,12 @@ def _execution_requires_continued_monitoring(
         return unobserved_requires_monitoring
     pair_status = latest.pair_status
     if pair_status is None:
-        for observation in observation_store.list_recent(limit=None, paper_trade_id=paper_trade_id):
-            if observation.pair_status is not None:
-                pair_status = observation.pair_status
-                break
-        else:
+        latest_with_pair_status = observation_store.latest_with_pair_status_for_paper_trade(
+            paper_trade_id
+        )
+        if latest_with_pair_status is None or latest_with_pair_status.pair_status is None:
             return True
+        pair_status = latest_with_pair_status.pair_status
     if (
         pair_status.derived_state == "review_required"
         and not review_required_pair_requires_continued_monitoring(pair_status)

--- a/packages/storage/src/carryme_storage/execution_observations.py
+++ b/packages/storage/src/carryme_storage/execution_observations.py
@@ -128,6 +128,37 @@ class ExecutionObservationStore:
             }
         )
 
+    def latest_with_pair_status_for_paper_trade(
+        self,
+        paper_trade_id: int,
+    ) -> ExecutionObservationEntry | None:
+        """Return the newest observation with a concrete pair status for one paper trade."""
+
+        self.initialize()
+        with self.database.begin() as connection:
+            row = connection.execute(
+                """
+                SELECT id, entry_json
+                FROM execution_observation_entries
+                WHERE paper_trade_id = ?
+                  AND entry_json LIKE ?
+                  AND entry_json NOT LIKE ?
+                ORDER BY observed_at DESC, id DESC
+                LIMIT 1
+                """,
+                (paper_trade_id, '%"pair_status":%', '%"pair_status":null%'),
+            ).fetchone()
+
+        if row is None:
+            return None
+        stored_id, entry_json = row
+        return ExecutionObservationEntry.model_validate(
+            {
+                **json.loads(entry_json),
+                "entry_id": stored_id,
+            }
+        )
+
     def list_recent(
         self,
         *,

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -2533,6 +2533,71 @@ def test_execution_observation_store_filters_by_paper_trade_id(tmp_path: Path) -
     assert latest_for_trade.entry_id == latest.entry_id
 
 
+def test_execution_observation_store_latest_with_pair_status_for_paper_trade(
+    tmp_path: Path,
+) -> None:
+    store = ExecutionObservationStore(tmp_path / "history.sqlite3")
+    order_state = ExecutionOrderState(
+        execution_entry_id=12,
+        paper_trade_id=7,
+        preview_hash="preview-hash-7",
+        legs=[],
+        notes=[],
+    )
+    reconciliation = ExecutionReconciliation(
+        execution_entry_id=12,
+        paper_trade_id=7,
+        preview_hash="preview-hash-7",
+        status="submitted",
+        recommended_action="monitor_open_hedge",
+        matched_all_leg_symbols=True,
+        venues=[],
+        notes=[],
+    )
+    older_with_status = store.append(
+        ExecutionObservationEntry(
+            observed_at=datetime(2026, 3, 29, 13, 6, tzinfo=UTC),
+            context="with-pair-status",
+            execution_entry_id=12,
+            paper_trade_id=7,
+            preview_hash="preview-hash-7",
+            order_state=order_state,
+            pair_status=ExecutionPairStatus(
+                execution_entry_id=12,
+                paper_trade_id=7,
+                preview_hash="preview-hash-7",
+                derived_state="hedged",
+                recommended_action="monitor_open_hedge",
+                order_state=order_state,
+                reconciliation=reconciliation,
+                notes=[],
+            ),
+        )
+    )
+    latest_without_status = store.append(
+        ExecutionObservationEntry(
+            observed_at=datetime(2026, 3, 29, 13, 7, tzinfo=UTC),
+            context="without-pair-status",
+            execution_entry_id=12,
+            paper_trade_id=7,
+            preview_hash="preview-hash-7",
+            order_state=order_state,
+        )
+    )
+
+    latest = store.latest_for_paper_trade(7)
+    latest_with_pair_status = store.latest_with_pair_status_for_paper_trade(7)
+
+    assert latest is not None
+    assert latest.entry_id == latest_without_status.entry_id
+    assert latest.pair_status is None
+    assert latest_with_pair_status is not None
+    assert latest_with_pair_status.entry_id == older_with_status.entry_id
+    assert latest_with_pair_status.pair_status is not None
+    assert latest_with_pair_status.pair_status.derived_state == "hedged"
+    assert store.latest_with_pair_status_for_paper_trade(8) is None
+
+
 def test_execution_observation_store_orders_ties_deterministically(tmp_path: Path) -> None:
     store = ExecutionObservationStore(tmp_path / "history.sqlite3")
     observed_at = datetime(2026, 3, 29, 13, 6, tzinfo=UTC)

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -2574,6 +2574,26 @@ def test_execution_observation_store_latest_with_pair_status_for_paper_trade(
             ),
         )
     )
+    same_time_with_status = store.append(
+        ExecutionObservationEntry(
+            observed_at=datetime(2026, 3, 29, 13, 6, tzinfo=UTC),
+            context="same-time-with-pair-status",
+            execution_entry_id=12,
+            paper_trade_id=7,
+            preview_hash="preview-hash-7",
+            order_state=order_state,
+            pair_status=ExecutionPairStatus(
+                execution_entry_id=12,
+                paper_trade_id=7,
+                preview_hash="preview-hash-7",
+                derived_state="hedged",
+                recommended_action="monitor_open_hedge",
+                order_state=order_state,
+                reconciliation=reconciliation,
+                notes=[],
+            ),
+        )
+    )
     latest_without_status = store.append(
         ExecutionObservationEntry(
             observed_at=datetime(2026, 3, 29, 13, 7, tzinfo=UTC),
@@ -2592,7 +2612,10 @@ def test_execution_observation_store_latest_with_pair_status_for_paper_trade(
     assert latest.entry_id == latest_without_status.entry_id
     assert latest.pair_status is None
     assert latest_with_pair_status is not None
-    assert latest_with_pair_status.entry_id == older_with_status.entry_id
+    assert older_with_status.entry_id is not None
+    assert same_time_with_status.entry_id is not None
+    assert same_time_with_status.entry_id > older_with_status.entry_id
+    assert latest_with_pair_status.entry_id == same_time_with_status.entry_id
     assert latest_with_pair_status.pair_status is not None
     assert latest_with_pair_status.pair_status.derived_state == "hedged"
     assert store.latest_with_pair_status_for_paper_trade(8) is None


### PR DESCRIPTION
## Summary
- add a bounded latest-with-pair-status lookup for execution observations
- stop API readiness and stable launch from fetching every historical observation for old live trades
- keep fail-closed behavior when pair status is unknown or missing

## Root cause
Old live executions can have a latest observation with `pair_status=None`. The readiness/stable-launch active-execution guard then scanned every observation for that paper trade with `list_recent(limit=None, ...)`, which can make Render readiness checks and stable-launch cycles slow or fail with DB connection errors.

## Safety
- does not remove any live-money guard
- does not widen notional caps, cooldowns, route approvals, or venue scope
- unknown/missing pair status still requires continued monitoring

## Validation
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run pytest -q tests/test_storage.py -k 'latest_with_pair_status_for_paper_trade or execution_observation_store_filters_by_paper_trade_id'`
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run pytest -q tests/test_worker.py -k 'execution_requires_continued_monitoring'`
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run pytest -q tests/test_api.py -k 'production_automation_readiness_endpoint_counts_beyond_scan_window or production_automation_readiness_endpoint_blocks_active_live_execution'`
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run pytest -q tests/test_storage.py tests/test_worker.py tests/test_api.py`
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run ruff check .`
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run mypy src apps packages tests`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized execution monitoring for paper trades by improving how the system looks up and tracks observations with status information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->