### PR TITLE
fix: use current execution quality for stable launch

### DIFF
--- a/apps/worker/src/carryme_worker/poller.py
+++ b/apps/worker/src/carryme_worker/poller.py
@@ -88,6 +88,7 @@ from carryme_runtime import (
 )
 from carryme_runtime.balance_accounting import FUNDING_WINDOW_CHECKPOINT_STAGE
 from carryme_runtime.execution_order_state import ExecutionLegOrderObserver
+from carryme_runtime.execution_quality import execution_quality_route_key
 from carryme_runtime.route_approvals import (
     scan_exact_canary_candidate_for_approval,
     scan_live_route_candidate_for_approval,
@@ -846,7 +847,7 @@ def _with_current_execution_quality(
 
     opportunity = candidate.opportunity.opportunity
     current_quality = execution_quality_index.get(
-        (
+        execution_quality_route_key(
             opportunity.canonical_symbol,
             opportunity.short_venue,
             opportunity.long_venue,
@@ -3083,10 +3084,13 @@ async def launch_latest_stable_canary_once(
     observation_store = ExecutionObservationStore(runtime_settings.database_path)
     execution_quality_index: dict[tuple[str, str, str], ExecutionQualitySummary] = {}
     if _stable_launch_needs_current_execution_quality(settings):
-        execution_quality_index = ExecutionQualityService(
+        execution_quality_service = ExecutionQualityService(
             journal_store=execution_store,
             observation_store=observation_store,
-        ).build_index()
+        )
+        execution_quality_index = await asyncio.to_thread(
+            execution_quality_service.build_index
+        )
     balance_service = BalanceAccountingService(
         store=BalanceSnapshotStore(runtime_settings.database_path)
     )

--- a/apps/worker/src/carryme_worker/poller.py
+++ b/apps/worker/src/carryme_worker/poller.py
@@ -39,6 +39,7 @@ from carryme_models import (
     ExecutionJournalEntry,
     ExecutionObservationEntry,
     ExecutionPairStatus,
+    ExecutionQualitySummary,
     FundingArbOpportunity,
     FundingUniverseCanaryCandidate,
     FundingUniverseScan,
@@ -824,6 +825,42 @@ def _build_stable_launch_execution_maturity_reason(
         )
 
     return None
+
+
+def _stable_launch_needs_current_execution_quality(settings: WorkerSettings) -> bool:
+    """Return whether launch guards need current execution-quality history."""
+
+    return (
+        settings.stable_canary_launch_min_execution_quality_score is not None
+        or settings.stable_canary_launch_min_execution_samples is not None
+        or settings.stable_canary_launch_block_adverse_latest_outcome
+    )
+
+
+def _with_current_execution_quality(
+    *,
+    candidate: FundingUniverseCanaryCandidate,
+    execution_quality_index: dict[tuple[str, str, str], ExecutionQualitySummary],
+) -> FundingUniverseCanaryCandidate:
+    """Overlay latest observed route quality onto a candidate before launch guards run."""
+
+    opportunity = candidate.opportunity.opportunity
+    current_quality = execution_quality_index.get(
+        (
+            opportunity.canonical_symbol,
+            opportunity.short_venue,
+            opportunity.long_venue,
+        )
+    )
+    if current_quality is None:
+        return candidate
+    return candidate.model_copy(
+        update={
+            "opportunity": candidate.opportunity.model_copy(
+                update={"execution_quality": current_quality}
+            )
+        }
+    )
 
 
 def _build_stable_launch_latest_outcome_reason(
@@ -3044,6 +3081,12 @@ async def launch_latest_stable_canary_once(
     source_approved_store = approved_store or ApprovedCanaryStore(runtime_settings.database_path)
     execution_store = ExecutionJournalStore(runtime_settings.database_path)
     observation_store = ExecutionObservationStore(runtime_settings.database_path)
+    execution_quality_index: dict[tuple[str, str, str], ExecutionQualitySummary] = {}
+    if _stable_launch_needs_current_execution_quality(settings):
+        execution_quality_index = ExecutionQualityService(
+            journal_store=execution_store,
+            observation_store=observation_store,
+        ).build_index()
     balance_service = BalanceAccountingService(
         store=BalanceSnapshotStore(runtime_settings.database_path)
     )
@@ -3326,9 +3369,14 @@ async def launch_latest_stable_canary_once(
             )
             continue
 
+        guard_candidate = _with_current_execution_quality(
+            candidate=candidate_selected,
+            execution_quality_index=execution_quality_index,
+        )
+
         execution_maturity_reason = _build_stable_launch_execution_maturity_reason(
             settings=settings,
-            candidate=latest_approved_snapshot.candidate,
+            candidate=guard_candidate,
         )
         if execution_maturity_reason is not None:
             if settings.stable_canary_launch_shadow_mode:
@@ -3349,7 +3397,7 @@ async def launch_latest_stable_canary_once(
 
         latest_outcome_reason = _build_stable_launch_latest_outcome_reason(
             settings=settings,
-            candidate=latest_approved_snapshot.candidate,
+            candidate=guard_candidate,
         )
         if latest_outcome_reason is not None:
             if settings.stable_canary_launch_shadow_mode:

--- a/packages/runtime/src/carryme_runtime/execution_quality.py
+++ b/packages/runtime/src/carryme_runtime/execution_quality.py
@@ -34,6 +34,20 @@ _Outcome = Literal[
 ]
 
 
+def execution_quality_route_key(
+    canonical_symbol: str,
+    short_venue: str,
+    long_venue: str,
+) -> tuple[str, str, str]:
+    """Return the normalized key used for execution-quality route buckets."""
+
+    return (
+        canonical_symbol.strip().upper(),
+        short_venue.strip().lower(),
+        long_venue.strip().lower(),
+    )
+
+
 @dataclass
 class _ExecutionQualityBucket:
     sample_size: int = 0
@@ -93,11 +107,13 @@ class ExecutionQualityService:
             entry = entries_by_paper_trade.get(paper_trade_id)
             if entry is None:
                 continue
+            if entry.mode != "live":
+                continue
             pair_status = observation.pair_status
             if pair_status is None:
                 continue
             intent = entry.paper_trade.intent
-            key = (
+            key = execution_quality_route_key(
                 intent.canonical_symbol,
                 intent.short_leg.venue,
                 intent.long_leg.venue,

--- a/packages/runtime/src/carryme_runtime/route_approvals.py
+++ b/packages/runtime/src/carryme_runtime/route_approvals.py
@@ -349,7 +349,9 @@ async def scan_exact_canary_candidate_for_approval(
         exclude_symbols=exclude_symbols,
         exclude_tags=exclude_tags,
         limit=max(1, limit),
-        use_execution_quality=False,
+        use_execution_quality=(
+            min_execution_quality_score > 0.0 or min_execution_samples > 0
+        ),
         use_route_stability=False,
     )
 

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -3779,6 +3779,59 @@ def test_scan_exact_canary_candidate_for_approval_skips_route_stability_index(
     assert captured["use_route_stability"] is False
 
 
+def test_scan_exact_canary_candidate_for_approval_keeps_execution_quality_when_required(
+    tmp_path: Path,
+) -> None:
+    approval = RouteApprovalEntry(
+        updated_at=datetime(2026, 4, 4, 10, 0, tzinfo=UTC),
+        label="near_extended_paradex",
+        canonical_symbol="NEAR-USD-PERP",
+        short_venue="extended",
+        long_venue="paradex",
+        short_fee_profile="default",
+        long_fee_profile="pro_fastfills",
+        approved=True,
+        max_live_notional=25.0,
+        note="approved canary",
+    )
+    captured: dict[str, object] = {}
+
+    class StubScanner:
+        async def scan_canary_candidates(self, **kwargs: object) -> list[object]:
+            captured.update(kwargs)
+            return []
+
+    async def run() -> None:
+        await scan_exact_canary_candidate_for_approval(
+            scanner=cast(Any, StubScanner()),
+            approval_service=RouteApprovalService(
+                store=RouteApprovalStore(tmp_path / "approvals.sqlite3")
+            ),
+            approval=approval,
+            venues=["extended", "paradex"],
+            target_notional=5_000.0,
+            canary_max_notional=25.0,
+            min_capacity_notional=0.0,
+            min_daily_volume=0.0,
+            min_open_interest=0.0,
+            min_roundtrip_edge=0.0,
+            min_execution_quality_score=0.7,
+            min_execution_samples=0,
+            min_route_stability_weight=0.0,
+            min_route_presence_ratio=0.0,
+            min_route_samples=0,
+            include_symbols=None,
+            exclude_symbols=None,
+            exclude_tags=None,
+            limit=5,
+        )
+
+    asyncio.run(run())
+
+    assert captured["use_execution_quality"] is True
+    assert captured["use_route_stability"] is False
+
+
 def test_scan_live_route_candidate_for_approval_returns_negative_edge_route() -> None:
     approval = RouteApprovalEntry(
         updated_at=datetime(2026, 4, 4, 10, 0, tzinfo=UTC),

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -1954,6 +1954,141 @@ def test_execution_quality_service_summarizes_latest_outcomes(tmp_path: Path) ->
     assert summary.weighted_score == pytest.approx(0.6)
 
 
+def test_execution_quality_service_ignores_mock_and_normalizes_route_keys(
+    tmp_path: Path,
+) -> None:
+    journal_store = ExecutionJournalStore(tmp_path / "quality-normalized.sqlite3")
+    observation_store = ExecutionObservationStore(tmp_path / "quality-normalized.sqlite3")
+
+    def paper_trade(
+        paper_trade_id: int,
+        *,
+        canonical_symbol: str,
+        short_venue: str,
+        long_venue: str,
+    ) -> PaperTradeEntry:
+        return PaperTradeEntry(
+            entry_id=paper_trade_id,
+            created_at=datetime(2026, 3, 29, 12, 0, tzinfo=UTC),
+            intent=FundingPairTradeIntent(
+                label=f"arb_{paper_trade_id}",
+                canonical_symbol=canonical_symbol,
+                source_recorded_at=datetime(2026, 3, 29, 11, 59, tzinfo=UTC),
+                one_day_net_edge_after_entry=0.001,
+                break_even_days_entry=0.2,
+                capacity_limit_notional=500.0,
+                target_notional=11.0,
+                capacity_fraction=0.1,
+                max_target_notional=100.0,
+                long_leg=TradeLegIntent(
+                    venue=long_venue,
+                    symbol="ARB-USD-PERP",
+                    fee_profile="pro",
+                    side="buy",
+                    target_notional=11.0,
+                ),
+                short_leg=TradeLegIntent(
+                    venue=short_venue,
+                    symbol="ARB-USD",
+                    fee_profile="default",
+                    side="sell",
+                    target_notional=11.0,
+                ),
+            ),
+        )
+
+    for paper_trade_id, mode, outcome in [
+        (1, "mock", "hedged"),
+        (2, "live", "closed"),
+    ]:
+        execution = journal_store.append(
+            ExecutionJournalEntry(
+                executed_at=datetime(2026, 3, 29, 12, paper_trade_id, tzinfo=UTC),
+                adapter="paired_live:test",
+                mode=cast(Literal["mock", "live"], mode),
+                status="submitted",
+                paper_trade_id=paper_trade_id,
+                preview_hash=f"hash-{paper_trade_id}",
+                confirmation_entry_id=paper_trade_id,
+                paper_trade=paper_trade(
+                    paper_trade_id,
+                    canonical_symbol=" arb-usd-perp ",
+                    short_venue=" Extended ",
+                    long_venue=" Paradex ",
+                ),
+                legs=[
+                    ExecutionLegResult(
+                        venue="extended",
+                        symbol="ARB-USD",
+                        fee_profile="default",
+                        side="sell",
+                        target_notional=11.0,
+                        status="submitted",
+                        simulated=(mode != "live"),
+                    )
+                ],
+            )
+        )
+        order_state = ExecutionOrderState(
+            execution_entry_id=execution.entry_id,
+            paper_trade_id=paper_trade_id,
+            preview_hash=execution.preview_hash,
+            legs=[],
+            notes=[],
+        )
+        observation_store.append(
+            ExecutionObservationEntry(
+                observed_at=datetime(2026, 3, 29, 12, 10 + paper_trade_id, tzinfo=UTC),
+                context="guarded_pair_poll",
+                execution_entry_id=execution.entry_id,
+                paper_trade_id=paper_trade_id,
+                preview_hash=execution.preview_hash,
+                order_state=order_state,
+                pair_status=ExecutionPairStatus(
+                    execution_entry_id=execution.entry_id,
+                    paper_trade_id=paper_trade_id,
+                    preview_hash=execution.preview_hash,
+                    derived_state=cast(
+                        Literal[
+                            "hedged",
+                            "pending",
+                            "unfilled",
+                            "closed",
+                            "cleanup_needed",
+                            "review_required",
+                        ],
+                        outcome,
+                    ),
+                    recommended_action="no_action",
+                    order_state=order_state,
+                    reconciliation=ExecutionReconciliation(
+                        execution_entry_id=execution.entry_id,
+                        paper_trade_id=paper_trade_id,
+                        preview_hash=execution.preview_hash,
+                        status="submitted",
+                        recommended_action="observe",
+                        matched_all_leg_symbols=True,
+                        venues=[],
+                        notes=[],
+                    ),
+                    notes=[],
+                ),
+            )
+        )
+
+    index = ExecutionQualityService(
+        journal_store=journal_store,
+        observation_store=observation_store,
+    ).build_index()
+
+    assert set(index) == {("ARB-USD-PERP", "extended", "paradex")}
+    summary = index[("ARB-USD-PERP", "extended", "paradex")]
+    assert summary.sample_size == 1
+    assert summary.latest_outcome == "closed"
+    assert summary.closed_count == 1
+    assert summary.hedged_count == 0
+
+
 def test_execution_quality_service_caps_after_latest_per_trade(tmp_path: Path) -> None:
     journal_store = ExecutionJournalStore(tmp_path / "quality-window.sqlite3")
     observation_store = ExecutionObservationStore(tmp_path / "quality-window.sqlite3")

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -129,6 +129,7 @@ from carryme_worker.poller import (
     _list_ranked_stable_launch_ready_stabilities,
     _maybe_auto_close_open_hedged_execution,
     _probe_candidate_system_state,
+    _with_current_execution_quality,
     cache_launch_ready_canaries_once,
     install_signal_handlers,
     launch_latest_stable_canary_once,
@@ -7243,6 +7244,43 @@ def test_launch_latest_stable_canary_once_allows_launch_when_execution_maturity_
     assert summary.status == "launched"
 
 
+def test_stable_launch_current_execution_quality_lookup_normalizes_route_key() -> None:
+    _approval, candidate, _snapshot, _stability = _build_stable_launch_test_snapshot(
+        label="arb_extended_paradex",
+        execution_quality=None,
+    )
+    raw_opportunity = candidate.opportunity.opportunity.model_copy(
+        update={
+            "canonical_symbol": " arb-usd-perp ",
+            "short_venue": " Extended ",
+            "long_venue": " Paradex ",
+        }
+    )
+    candidate = candidate.model_copy(
+        update={
+            "opportunity": candidate.opportunity.model_copy(
+                update={"opportunity": raw_opportunity}
+            )
+        }
+    )
+    quality = ExecutionQualitySummary(
+        canonical_symbol="ARB-USD-PERP",
+        short_venue="extended",
+        long_venue="paradex",
+        sample_size=2,
+        weighted_score=0.72,
+        latest_outcome="closed",
+        closed_count=2,
+    )
+
+    updated = _with_current_execution_quality(
+        candidate=candidate,
+        execution_quality_index={("ARB-USD-PERP", "extended", "paradex"): quality},
+    )
+
+    assert updated.opportunity.execution_quality == quality
+
+
 def test_launch_latest_stable_canary_once_uses_latest_execution_quality_for_maturity(
     tmp_path: Path,
 ) -> None:
@@ -7382,6 +7420,13 @@ def test_launch_latest_stable_canary_once_uses_latest_execution_quality_for_matu
     async def run_stub_lifecycle(**_: object) -> StubLifecycleResult:
         return StubLifecycleResult()
 
+    to_thread_calls = 0
+
+    async def fake_to_thread(func: Any, *args: Any, **kwargs: Any) -> Any:
+        nonlocal to_thread_calls
+        to_thread_calls += 1
+        return func(*args, **kwargs)
+
     with pytest.MonkeyPatch.context() as monkeypatch:
         monkeypatch.setattr(
             "carryme_worker.poller._build_launch_ready_canary_stability",
@@ -7395,6 +7440,7 @@ def test_launch_latest_stable_canary_once_uses_latest_execution_quality_for_matu
             "carryme_worker.poller._run_guarded_canary_lifecycle",
             run_stub_lifecycle,
         )
+        monkeypatch.setattr("carryme_worker.poller.asyncio.to_thread", fake_to_thread)
         summary = asyncio.run(
             launch_latest_stable_canary_once(
                 settings,
@@ -7403,6 +7449,7 @@ def test_launch_latest_stable_canary_once_uses_latest_execution_quality_for_matu
             )
         )
 
+    assert to_thread_calls == 1
     assert summary.status == "launched"
 
 

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -7243,6 +7243,169 @@ def test_launch_latest_stable_canary_once_allows_launch_when_execution_maturity_
     assert summary.status == "launched"
 
 
+def test_launch_latest_stable_canary_once_uses_latest_execution_quality_for_maturity(
+    tmp_path: Path,
+) -> None:
+    settings = WorkerSettings(
+        database_path=str(tmp_path / "history.sqlite3"),
+        stable_canary_launch_min_execution_quality_score=0.7,
+        stable_canary_launch_min_execution_samples=2,
+    )
+    approval, candidate, snapshot, stability = _build_stable_launch_test_snapshot(
+        label="arb_extended_paradex",
+        execution_quality=None,
+    )
+    approved_store = ApprovedCanaryStore(settings.database_path)
+    persisted_snapshot = approved_store.append(snapshot.approved_snapshot)
+    snapshot = snapshot.model_copy(update={"approved_snapshot": persisted_snapshot})
+    stability = stability.model_copy(update={"snapshot": snapshot})
+
+    execution_store = ExecutionJournalStore(settings.database_path)
+    observation_store = ExecutionObservationStore(settings.database_path)
+    for index in range(2):
+        paper_trade_id = 210 + index
+        execution = execution_store.append(
+            ExecutionJournalEntry(
+                executed_at=datetime(2026, 4, 4, 9, 50 + index, tzinfo=UTC),
+                adapter="paired_live:extended_then_paradex",
+                mode="live",
+                status="submitted",
+                paper_trade_id=paper_trade_id,
+                preview_hash=f"maturity-quality-{index}",
+                confirmation_entry_id=310 + index,
+                paper_trade=_build_auto_close_paper_trade(
+                    entry_id=paper_trade_id,
+                    created_at=datetime(2026, 4, 4, 9, 49 + index, tzinfo=UTC),
+                    label="arb_extended_paradex",
+                    canonical_symbol="ARB-USD-PERP",
+                ),
+                legs=[_build_auto_close_execution_leg()],
+            )
+        )
+        observation_store.append(
+            ExecutionObservationEntry(
+                observed_at=datetime(2026, 4, 4, 9, 51 + index, tzinfo=UTC),
+                context="worker_execution_monitor",
+                execution_entry_id=execution.entry_id,
+                paper_trade_id=paper_trade_id,
+                preview_hash=execution.preview_hash,
+                order_state=ExecutionOrderState(
+                    execution_entry_id=execution.entry_id,
+                    paper_trade_id=paper_trade_id,
+                    preview_hash=execution.preview_hash,
+                    legs=[],
+                    notes=[],
+                ),
+                pair_status=_build_auto_close_pair_status(
+                    execution=execution,
+                    derived_state="closed",
+                    recommended_action="no_action",
+                ),
+            )
+        )
+
+    api_settings = ApiSettings(
+        database_path=settings.database_path,
+        watchlist_path=settings.watchlist_path,
+        environment=settings.environment,
+        extended_live_enabled=True,
+        extended_api_key="extended-key",
+        extended_stark_private_key="extended-secret",
+        paradex_live_enabled=True,
+        paradex_account_address="0x123",
+        paradex_private_key="0x456",
+    )
+
+    class StubLifecycleResult:
+        def __init__(self) -> None:
+            self.paper_trade = PaperTradeEntry(
+                entry_id=177,
+                created_at=datetime(2026, 4, 4, 10, 2, tzinfo=UTC),
+                intent=FundingPairTradeIntent(
+                    label="arb_extended_paradex",
+                    canonical_symbol="ARB-USD-PERP",
+                    source_recorded_at=datetime(2026, 4, 4, 10, 1, tzinfo=UTC),
+                    one_day_net_edge_after_entry=0.00355,
+                    break_even_days_entry=0.2,
+                    capacity_limit_notional=900.0,
+                    target_notional=20.0,
+                    capacity_fraction=20.0 / 900.0,
+                    max_target_notional=20.0,
+                    long_leg=TradeLegIntent(
+                        venue="paradex",
+                        symbol="ARB-USD-PERP",
+                        fee_profile="pro_fastfills",
+                        side="buy",
+                        target_notional=20.0,
+                    ),
+                    short_leg=TradeLegIntent(
+                        venue="extended",
+                        symbol="ARB-USD",
+                        fee_profile="default",
+                        side="sell",
+                        target_notional=20.0,
+                    ),
+                ),
+            )
+            self.execution = ExecutionJournalEntry(
+                entry_id=271,
+                executed_at=datetime(2026, 4, 4, 10, 2, tzinfo=UTC),
+                adapter="paired_live:extended_then_paradex",
+                mode="live",
+                status="submitted",
+                paper_trade_id=177,
+                preview_hash="launch-preview-current-maturity",
+                confirmation_entry_id=371,
+                paper_trade=self.paper_trade,
+                legs=[_build_auto_close_execution_leg()],
+            )
+            self.final_pair_status = _build_auto_close_pair_status(
+                execution=self.execution,
+                derived_state="closed",
+                recommended_action="no_action",
+            )
+            self.observation = ExecutionObservationEntry(
+                observed_at=datetime(2026, 4, 4, 10, 3, tzinfo=UTC),
+                context="worker_execution_monitor",
+                execution_entry_id=271,
+                paper_trade_id=177,
+                preview_hash="launch-preview-current-maturity",
+                order_state=ExecutionOrderState(
+                    execution_entry_id=271,
+                    paper_trade_id=177,
+                    preview_hash="launch-preview-current-maturity",
+                    legs=[],
+                    notes=[],
+                ),
+            )
+
+    async def run_stub_lifecycle(**_: object) -> StubLifecycleResult:
+        return StubLifecycleResult()
+
+    with pytest.MonkeyPatch.context() as monkeypatch:
+        monkeypatch.setattr(
+            "carryme_worker.poller._build_launch_ready_canary_stability",
+            lambda **_: stability,
+        )
+        monkeypatch.setattr(
+            "carryme_worker.poller._select_latest_launch_ready_canary_snapshot",
+            lambda **_: (snapshot, candidate, approval),
+        )
+        monkeypatch.setattr(
+            "carryme_worker.poller._run_guarded_canary_lifecycle",
+            run_stub_lifecycle,
+        )
+        summary = asyncio.run(
+            launch_latest_stable_canary_once(
+                settings,
+                api_settings=api_settings,
+                now=datetime(2026, 4, 4, 10, 2, tzinfo=UTC),
+            )
+        )
+
+    assert summary.status == "launched"
+
+
 def test_launch_latest_stable_canary_once_allows_launch_at_exact_maturity_thresholds(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary
- keep execution-quality evidence on exact approved-canary scans when quality filters are configured
- re-check latest execution-quality history during stable-launch maturity and latest-outcome guards
- add regression coverage for exact scans and stable-launch maturity with missing serialized quality

## Why
Production stable launch is currently blocked with `Stable launch execution maturity is missing` even though the API has observed route samples. The launcher was trusting serialized candidate evidence that can be missing/stale instead of the latest execution journal.

## Validation
- UV_PROJECT_ENVIRONMENT=.venv-codex uv run pytest -q tests/test_runtime.py -k 'scan_exact_canary_candidate_for_approval'
- UV_PROJECT_ENVIRONMENT=.venv-codex uv run pytest -q tests/test_worker.py -k 'execution_maturity or latest_execution_quality_for_maturity or latest_outcome'
- UV_PROJECT_ENVIRONMENT=.venv-codex uv run pytest -q tests/test_runtime.py tests/test_worker.py
- UV_PROJECT_ENVIRONMENT=.venv-codex uv run ruff check .
- UV_PROJECT_ENVIRONMENT=.venv-codex uv run mypy src apps packages tests
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Canary launch evaluations now dynamically use the latest execution-quality data for maturity and adverse-outcome checks when applicable.
  * Route identifiers are normalized so execution-quality lookups are consistent across formatting variants.

* **Bug Fixes**
  * Execution-quality summaries now ignore mock entries, ensuring only live observations affect approvals.

* **Tests**
  * Added tests covering normalization, live-only filtering, and canary approval behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->