### PR TITLE
fix: index latest execution observation lookups

### DIFF
--- a/packages/storage/src/carryme_storage/execution_observations.py
+++ b/packages/storage/src/carryme_storage/execution_observations.py
@@ -64,6 +64,12 @@ class ExecutionObservationStore:
             )
             connection.execute(
                 """
+                CREATE INDEX IF NOT EXISTS idx_execution_observation_entries_paper_trade_latest
+                ON execution_observation_entries(paper_trade_id, observed_at DESC, id DESC)
+                """
+            )
+            connection.execute(
+                """
                 CREATE INDEX IF NOT EXISTS idx_execution_observation_entries_preview_hash
                 ON execution_observation_entries(preview_hash)
                 """

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -2679,6 +2679,31 @@ def test_execution_observation_store_filters_by_paper_trade_id(tmp_path: Path) -
     assert latest_for_trade.entry_id == latest.entry_id
 
 
+def test_execution_observation_store_initializes_latest_lookup_index(
+    tmp_path: Path,
+) -> None:
+    store = ExecutionObservationStore(tmp_path / "history.sqlite3")
+
+    store.initialize()
+
+    with store.database.begin() as connection:
+        rows = connection.execute(
+            """
+            SELECT name
+            FROM sqlite_master
+            WHERE type = ? AND name = ?
+            """,
+            (
+                "index",
+                "idx_execution_observation_entries_paper_trade_latest",
+            ),
+        ).fetchall()
+
+    assert [str(row[0]) for row in rows] == [
+        "idx_execution_observation_entries_paper_trade_latest"
+    ]
+
+
 def test_execution_observation_store_latest_with_pair_status_for_paper_trade(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary
- add a composite index for latest observation lookups by paper trade
- cover the index initialization path in storage tests
- keep API and worker behavior unchanged while removing the production sort pressure behind readiness/stable-launch checks

## Root cause
Production still has old live/submitted execution journal rows whose latest observations resolve to closed/no-action. Automation readiness and stable launch need the latest observation for each candidate paper trade. The observation table only indexed `paper_trade_id`, so each latest lookup could sort a long observation history by `observed_at DESC, id DESC`.

## Safety
- no live-money guard changes
- no notional, cooldown, approval, or venue-scope changes
- this only adds an idempotent index used by existing latest-observation queries

## Validation
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run pytest -q tests/test_storage.py -k 'latest_lookup_index or latest_with_pair_status_for_paper_trade or filters_by_paper_trade_id'`
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run pytest -q tests/test_storage.py tests/test_api.py tests/test_worker.py`
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run ruff check .`
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run mypy src apps packages tests`
- `git diff --check`
