### PR TITLE
fix: filter active live execution scans in storage

### DIFF
--- a/apps/api/src/carryme_api/app.py
+++ b/apps/api/src/carryme_api/app.py
@@ -3251,14 +3251,12 @@ def _list_recent_live_executions_for_automation_readiness(
     selected: list[ExecutionJournalEntry] = []
 
     while len(selected) < limit:
-        batch = execution_store.list_recent(limit=page_size, offset=offset)
+        batch = execution_store.list_recent_active_live(limit=page_size, offset=offset)
         if not batch:
             break
         offset += len(batch)
 
         for execution in batch:
-            if execution.mode != "live" or execution.status not in {"submitted", "partial"}:
-                continue
             age_seconds = (now - execution.executed_at).total_seconds()
             if age_seconds > max_age_seconds and not _execution_requires_continued_monitoring(
                 observation_store,

--- a/apps/worker/src/carryme_worker/poller.py
+++ b/apps/worker/src/carryme_worker/poller.py
@@ -5291,14 +5291,12 @@ def _list_recent_live_executions(
     selected: list[ExecutionJournalEntry] = []
 
     while len(selected) < limit:
-        batch = journal_store.list_recent(limit=page_size, offset=offset)
+        batch = journal_store.list_recent_active_live(limit=page_size, offset=offset)
         if not batch:
             break
         offset += len(batch)
 
         for execution in batch:
-            if execution.mode != "live" or execution.status not in {"submitted", "partial"}:
-                continue
             age_seconds = max(0.0, (now - execution.executed_at).total_seconds())
             if age_seconds > max_age_seconds and not _execution_requires_continued_monitoring(
                 observation_store,

--- a/packages/storage/src/carryme_storage/executions.py
+++ b/packages/storage/src/carryme_storage/executions.py
@@ -89,6 +89,12 @@ class ExecutionJournalStore:
                 )
                 connection.execute(
                     """
+                    CREATE INDEX IF NOT EXISTS idx_execution_journal_entries_active_live
+                    ON execution_journal_entries(status, executed_at DESC, id DESC)
+                    """
+                )
+                connection.execute(
+                    """
                     CREATE INDEX IF NOT EXISTS idx_execution_journal_entries_label
                     ON execution_journal_entries(label)
                     """
@@ -777,6 +783,41 @@ class ExecutionJournalStore:
 
         with self.database.begin() as connection:
             rows = connection.execute(query, params).fetchall()
+
+        return [
+            ExecutionJournalEntry.model_validate(
+                {
+                    **json.loads(entry_json),
+                    "entry_id": stored_id,
+                }
+            )
+            for stored_id, entry_json in rows
+        ]
+
+    def list_recent_active_live(
+        self,
+        *,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> list[ExecutionJournalEntry]:
+        """Return recent live executions that still have an in-flight status."""
+
+        if limit < 1:
+            raise ValueError("limit must be at least 1")
+        if offset < 0:
+            raise ValueError("offset must be at least 0")
+        self.initialize()
+        with self.database.begin() as connection:
+            rows = connection.execute(
+                """
+                SELECT id, entry_json
+                FROM execution_journal_entries
+                WHERE status IN (?, ?) AND entry_json LIKE ?
+                ORDER BY executed_at DESC, id DESC
+                LIMIT ? OFFSET ?
+                """,
+                ("submitted", "partial", '%"mode":"live"%', limit, offset),
+            ).fetchall()
 
         return [
             ExecutionJournalEntry.model_validate(

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -2499,6 +2499,18 @@ def test_production_automation_readiness_endpoint_counts_beyond_scan_window(
     tmp_path: Path,
 ) -> None:
     database_path = tmp_path / "readiness-scan-window.sqlite3"
+
+    class ActiveLiveOnlyExecutionJournalStore(ExecutionJournalStore):
+        def list_recent(
+            self,
+            *,
+            limit: int = 50,
+            label: str | None = None,
+            offset: int = 0,
+        ) -> list[ExecutionJournalEntry]:
+            del limit, label, offset
+            raise AssertionError("automation readiness must not scan the full journal")
+
     approved_store = ApprovedCanaryStore(database_path)
     launch_ready_store = LaunchReadyCanaryStore(database_path)
     stable_launch_store = StableCanaryLaunchStore(database_path)
@@ -2617,7 +2629,9 @@ def test_production_automation_readiness_endpoint_counts_beyond_scan_window(
     app.dependency_overrides[get_approved_canary_store] = lambda: approved_store
     app.dependency_overrides[get_launch_ready_canary_store] = lambda: launch_ready_store
     app.dependency_overrides[get_stable_canary_launch_store] = lambda: stable_launch_store
-    app.dependency_overrides[get_execution_journal_store] = lambda: execution_store
+    app.dependency_overrides[get_execution_journal_store] = (
+        lambda: ActiveLiveOnlyExecutionJournalStore(database_path)
+    )
     app.dependency_overrides[get_execution_observation_store] = lambda: observation_store
     app.dependency_overrides[get_automation_readiness_checked_at] = (
         lambda: datetime(2026, 3, 29, 16, 1, 10, tzinfo=UTC)

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -787,6 +787,152 @@ def test_execution_journal_store_lists_latest_for_multiple_paper_trades(
     assert latest_entries[7].entry_id != older_trade_7.entry_id
 
 
+def test_execution_journal_store_lists_recent_active_live_from_legacy_rows(
+    tmp_path: Path,
+) -> None:
+    database_path = tmp_path / "history.sqlite3"
+
+    def make_entry(
+        *,
+        paper_trade_id: int,
+        minute: int,
+        mode: Literal["live", "mock"],
+        status: Literal["accepted", "submitted", "partial"],
+    ) -> ExecutionJournalEntry:
+        leg_status: Literal["accepted", "submitted"] = (
+            "submitted" if status == "partial" else status
+        )
+        return ExecutionJournalEntry(
+            executed_at=datetime(2026, 3, 29, 13, minute, tzinfo=UTC),
+            adapter="paired_live:extended_then_paradex" if mode == "live" else "mock",
+            mode=mode,
+            status=status,
+            paper_trade_id=paper_trade_id,
+            preview_hash=f"preview-{paper_trade_id}",
+            confirmation_entry_id=paper_trade_id + 100,
+            paper_trade=PaperTradeEntry(
+                entry_id=paper_trade_id,
+                created_at=datetime(2026, 3, 29, 13, 0, tzinfo=UTC),
+                note="active live lookup test",
+                intent=FundingPairTradeIntent(
+                    label=f"pair_{paper_trade_id}",
+                    canonical_symbol="ARB-USD-PERP",
+                    source_recorded_at=datetime(2026, 3, 29, 12, 55, tzinfo=UTC),
+                    one_day_net_edge_after_entry=0.00055,
+                    break_even_days_entry=0.45,
+                    capacity_limit_notional=4500.0,
+                    target_notional=1000.0,
+                    capacity_fraction=0.25,
+                    max_target_notional=1000.0,
+                    long_leg=TradeLegIntent(
+                        venue="paradex",
+                        symbol="ARB-USD-PERP",
+                        fee_profile="pro",
+                        side="buy",
+                        target_notional=1000.0,
+                    ),
+                    short_leg=TradeLegIntent(
+                        venue="extended",
+                        symbol="ARB-USD",
+                        fee_profile="default",
+                        side="sell",
+                        target_notional=1000.0,
+                    ),
+                ),
+            ),
+            legs=[
+                ExecutionLegResult(
+                    venue="extended",
+                    symbol="ARB-USD",
+                    fee_profile="default",
+                    side="sell",
+                    target_notional=1000.0,
+                    status=leg_status,
+                    simulated=mode != "live",
+                )
+            ],
+        )
+
+    live_submitted = make_entry(
+        paper_trade_id=7,
+        minute=5,
+        mode="live",
+        status="submitted",
+    )
+    live_partial = make_entry(
+        paper_trade_id=8,
+        minute=6,
+        mode="live",
+        status="partial",
+    )
+    live_accepted = make_entry(
+        paper_trade_id=9,
+        minute=7,
+        mode="live",
+        status="accepted",
+    )
+    mock_submitted = make_entry(
+        paper_trade_id=10,
+        minute=8,
+        mode="mock",
+        status="submitted",
+    )
+
+    with Database(database_path).begin() as connection:
+        connection.execute(
+            """
+            CREATE TABLE execution_journal_entries (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                executed_at TEXT NOT NULL,
+                adapter TEXT NOT NULL,
+                status TEXT NOT NULL,
+                paper_trade_id INTEGER,
+                preview_hash TEXT,
+                confirmation_entry_id INTEGER,
+                label TEXT NOT NULL,
+                entry_json TEXT NOT NULL
+            )
+            """
+        )
+        for entry in (live_submitted, live_partial, live_accepted, mock_submitted):
+            connection.execute(
+                """
+                INSERT INTO execution_journal_entries (
+                    executed_at,
+                    adapter,
+                    status,
+                    paper_trade_id,
+                    preview_hash,
+                    confirmation_entry_id,
+                    label,
+                    entry_json
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    entry.executed_at.isoformat(),
+                    entry.adapter,
+                    entry.status,
+                    entry.paper_trade_id,
+                    entry.preview_hash,
+                    entry.confirmation_entry_id,
+                    entry.paper_trade.intent.label,
+                    entry.model_dump_json(),
+                ),
+            )
+
+    store = ExecutionJournalStore(database_path)
+    results = store.list_recent_active_live(limit=10)
+    offset_results = store.list_recent_active_live(limit=1, offset=1)
+
+    assert [(entry.paper_trade_id, entry.status) for entry in results] == [
+        (8, "partial"),
+        (7, "submitted"),
+    ]
+    assert [(entry.paper_trade_id, entry.status) for entry in offset_results] == [
+        (7, "submitted")
+    ]
+
+
 def test_execution_journal_store_allows_same_confirmation_id_for_different_hashes(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -7852,6 +7852,17 @@ def test_launch_latest_stable_canary_once_counts_beyond_active_execution_scan_li
         )
 
     with pytest.MonkeyPatch.context() as monkeypatch:
+        def reject_full_journal_scan(
+            self: ExecutionJournalStore,
+            *,
+            limit: int = 50,
+            label: str | None = None,
+            offset: int = 0,
+        ) -> list[ExecutionJournalEntry]:
+            del self, limit, label, offset
+            raise AssertionError("stable launch must not scan the full journal")
+
+        monkeypatch.setattr(ExecutionJournalStore, "list_recent", reject_full_journal_scan)
         monkeypatch.setattr(
             "carryme_worker.poller._build_launch_ready_canary_stability",
             lambda **_: (_ for _ in ()).throw(


### PR DESCRIPTION
## Summary
- add a storage-level active-live execution lookup for submitted/partial live rows
- stop API automation readiness and stable-launch from paging the full execution journal
- avoid schema-column migrations so concurrent Render deploys do not race on `ALTER TABLE`

## Root cause
After #240, `/v1/automation/readiness` and stable launch could still time out because they paged through the entire execution journal looking for live submitted/partial executions. In production, most journal rows are old or closed, so finding no active rows can still be expensive.

## Safety
- does not remove live-money guards
- does not widen notional caps, cooldowns, route approvals, or venue scope
- active live executions still block unattended launch when their latest observation requires monitoring
- uses existing `status` column plus compact JSON `mode` filtering, with a status/time index, to avoid a deploy-time column migration race

## Validation
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run pytest -q tests/test_storage.py -k 'recent_active_live or appends_and_lists_recent or lists_latest_for_multiple_paper_trades'`
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run pytest -q tests/test_api.py -k 'production_automation_readiness_endpoint_counts_beyond_scan_window or production_automation_readiness_endpoint_reports_stable_launch_ready'`
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run pytest -q tests/test_worker.py -k 'launch_latest_stable_canary_once_counts_beyond_active_execution_scan_limit or launch_latest_stable_canary_once_skips_when_risk_budget_scan_truncates'`
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run pytest -q tests/test_storage.py tests/test_api.py tests/test_worker.py`
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run ruff check .`
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run mypy src apps packages tests`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for active live execution filtering with legacy database rows.
  * Enhanced execution readiness and worker polling tests to verify optimized query paths.

* **Chores**
  * Optimized active live execution lookups through improved data retrieval methods, reducing unnecessary filtering overhead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->