### PR TITLE
fix: shortlist current route approval proposals

### DIFF
--- a/apps/api/src/carryme_api/app.py
+++ b/apps/api/src/carryme_api/app.py
@@ -2478,6 +2478,98 @@ def _select_trade_intent_records(
     return rank_history_records(candidates, limit=limit)
 
 
+def _record_capacity_notional(record: OpportunityRecord) -> float:
+    """Return the saved max entry capacity as a sortable/filterable number."""
+
+    capacity = record.opportunity.capacity
+    if capacity is None or capacity.max_entry_notional is None:
+        return 0.0
+    return capacity.max_entry_notional
+
+
+def _min_saved_liquidity_values(short_value: float | None, long_value: float | None) -> float:
+    """Return the weaker saved venue metric for volume/OI filters."""
+
+    values = [value for value in (short_value, long_value) if value is not None]
+    if not values:
+        return 0.0
+    return min(values)
+
+
+def _select_canary_reprice_symbols_from_history(
+    store: OpportunityHistoryStore,
+    *,
+    sample: int,
+    limit: int,
+    venues: list[str],
+    exclude_symbols: list[str] | None,
+    exclude_tags: list[str] | None,
+    min_roundtrip_edge: float,
+    min_capacity_notional: float,
+    min_daily_volume: float,
+    min_open_interest: float,
+) -> list[str]:
+    """Select saved symbols worth live repricing before approval proposal generation."""
+
+    selected_venues = {venue.strip().lower() for venue in venues if venue.strip()}
+    records = store.list_recent(limit=sample)
+    latest = latest_records_by_label(records, limit=len(records))
+    candidates: list[OpportunityRecord] = []
+    for record in latest:
+        opportunity = record.opportunity
+        route_venues = {
+            opportunity.short_venue.strip().lower(),
+            opportunity.long_venue.strip().lower(),
+        }
+        if not route_venues.issubset(selected_venues):
+            continue
+        if not passes_symbol_policy(
+            opportunity.canonical_symbol,
+            exclude_symbols=exclude_symbols,
+            exclude_tags=exclude_tags,
+        ):
+            continue
+        if opportunity.one_day_net_edge_after_round_trip < min_roundtrip_edge:
+            continue
+        if _record_capacity_notional(record) < min_capacity_notional:
+            continue
+        saved_daily_volume = _min_saved_liquidity_values(
+            opportunity.short_daily_volume,
+            opportunity.long_daily_volume,
+        )
+        if saved_daily_volume < min_daily_volume:
+            continue
+        saved_open_interest = _min_saved_liquidity_values(
+            opportunity.short_open_interest,
+            opportunity.long_open_interest,
+        )
+        if saved_open_interest < min_open_interest:
+            continue
+        candidates.append(record)
+
+    ranked = sorted(
+        candidates,
+        key=lambda record: (
+            record.opportunity.one_day_net_edge_after_round_trip,
+            record.opportunity.one_day_net_edge_after_entry,
+            _record_capacity_notional(record),
+            record.recorded_at.timestamp(),
+        ),
+        reverse=True,
+    )
+    symbols: list[str] = []
+    seen_symbols: set[str] = set()
+    for record in ranked:
+        symbol = record.opportunity.canonical_symbol
+        if symbol in seen_symbols:
+            continue
+        symbols.append(symbol)
+        seen_symbols.add(symbol)
+        if len(symbols) >= limit:
+            break
+    return symbols
+
+
 def _build_trade_intent_candidates(
     store: OpportunityHistoryStore,
     *,
@@ -6931,6 +7023,7 @@ def create_app() -> FastAPI:
             RouteApprovalService,
             Depends(get_route_approval_service),
         ],
+        history_store: Annotated[OpportunityHistoryStore, Depends(get_history_store)],
         venues: Annotated[list[str] | None, Query()] = None,
         extended_fee_profile: str | None = None,
         paradex_fee_profile: str | None = "pro_fastfills",
@@ -6951,6 +7044,9 @@ def create_app() -> FastAPI:
         exclude_tags: Annotated[list[str] | None, Query()] = None,
         limit: int = 10,
         candidate_sample: int = 50,
+        use_history_shortlist: bool = True,
+        history_shortlist_sample: int = 500,
+        history_shortlist_limit: int = 50,
     ) -> list[FundingUniverseCanaryApprovalProposalSummary]:
         try:
             limit = _validated_history_limit("limit", limit)
@@ -6958,7 +7054,32 @@ def create_app() -> FastAPI:
                 limit,
                 _validated_history_limit("candidate_sample", candidate_sample),
             )
+            history_shortlist_sample = _validated_history_limit(
+                "history_shortlist_sample",
+                history_shortlist_sample,
+            )
+            history_shortlist_limit = max(
+                limit,
+                _validated_history_limit("history_shortlist_limit", history_shortlist_limit),
+            )
             selected_venues = venues or list(SUPPORTED_UNIVERSE_VENUES)
+            effective_include_symbols = include_symbols
+            if use_history_shortlist and include_symbols is None:
+                shortlisted_symbols = _select_canary_reprice_symbols_from_history(
+                    history_store,
+                    sample=history_shortlist_sample,
+                    limit=history_shortlist_limit,
+                    venues=selected_venues,
+                    exclude_symbols=exclude_symbols,
+                    exclude_tags=exclude_tags,
+                    min_roundtrip_edge=min_roundtrip_edge,
+                    min_capacity_notional=min_capacity_notional,
+                    min_daily_volume=min_daily_volume,
+                    min_open_interest=min_open_interest,
+                )
+                if shortlisted_symbols:
+                    effective_include_symbols = shortlisted_symbols
+                    candidate_sample = min(candidate_sample, len(shortlisted_symbols))
             generated_at = datetime.now(UTC)
             candidates = await _run_bounded_universe_scan(
                 "funding universe canary approval proposal scan",
@@ -6981,7 +7102,7 @@ def create_app() -> FastAPI:
                     min_route_stability_weight=min_route_stability_weight,
                     min_route_presence_ratio=min_route_presence_ratio,
                     min_route_samples=min_route_samples,
-                    include_symbols=include_symbols,
+                    include_symbols=effective_include_symbols,
                     exclude_symbols=exclude_symbols,
                     exclude_tags=exclude_tags,
                     limit=candidate_sample,

--- a/apps/api/src/carryme_api/app.py
+++ b/apps/api/src/carryme_api/app.py
@@ -11,7 +11,7 @@ import secrets
 from collections.abc import AsyncIterator, Awaitable, Callable
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from functools import lru_cache
 from pathlib import Path
 from typing import Annotated, Any, cast
@@ -187,6 +187,7 @@ UNIVERSE_SCAN_TIMEOUT_SECONDS = 20.0
 UNIVERSE_SCAN_ACQUIRE_TIMEOUT_SECONDS = 0.25
 MUTATING_HTTP_METHODS = frozenset({"POST", "PUT", "PATCH", "DELETE"})
 DEFAULT_CANARY_EXCLUDE_TAGS = ["meme", "political"]
+DEFAULT_HISTORY_SHORTLIST_MAX_AGE_SECONDS = 3600
 logger = logging.getLogger(__name__)
 _UNIVERSE_SCAN_SEMAPHORE = asyncio.Semaphore(1)
 
@@ -2500,12 +2501,16 @@ def _canary_candidate_identity(candidate: FundingUniverseCanaryCandidate) -> tup
     """Return a stable identity for deduping canary candidates across scans."""
 
     opportunity = candidate.opportunity.opportunity
+    venue_markets: list[str] = []
+    for venue, market in sorted(candidate.opportunity.venue_markets.items()):
+        venue_markets.extend([venue, market.venue, market.symbol])
     return (
         opportunity.canonical_symbol,
         opportunity.short_venue,
         opportunity.long_venue,
         opportunity.short_fee_profile,
         opportunity.long_fee_profile,
+        *venue_markets,
     )
 
 
@@ -2530,11 +2535,21 @@ def _merge_canary_candidates(
     return merged
 
 
+def _ensure_aware_utc(value: datetime) -> datetime:
+    """Normalize persisted datetimes before freshness comparisons."""
+
+    if value.tzinfo is None:
+        return value.replace(tzinfo=UTC)
+    return value.astimezone(UTC)
+
+
 def _select_canary_reprice_symbols_from_history(
     store: OpportunityHistoryStore,
     *,
     sample: int,
     limit: int,
+    now: datetime,
+    max_age_seconds: int,
     venues: list[str],
     exclude_symbols: list[str] | None,
     exclude_tags: list[str] | None,
@@ -2546,7 +2561,14 @@ def _select_canary_reprice_symbols_from_history(
     """Select saved symbols worth live repricing before approval proposal generation."""
 
     selected_venues = {venue.strip().lower() for venue in venues if venue.strip()}
-    records = store.list_recent(limit=sample)
+    cutoff = _ensure_aware_utc(now) - timedelta(seconds=max_age_seconds)
+    records = [
+        record
+        for record in store.list_recent(limit=sample)
+        if _ensure_aware_utc(record.recorded_at) >= cutoff
+    ]
+    if not records:
+        return []
     latest = latest_records_by_label(records, limit=len(records))
     candidates: list[OpportunityRecord] = []
     for record in latest:
@@ -2989,7 +3011,7 @@ def _validate_latest_approved_canary_snapshot_request(
         route.canonical_symbol,
         include_symbols=include_symbols,
         exclude_symbols=exclude_symbols,
-        exclude_tags=exclude_tags or ["meme", "political"],
+        exclude_tags=DEFAULT_CANARY_EXCLUDE_TAGS if exclude_tags is None else exclude_tags,
     ):
         raise HTTPException(
             status_code=409,
@@ -7081,6 +7103,7 @@ def create_app() -> FastAPI:
         use_history_shortlist: bool = True,
         history_shortlist_sample: int = 500,
         history_shortlist_limit: int = 50,
+        history_shortlist_max_age_seconds: int = DEFAULT_HISTORY_SHORTLIST_MAX_AGE_SECONDS,
     ) -> list[FundingUniverseCanaryApprovalProposalSummary]:
         try:
             limit = _validated_history_limit("limit", limit)
@@ -7096,8 +7119,15 @@ def create_app() -> FastAPI:
                 limit,
                 _validated_history_limit("history_shortlist_limit", history_shortlist_limit),
             )
+            if history_shortlist_max_age_seconds < 1:
+                raise HTTPException(
+                    status_code=400,
+                    detail="history_shortlist_max_age_seconds must be at least 1",
+                )
             selected_venues = venues or list(SUPPORTED_UNIVERSE_VENUES)
-            effective_exclude_tags = exclude_tags or DEFAULT_CANARY_EXCLUDE_TAGS
+            effective_exclude_tags = (
+                DEFAULT_CANARY_EXCLUDE_TAGS if exclude_tags is None else exclude_tags
+            )
             effective_include_symbols = include_symbols
             used_history_shortlist = False
             broad_candidate_sample = candidate_sample
@@ -7108,6 +7138,8 @@ def create_app() -> FastAPI:
                         history_store,
                         sample=history_shortlist_sample,
                         limit=history_shortlist_limit,
+                        now=datetime.now(UTC),
+                        max_age_seconds=history_shortlist_max_age_seconds,
                         venues=selected_venues,
                         exclude_symbols=exclude_symbols,
                         exclude_tags=effective_exclude_tags,

--- a/apps/api/src/carryme_api/app.py
+++ b/apps/api/src/carryme_api/app.py
@@ -189,6 +189,7 @@ MUTATING_HTTP_METHODS = frozenset({"POST", "PUT", "PATCH", "DELETE"})
 DEFAULT_CANARY_EXCLUDE_TAGS = ["meme", "political"]
 DEFAULT_HISTORY_SHORTLIST_MAX_AGE_SECONDS = 3600
 MAX_HISTORY_SHORTLIST_MAX_AGE_SECONDS = 30 * 24 * 60 * 60
+MIN_AWARE_UTC_DATETIME = datetime.min.replace(tzinfo=UTC)
 logger = logging.getLogger(__name__)
 _UNIVERSE_SCAN_SEMAPHORE = asyncio.Semaphore(1)
 
@@ -2496,12 +2497,87 @@ def _record_capacity_notional(record: OpportunityRecord) -> float:
     return capacity.max_entry_notional
 
 
+def _opportunity_spread_penalty(opportunity: FundingArbOpportunity) -> float:
+    """Return a sortable penalty for wide or missing saved spreads."""
+
+    penalty = 0.0
+    for spread_rate in (opportunity.short_spread_rate, opportunity.long_spread_rate):
+        if spread_rate is None:
+            penalty += 0.01
+        else:
+            penalty += spread_rate
+    return penalty
+
+
+def _opportunity_stale_book_penalty(opportunity: FundingArbOpportunity) -> float:
+    """Return a sortable penalty for stale saved order books."""
+
+    penalty = 0.0
+    if opportunity.short_stale_book:
+        penalty += 1.0
+    if opportunity.long_stale_book:
+        penalty += 1.0
+    return penalty
+
+
 def _min_saved_liquidity_values(short_value: float | None, long_value: float | None) -> float:
     """Return the weaker saved metric, failing closed when either side is missing."""
 
     if short_value is None or long_value is None:
         return 0.0
     return min(short_value, long_value)
+
+
+def _opportunity_liquidity_score(opportunity: FundingArbOpportunity) -> float:
+    """Return a small sortable bonus for weaker-side saved liquidity."""
+
+    min_daily_volume = _min_saved_liquidity_values(
+        opportunity.short_daily_volume,
+        opportunity.long_daily_volume,
+    )
+    min_open_interest = _min_saved_liquidity_values(
+        opportunity.short_open_interest,
+        opportunity.long_open_interest,
+    )
+    return math.log10(1.0 + min_daily_volume) * 1e-6 + math.log10(
+        1.0 + min_open_interest
+    ) * 1e-6
+
+
+def _ensure_aware_utc(value: datetime) -> datetime:
+    """Normalize persisted datetimes before freshness comparisons."""
+
+    if value.tzinfo is None:
+        return value.replace(tzinfo=UTC)
+    return value.astimezone(UTC)
+
+
+def _safe_aware_utc(value: datetime) -> datetime:
+    """Normalize datetimes without letting malformed persisted values abort ranking."""
+
+    try:
+        return _ensure_aware_utc(value)
+    except (OSError, OverflowError, ValueError):
+        return MIN_AWARE_UTC_DATETIME
+
+
+def _opportunity_quality_key(
+    opportunity: FundingArbOpportunity,
+    *,
+    capacity_notional: float,
+    recency: datetime,
+) -> tuple[float, float, float, float, float, float, datetime]:
+    """Rank by edge while demoting poor execution quality and stale saved data."""
+
+    return (
+        opportunity.one_day_net_edge_after_round_trip,
+        -_opportunity_spread_penalty(opportunity),
+        _opportunity_liquidity_score(opportunity),
+        -_opportunity_stale_book_penalty(opportunity),
+        opportunity.one_day_net_edge_after_entry,
+        capacity_notional,
+        recency,
+    )
 
 
 def _canary_candidate_identity(candidate: FundingUniverseCanaryCandidate) -> tuple[str, ...]:
@@ -2521,6 +2597,24 @@ def _canary_candidate_identity(candidate: FundingUniverseCanaryCandidate) -> tup
     )
 
 
+def _canary_candidate_quality_key(
+    candidate: FundingUniverseCanaryCandidate,
+) -> tuple[float, float, float, float, float, float, datetime]:
+    """Return the same execution-aware key used for history shortlist ranking."""
+
+    opportunity = candidate.opportunity.opportunity
+    capacity_notional = 0.0
+    if candidate.opportunity.deployable_notional is not None:
+        capacity_notional = candidate.opportunity.deployable_notional
+    elif opportunity.capacity is not None and opportunity.capacity.max_entry_notional is not None:
+        capacity_notional = opportunity.capacity.max_entry_notional
+    return _opportunity_quality_key(
+        opportunity,
+        capacity_notional=capacity_notional,
+        recency=MIN_AWARE_UTC_DATETIME,
+    )
+
+
 def _merge_canary_candidates(
     first: list[FundingUniverseCanaryCandidate],
     second: list[FundingUniverseCanaryCandidate],
@@ -2537,17 +2631,7 @@ def _merge_canary_candidates(
             continue
         merged.append(candidate)
         seen.add(identity)
-        if len(merged) >= limit:
-            break
-    return merged
-
-
-def _ensure_aware_utc(value: datetime) -> datetime:
-    """Normalize persisted datetimes before freshness comparisons."""
-
-    if value.tzinfo is None:
-        return value.replace(tzinfo=UTC)
-    return value.astimezone(UTC)
+    return sorted(merged, key=_canary_candidate_quality_key, reverse=True)[:limit]
 
 
 def _select_canary_reprice_symbols_from_history(
@@ -2577,7 +2661,7 @@ def _select_canary_reprice_symbols_from_history(
     records = [
         record
         for record in store.list_recent(limit=sample)
-        if _ensure_aware_utc(record.recorded_at) >= cutoff
+        if _safe_aware_utc(record.recorded_at) >= cutoff
     ]
     if not records:
         return []
@@ -2617,11 +2701,10 @@ def _select_canary_reprice_symbols_from_history(
 
     ranked = sorted(
         candidates,
-        key=lambda record: (
-            record.opportunity.one_day_net_edge_after_round_trip,
-            record.opportunity.one_day_net_edge_after_entry,
-            _record_capacity_notional(record),
-            _ensure_aware_utc(record.recorded_at).timestamp(),
+        key=lambda record: _opportunity_quality_key(
+            record.opportunity,
+            capacity_notional=_record_capacity_notional(record),
+            recency=_safe_aware_utc(record.recorded_at),
         ),
         reverse=True,
     )

--- a/apps/api/src/carryme_api/app.py
+++ b/apps/api/src/carryme_api/app.py
@@ -186,6 +186,7 @@ PAIR_STATUS_POLL_CALL_TIMEOUT_SECONDS = 10.0
 UNIVERSE_SCAN_TIMEOUT_SECONDS = 20.0
 UNIVERSE_SCAN_ACQUIRE_TIMEOUT_SECONDS = 0.25
 MUTATING_HTTP_METHODS = frozenset({"POST", "PUT", "PATCH", "DELETE"})
+DEFAULT_CANARY_EXCLUDE_TAGS = ["meme", "political"]
 logger = logging.getLogger(__name__)
 _UNIVERSE_SCAN_SEMAPHORE = asyncio.Semaphore(1)
 
@@ -2488,12 +2489,45 @@ def _record_capacity_notional(record: OpportunityRecord) -> float:
 
 
 def _min_saved_liquidity_values(short_value: float | None, long_value: float | None) -> float:
-    """Return the weaker saved venue metric for volume/OI filters."""
+    """Return the weaker saved metric, failing closed when either side is missing."""
 
-    values = [value for value in (short_value, long_value) if value is not None]
-    if not values:
+    if short_value is None or long_value is None:
         return 0.0
-    return min(values)
+    return min(short_value, long_value)
+
+
+def _canary_candidate_identity(candidate: FundingUniverseCanaryCandidate) -> tuple[str, ...]:
+    """Return a stable identity for deduping canary candidates across scans."""
+
+    opportunity = candidate.opportunity.opportunity
+    return (
+        opportunity.canonical_symbol,
+        opportunity.short_venue,
+        opportunity.long_venue,
+        opportunity.short_fee_profile,
+        opportunity.long_fee_profile,
+    )
+
+
+def _merge_canary_candidates(
+    first: list[FundingUniverseCanaryCandidate],
+    second: list[FundingUniverseCanaryCandidate],
+    *,
+    limit: int,
+) -> list[FundingUniverseCanaryCandidate]:
+    """Merge shortlist and broad-scan candidates without duplicating routes."""
+
+    merged: list[FundingUniverseCanaryCandidate] = []
+    seen: set[tuple[str, ...]] = set()
+    for candidate in [*first, *second]:
+        identity = _canary_candidate_identity(candidate)
+        if identity in seen:
+            continue
+        merged.append(candidate)
+        seen.add(identity)
+        if len(merged) >= limit:
+            break
+    return merged
 
 
 def _select_canary_reprice_symbols_from_history(
@@ -7063,51 +7097,75 @@ def create_app() -> FastAPI:
                 _validated_history_limit("history_shortlist_limit", history_shortlist_limit),
             )
             selected_venues = venues or list(SUPPORTED_UNIVERSE_VENUES)
+            effective_exclude_tags = exclude_tags or DEFAULT_CANARY_EXCLUDE_TAGS
             effective_include_symbols = include_symbols
+            used_history_shortlist = False
+            broad_candidate_sample = candidate_sample
             if use_history_shortlist and include_symbols is None:
-                shortlisted_symbols = _select_canary_reprice_symbols_from_history(
-                    history_store,
-                    sample=history_shortlist_sample,
-                    limit=history_shortlist_limit,
-                    venues=selected_venues,
-                    exclude_symbols=exclude_symbols,
-                    exclude_tags=exclude_tags,
-                    min_roundtrip_edge=min_roundtrip_edge,
-                    min_capacity_notional=min_capacity_notional,
-                    min_daily_volume=min_daily_volume,
-                    min_open_interest=min_open_interest,
-                )
+                try:
+                    shortlisted_symbols = await asyncio.to_thread(
+                        _select_canary_reprice_symbols_from_history,
+                        history_store,
+                        sample=history_shortlist_sample,
+                        limit=history_shortlist_limit,
+                        venues=selected_venues,
+                        exclude_symbols=exclude_symbols,
+                        exclude_tags=effective_exclude_tags,
+                        min_roundtrip_edge=min_roundtrip_edge,
+                        min_capacity_notional=min_capacity_notional,
+                        min_daily_volume=min_daily_volume,
+                        min_open_interest=min_open_interest,
+                    )
+                except Exception:
+                    logger.exception(
+                        "failed to build history shortlist for canary approval proposals"
+                    )
+                    shortlisted_symbols = []
                 if shortlisted_symbols:
                     effective_include_symbols = shortlisted_symbols
-                    candidate_sample = min(candidate_sample, len(shortlisted_symbols))
+                    used_history_shortlist = True
             generated_at = datetime.now(UTC)
-            candidates = await _run_bounded_universe_scan(
-                "funding universe canary approval proposal scan",
-                lambda: service.scan_canary_candidates(
-                    venues=selected_venues,
-                    fee_profile_overrides=_build_fee_profile_overrides(
-                        extended_fee_profile=extended_fee_profile,
-                        paradex_fee_profile=paradex_fee_profile,
-                        hyperliquid_fee_profile=hyperliquid_fee_profile,
-                        selected_venues=selected_venues,
+
+            async def _scan_candidates(
+                include_symbols_override: list[str] | None,
+                scan_limit: int,
+            ) -> list[FundingUniverseCanaryCandidate]:
+                return await _run_bounded_universe_scan(
+                    "funding universe canary approval proposal scan",
+                    lambda: service.scan_canary_candidates(
+                        venues=selected_venues,
+                        fee_profile_overrides=_build_fee_profile_overrides(
+                            extended_fee_profile=extended_fee_profile,
+                            paradex_fee_profile=paradex_fee_profile,
+                            hyperliquid_fee_profile=hyperliquid_fee_profile,
+                            selected_venues=selected_venues,
+                        ),
+                        target_notional=target_notional,
+                        canary_max_notional=canary_max_notional,
+                        min_capacity_notional=min_capacity_notional,
+                        min_daily_volume=min_daily_volume,
+                        min_open_interest=min_open_interest,
+                        min_roundtrip_edge=min_roundtrip_edge,
+                        min_execution_quality_score=min_execution_quality_score,
+                        min_execution_samples=min_execution_samples,
+                        min_route_stability_weight=min_route_stability_weight,
+                        min_route_presence_ratio=min_route_presence_ratio,
+                        min_route_samples=min_route_samples,
+                        include_symbols=include_symbols_override,
+                        exclude_symbols=exclude_symbols,
+                        exclude_tags=effective_exclude_tags,
+                        limit=scan_limit,
                     ),
-                    target_notional=target_notional,
-                    canary_max_notional=canary_max_notional,
-                    min_capacity_notional=min_capacity_notional,
-                    min_daily_volume=min_daily_volume,
-                    min_open_interest=min_open_interest,
-                    min_roundtrip_edge=min_roundtrip_edge,
-                    min_execution_quality_score=min_execution_quality_score,
-                    min_execution_samples=min_execution_samples,
-                    min_route_stability_weight=min_route_stability_weight,
-                    min_route_presence_ratio=min_route_presence_ratio,
-                    min_route_samples=min_route_samples,
-                    include_symbols=effective_include_symbols,
-                    exclude_symbols=exclude_symbols,
-                    exclude_tags=exclude_tags,
-                    limit=candidate_sample,
-                ),
-            )
+                )
+
+            candidates = await _scan_candidates(effective_include_symbols, candidate_sample)
+            if used_history_shortlist and len(candidates) < limit:
+                broad_candidates = await _scan_candidates(None, broad_candidate_sample)
+                candidates = _merge_canary_candidates(
+                    candidates,
+                    broad_candidates,
+                    limit=broad_candidate_sample,
+                )
             proposals = approval_service.propose_canary_route_approvals(
                 candidates,
                 limit=limit,

--- a/apps/api/src/carryme_api/app.py
+++ b/apps/api/src/carryme_api/app.py
@@ -7215,6 +7215,10 @@ def create_app() -> FastAPI:
                 limit,
                 _validated_history_limit("history_shortlist_limit", history_shortlist_limit),
             )
+            history_shortlist_sample = max(
+                history_shortlist_sample,
+                history_shortlist_limit,
+            )
             if history_shortlist_max_age_seconds < 1:
                 raise HTTPException(
                     status_code=400,
@@ -7234,7 +7238,6 @@ def create_app() -> FastAPI:
             )
             effective_include_symbols = include_symbols
             used_history_shortlist = False
-            broad_candidate_sample = candidate_sample
             if use_history_shortlist and include_symbols is None:
                 try:
                     shortlisted_symbols = await asyncio.to_thread(
@@ -7296,11 +7299,12 @@ def create_app() -> FastAPI:
 
             candidates = await _scan_candidates(effective_include_symbols, candidate_sample)
             if used_history_shortlist and len(candidates) < limit:
-                broad_candidates = await _scan_candidates(None, broad_candidate_sample)
+                remaining_candidate_slots = max(1, limit - len(candidates))
+                broad_candidates = await _scan_candidates(None, remaining_candidate_slots)
                 candidates = _merge_canary_candidates(
                     candidates,
                     broad_candidates,
-                    limit=broad_candidate_sample,
+                    limit=limit,
                 )
             proposals = approval_service.propose_canary_route_approvals(
                 candidates,

--- a/apps/api/src/carryme_api/app.py
+++ b/apps/api/src/carryme_api/app.py
@@ -188,6 +188,7 @@ UNIVERSE_SCAN_ACQUIRE_TIMEOUT_SECONDS = 0.25
 MUTATING_HTTP_METHODS = frozenset({"POST", "PUT", "PATCH", "DELETE"})
 DEFAULT_CANARY_EXCLUDE_TAGS = ["meme", "political"]
 DEFAULT_HISTORY_SHORTLIST_MAX_AGE_SECONDS = 3600
+MAX_HISTORY_SHORTLIST_MAX_AGE_SECONDS = 30 * 24 * 60 * 60
 logger = logging.getLogger(__name__)
 _UNIVERSE_SCAN_SEMAPHORE = asyncio.Semaphore(1)
 
@@ -444,6 +445,12 @@ def get_app_environment() -> str:
 
 def get_automation_readiness_checked_at() -> datetime:
     """Return the authoritative UTC evaluation time for automation readiness."""
+
+    return datetime.now(UTC)
+
+
+def get_current_utc_time() -> datetime:
+    """Return the current UTC time through a dependency for deterministic tests."""
 
     return datetime.now(UTC)
 
@@ -2561,7 +2568,12 @@ def _select_canary_reprice_symbols_from_history(
     """Select saved symbols worth live repricing before approval proposal generation."""
 
     selected_venues = {venue.strip().lower() for venue in venues if venue.strip()}
-    cutoff = _ensure_aware_utc(now) - timedelta(seconds=max_age_seconds)
+    if max_age_seconds < 1 or max_age_seconds > MAX_HISTORY_SHORTLIST_MAX_AGE_SECONDS:
+        return []
+    try:
+        cutoff = _ensure_aware_utc(now) - timedelta(seconds=max_age_seconds)
+    except OverflowError:
+        return []
     records = [
         record
         for record in store.list_recent(limit=sample)
@@ -2609,7 +2621,7 @@ def _select_canary_reprice_symbols_from_history(
             record.opportunity.one_day_net_edge_after_round_trip,
             record.opportunity.one_day_net_edge_after_entry,
             _record_capacity_notional(record),
-            record.recorded_at.timestamp(),
+            _ensure_aware_utc(record.recorded_at).timestamp(),
         ),
         reverse=True,
     )
@@ -7080,6 +7092,7 @@ def create_app() -> FastAPI:
             Depends(get_route_approval_service),
         ],
         history_store: Annotated[OpportunityHistoryStore, Depends(get_history_store)],
+        current_time: Annotated[datetime, Depends(get_current_utc_time)],
         venues: Annotated[list[str] | None, Query()] = None,
         extended_fee_profile: str | None = None,
         paradex_fee_profile: str | None = "pro_fastfills",
@@ -7124,6 +7137,14 @@ def create_app() -> FastAPI:
                     status_code=400,
                     detail="history_shortlist_max_age_seconds must be at least 1",
                 )
+            if history_shortlist_max_age_seconds > MAX_HISTORY_SHORTLIST_MAX_AGE_SECONDS:
+                raise HTTPException(
+                    status_code=400,
+                    detail=(
+                        "history_shortlist_max_age_seconds must be at most "
+                        f"{MAX_HISTORY_SHORTLIST_MAX_AGE_SECONDS}"
+                    ),
+                )
             selected_venues = venues or list(SUPPORTED_UNIVERSE_VENUES)
             effective_exclude_tags = (
                 DEFAULT_CANARY_EXCLUDE_TAGS if exclude_tags is None else exclude_tags
@@ -7138,7 +7159,7 @@ def create_app() -> FastAPI:
                         history_store,
                         sample=history_shortlist_sample,
                         limit=history_shortlist_limit,
-                        now=datetime.now(UTC),
+                        now=current_time,
                         max_age_seconds=history_shortlist_max_age_seconds,
                         venues=selected_venues,
                         exclude_symbols=exclude_symbols,
@@ -7156,7 +7177,7 @@ def create_app() -> FastAPI:
                 if shortlisted_symbols:
                     effective_include_symbols = shortlisted_symbols
                     used_history_shortlist = True
-            generated_at = datetime.now(UTC)
+            generated_at = current_time
 
             async def _scan_candidates(
                 include_symbols_override: list[str] | None,

--- a/packages/runtime/src/carryme_runtime/universe.py
+++ b/packages/runtime/src/carryme_runtime/universe.py
@@ -219,7 +219,7 @@ class OpportunityUniverseService:
             min_route_samples=min_route_samples,
             include_symbols=include_symbols,
             exclude_symbols=exclude_symbols,
-            exclude_tags=exclude_tags or ["meme", "political"],
+            exclude_tags=["meme", "political"] if exclude_tags is None else exclude_tags,
             limit=limit,
             use_execution_quality=use_execution_quality,
             use_route_stability=use_route_stability,

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1025,7 +1025,9 @@ def test_funding_universe_canary_endpoint_can_filter_approved_routes() -> None:
     assert payload[0]["suggested_canary_notional"] == 11.0
 
 
-def test_funding_universe_canary_approval_proposals_endpoint_uses_candidate_sample() -> None:
+def test_funding_universe_canary_approval_proposals_endpoint_uses_candidate_sample(
+    tmp_path: Path,
+) -> None:
     candidate = FundingUniverseCanaryCandidate(
         opportunity=FundingUniverseOpportunity(
             opportunity=FundingArbOpportunity(
@@ -1116,6 +1118,8 @@ def test_funding_universe_canary_approval_proposals_endpoint_uses_candidate_samp
                 )
             ]
 
+    history_store = OpportunityHistoryStore(tmp_path / "history.sqlite3")
+    app.dependency_overrides[get_history_store] = lambda: history_store
     app.dependency_overrides[get_opportunity_universe_service] = lambda: StubUniverseService()
     app.dependency_overrides[get_route_approval_service] = lambda: StubRouteApprovalService()
     try:
@@ -1144,7 +1148,216 @@ def test_funding_universe_canary_approval_proposals_endpoint_uses_candidate_samp
     assert "candidate" not in payload[0]
 
 
+def test_funding_universe_canary_approval_proposals_uses_history_shortlist(
+    tmp_path: Path,
+) -> None:
+    store = OpportunityHistoryStore(tmp_path / "history.sqlite3")
+    now = datetime(2026, 3, 29, 12, 0, tzinfo=UTC)
+    for label, symbol, roundtrip_edge, capacity in (
+        ("ton_extended_paradex", "TON-USD-PERP", 0.003, 2_500.0),
+        ("zro_extended_paradex", "ZRO-USD-PERP", 0.002, 1_500.0),
+        ("jup_extended_paradex", "JUP-USD-PERP", -0.001, 4_000.0),
+        ("near_extended_hyperliquid", "NEAR-USD-PERP", 0.004, 3_000.0),
+    ):
+        right_venue = "hyperliquid" if "hyperliquid" in label else "paradex"
+        store.append(
+            OpportunityRecord(
+                recorded_at=now,
+                pair=FundingPairSpec(
+                    label=label,
+                    left_venue="extended",
+                    left_symbol=symbol.removesuffix("-PERP"),
+                    left_fee_profile="default",
+                    right_venue=right_venue,
+                    right_symbol=(
+                        symbol
+                        if right_venue == "paradex"
+                        else symbol.removesuffix("-USD-PERP")
+                    ),
+                    right_fee_profile="pro_fastfills" if right_venue == "paradex" else "tier0",
+                ),
+                opportunity=FundingArbOpportunity(
+                    canonical_symbol=symbol,
+                    long_venue=right_venue,
+                    short_venue="extended",
+                    long_fee_profile="pro_fastfills" if right_venue == "paradex" else "tier0",
+                    short_fee_profile="default",
+                    gross_daily_edge=roundtrip_edge + 0.001,
+                    entry_cost_rate=0.0003,
+                    round_trip_cost_rate=0.0006,
+                    one_day_net_edge_after_entry=roundtrip_edge + 0.0003,
+                    one_day_net_edge_after_round_trip=roundtrip_edge,
+                    break_even_days_entry=0.2,
+                    break_even_days_round_trip=0.4,
+                    capacity=CapacityEstimate(
+                        short_bid_notional=capacity + 100.0,
+                        long_ask_notional=capacity,
+                        max_entry_notional=capacity,
+                        limiting_venue=right_venue,
+                    ),
+                ),
+            )
+        )
+    candidate = FundingUniverseCanaryCandidate(
+        opportunity=FundingUniverseOpportunity(
+            opportunity=FundingArbOpportunity(
+                canonical_symbol="TON-USD-PERP",
+                long_venue="paradex",
+                short_venue="extended",
+                long_fee_profile="pro_fastfills",
+                short_fee_profile="default",
+                gross_daily_edge=0.004,
+                entry_cost_rate=0.00045,
+                round_trip_cost_rate=0.0009,
+                one_day_net_edge_after_entry=0.00355,
+                one_day_net_edge_after_round_trip=0.0031,
+                break_even_days_entry=0.2,
+                break_even_days_round_trip=0.3,
+                capacity=CapacityEstimate(
+                    short_bid_notional=1_400.0,
+                    long_ask_notional=900.0,
+                    max_entry_notional=900.0,
+                    limiting_venue="paradex",
+                ),
+            ),
+            venue_markets={
+                "extended": FundingUniverseVenueMarket(
+                    venue="extended",
+                    symbol="TON-USD",
+                ),
+                "paradex": FundingUniverseVenueMarket(
+                    venue="paradex",
+                    symbol="TON-USD-PERP",
+                ),
+            },
+            deployable_notional=900.0,
+            estimated_one_day_pnl_after_round_trip=2.79,
+        ),
+        suggested_canary_notional=25.0,
+    )
+    captured: dict[str, object] = {}
+
+    class StubUniverseService:
+        async def scan_canary_candidates(
+            self, **kwargs: object
+        ) -> list[FundingUniverseCanaryCandidate]:
+            captured.update(kwargs)
+            return [candidate]
+
+    class StubRouteApprovalService:
+        def propose_canary_route_approvals(
+            self,
+            candidates: list[FundingUniverseCanaryCandidate],
+            *,
+            limit: int,
+        ) -> list[FundingUniverseCanaryApprovalProposal]:
+            assert candidates == [candidate]
+            assert limit == 2
+            return []
+
+    app.dependency_overrides[get_history_store] = lambda: store
+    app.dependency_overrides[get_opportunity_universe_service] = lambda: StubUniverseService()
+    app.dependency_overrides[get_route_approval_service] = lambda: StubRouteApprovalService()
+    try:
+        client = TestClient(app)
+        response = client.get(
+            "/v1/opportunities/funding-universe/canary/approval-proposals",
+            params=[
+                ("venues", "extended"),
+                ("venues", "paradex"),
+                ("limit", "2"),
+                ("history_shortlist_limit", "2"),
+                ("history_shortlist_sample", "20"),
+            ],
+        )
+    finally:
+        app.dependency_overrides.clear()
+
+    assert response.status_code == 200
+    assert captured["include_symbols"] == ["TON-USD-PERP", "ZRO-USD-PERP"]
+    assert captured["limit"] == 2
+
+
+def test_funding_universe_canary_approval_proposals_preserves_explicit_symbols(
+    tmp_path: Path,
+) -> None:
+    store = OpportunityHistoryStore(tmp_path / "history.sqlite3")
+    store.append(
+        OpportunityRecord(
+            recorded_at=datetime(2026, 3, 29, tzinfo=UTC),
+            pair=FundingPairSpec(
+                label="ton_extended_paradex",
+                left_venue="extended",
+                left_symbol="TON-USD",
+                left_fee_profile="default",
+                right_venue="paradex",
+                right_symbol="TON-USD-PERP",
+                right_fee_profile="pro_fastfills",
+            ),
+            opportunity=FundingArbOpportunity(
+                canonical_symbol="TON-USD-PERP",
+                long_venue="paradex",
+                short_venue="extended",
+                long_fee_profile="pro_fastfills",
+                short_fee_profile="default",
+                gross_daily_edge=0.004,
+                entry_cost_rate=0.0003,
+                round_trip_cost_rate=0.0006,
+                one_day_net_edge_after_entry=0.0037,
+                one_day_net_edge_after_round_trip=0.0034,
+                break_even_days_entry=0.2,
+                break_even_days_round_trip=0.4,
+                capacity=CapacityEstimate(
+                    short_bid_notional=2_500.0,
+                    long_ask_notional=2_000.0,
+                    max_entry_notional=2_000.0,
+                    limiting_venue="paradex",
+                ),
+            ),
+        )
+    )
+    captured: dict[str, object] = {}
+
+    class StubUniverseService:
+        async def scan_canary_candidates(
+            self, **kwargs: object
+        ) -> list[FundingUniverseCanaryCandidate]:
+            captured.update(kwargs)
+            return []
+
+    class StubRouteApprovalService:
+        def propose_canary_route_approvals(
+            self,
+            candidates: list[FundingUniverseCanaryCandidate],
+            *,
+            limit: int,
+        ) -> list[FundingUniverseCanaryApprovalProposal]:
+            assert candidates == []
+            assert limit == 1
+            return []
+
+    app.dependency_overrides[get_history_store] = lambda: store
+    app.dependency_overrides[get_opportunity_universe_service] = lambda: StubUniverseService()
+    app.dependency_overrides[get_route_approval_service] = lambda: StubRouteApprovalService()
+    try:
+        client = TestClient(app)
+        response = client.get(
+            "/v1/opportunities/funding-universe/canary/approval-proposals",
+            params=[
+                ("include_symbols", "S-USD-PERP"),
+                ("limit", "1"),
+                ("history_shortlist_limit", "10"),
+            ],
+        )
+    finally:
+        app.dependency_overrides.clear()
+
+    assert response.status_code == 200
+    assert captured["include_symbols"] == ["S-USD-PERP"]
+
+
 def test_funding_universe_canary_approval_proposals_filters_fee_overrides_to_selected_venues(
+    tmp_path: Path,
 ) -> None:
     captured: dict[str, object] = {}
 
@@ -1166,6 +1379,8 @@ def test_funding_universe_canary_approval_proposals_filters_fee_overrides_to_sel
             assert limit == 2
             return []
 
+    history_store = OpportunityHistoryStore(tmp_path / "history.sqlite3")
+    app.dependency_overrides[get_history_store] = lambda: history_store
     app.dependency_overrides[get_opportunity_universe_service] = lambda: StubUniverseService()
     app.dependency_overrides[get_route_approval_service] = lambda: StubRouteApprovalService()
     try:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,5 +1,5 @@
 import asyncio
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any, cast
 
@@ -1152,7 +1152,7 @@ def test_funding_universe_canary_approval_proposals_uses_history_shortlist(
     tmp_path: Path,
 ) -> None:
     store = OpportunityHistoryStore(tmp_path / "history.sqlite3")
-    now = datetime(2026, 3, 29, 12, 0, tzinfo=UTC)
+    now = datetime.now(UTC)
     for label, symbol, roundtrip_edge, capacity in (
         ("ton_extended_paradex", "TON-USD-PERP", 0.003, 2_500.0),
         ("zro_extended_paradex", "ZRO-USD-PERP", 0.002, 1_500.0),
@@ -1282,7 +1282,7 @@ def test_funding_universe_canary_approval_proposals_shortlist_matches_live_polic
     tmp_path: Path,
 ) -> None:
     store = OpportunityHistoryStore(tmp_path / "history.sqlite3")
-    now = datetime(2026, 3, 29, 12, 0, tzinfo=UTC)
+    now = datetime.now(UTC)
     for label, symbol, short_daily_volume, long_daily_volume in (
         ("wif_extended_paradex", "WIF-USD-PERP", 1_000_000.0, 1_000_000.0),
         ("ton_extended_paradex", "TON-USD-PERP", None, 1_000_000.0),
@@ -1366,13 +1366,91 @@ def test_funding_universe_canary_approval_proposals_shortlist_matches_live_polic
     assert calls[0]["exclude_tags"] == ["meme", "political"]
 
 
+def test_funding_universe_canary_approval_proposals_ignores_stale_history_shortlist(
+    tmp_path: Path,
+) -> None:
+    store = OpportunityHistoryStore(tmp_path / "history.sqlite3")
+    store.append(
+        OpportunityRecord(
+            recorded_at=datetime.now(UTC) - timedelta(hours=2),
+            pair=FundingPairSpec(
+                label="ton_extended_paradex",
+                left_venue="extended",
+                left_symbol="TON-USD",
+                left_fee_profile="default",
+                right_venue="paradex",
+                right_symbol="TON-USD-PERP",
+                right_fee_profile="pro_fastfills",
+            ),
+            opportunity=FundingArbOpportunity(
+                canonical_symbol="TON-USD-PERP",
+                long_venue="paradex",
+                short_venue="extended",
+                long_fee_profile="pro_fastfills",
+                short_fee_profile="default",
+                gross_daily_edge=0.004,
+                entry_cost_rate=0.0003,
+                round_trip_cost_rate=0.0006,
+                one_day_net_edge_after_entry=0.0037,
+                one_day_net_edge_after_round_trip=0.0034,
+                break_even_days_entry=0.2,
+                break_even_days_round_trip=0.4,
+                capacity=CapacityEstimate(
+                    short_bid_notional=2_500.0,
+                    long_ask_notional=2_000.0,
+                    max_entry_notional=2_000.0,
+                    limiting_venue="paradex",
+                ),
+            ),
+        )
+    )
+    captured: dict[str, object] = {}
+
+    class StubUniverseService:
+        async def scan_canary_candidates(
+            self, **kwargs: object
+        ) -> list[FundingUniverseCanaryCandidate]:
+            captured.update(kwargs)
+            return []
+
+    class StubRouteApprovalService:
+        def propose_canary_route_approvals(
+            self,
+            candidates: list[FundingUniverseCanaryCandidate],
+            *,
+            limit: int,
+        ) -> list[FundingUniverseCanaryApprovalProposal]:
+            assert candidates == []
+            assert limit == 2
+            return []
+
+    app.dependency_overrides[get_history_store] = lambda: store
+    app.dependency_overrides[get_opportunity_universe_service] = lambda: StubUniverseService()
+    app.dependency_overrides[get_route_approval_service] = lambda: StubRouteApprovalService()
+    try:
+        client = TestClient(app)
+        response = client.get(
+            "/v1/opportunities/funding-universe/canary/approval-proposals",
+            params=[
+                ("venues", "extended"),
+                ("venues", "paradex"),
+                ("limit", "2"),
+            ],
+        )
+    finally:
+        app.dependency_overrides.clear()
+
+    assert response.status_code == 200
+    assert captured["include_symbols"] is None
+
+
 def test_funding_universe_canary_approval_proposals_falls_back_when_shortlist_misses(
     tmp_path: Path,
 ) -> None:
     store = OpportunityHistoryStore(tmp_path / "history.sqlite3")
     store.append(
         OpportunityRecord(
-            recorded_at=datetime(2026, 3, 29, 12, 0, tzinfo=UTC),
+            recorded_at=datetime.now(UTC),
             pair=FundingPairSpec(
                 label="ton_extended_paradex",
                 left_venue="extended",
@@ -1490,7 +1568,7 @@ def test_funding_universe_canary_approval_proposals_preserves_explicit_symbols(
     store = OpportunityHistoryStore(tmp_path / "history.sqlite3")
     store.append(
         OpportunityRecord(
-            recorded_at=datetime(2026, 3, 29, tzinfo=UTC),
+            recorded_at=datetime.now(UTC),
             pair=FundingPairSpec(
                 label="ton_extended_paradex",
                 left_venue="extended",

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1202,16 +1202,71 @@ def test_funding_universe_canary_approval_proposals_rejects_unbounded_history_sh
     assert called is False
 
 
+def test_funding_universe_canary_approval_proposals_rejects_zero_history_shortlist_age(
+    tmp_path: Path,
+) -> None:
+    called = False
+
+    class StubUniverseService:
+        async def scan_canary_candidates(
+            self, **_: object
+        ) -> list[FundingUniverseCanaryCandidate]:
+            nonlocal called
+            called = True
+            return []
+
+    class StubRouteApprovalService:
+        def propose_canary_route_approvals(
+            self,
+            candidates: list[FundingUniverseCanaryCandidate],
+            *,
+            limit: int,
+        ) -> list[FundingUniverseCanaryApprovalProposal]:
+            assert candidates == []
+            assert limit == 1
+            return []
+
+    history_store = OpportunityHistoryStore(tmp_path / "history.sqlite3")
+    app.dependency_overrides[get_history_store] = lambda: history_store
+    app.dependency_overrides[get_current_utc_time] = lambda: FIXED_APPROVAL_PROPOSAL_NOW
+    app.dependency_overrides[get_opportunity_universe_service] = lambda: StubUniverseService()
+    app.dependency_overrides[get_route_approval_service] = lambda: StubRouteApprovalService()
+    try:
+        client = TestClient(app)
+        response = client.get(
+            "/v1/opportunities/funding-universe/canary/approval-proposals",
+            params={
+                "limit": "1",
+                "history_shortlist_max_age_seconds": "0",
+            },
+        )
+    finally:
+        app.dependency_overrides.clear()
+
+    assert response.status_code == 400
+    assert (
+        response.json()["detail"] == "history_shortlist_max_age_seconds must be at least 1"
+    )
+    assert called is False
+
+
 def test_funding_universe_canary_approval_proposals_uses_history_shortlist(
     tmp_path: Path,
 ) -> None:
     store = OpportunityHistoryStore(tmp_path / "history.sqlite3")
     now = FIXED_APPROVAL_PROPOSAL_NOW
-    for label, symbol, roundtrip_edge, capacity in (
-        ("ton_extended_paradex", "TON-USD-PERP", 0.003, 2_500.0),
-        ("zro_extended_paradex", "ZRO-USD-PERP", 0.002, 1_500.0),
-        ("jup_extended_paradex", "JUP-USD-PERP", -0.001, 4_000.0),
-        ("near_extended_hyperliquid", "NEAR-USD-PERP", 0.004, 3_000.0),
+    for label, symbol, roundtrip_edge, capacity, spread_rate, liquidity in (
+        ("ton_extended_paradex", "TON-USD-PERP", 0.003, 2_500.0, 0.020, 100_000.0),
+        ("zro_extended_paradex", "ZRO-USD-PERP", 0.003, 1_500.0, 0.001, 2_000_000.0),
+        ("jup_extended_paradex", "JUP-USD-PERP", -0.001, 4_000.0, 0.001, 5_000_000.0),
+        (
+            "near_extended_hyperliquid",
+            "NEAR-USD-PERP",
+            0.004,
+            3_000.0,
+            0.001,
+            2_000_000.0,
+        ),
     ):
         right_venue = "hyperliquid" if "hyperliquid" in label else "paradex"
         store.append(
@@ -1243,6 +1298,12 @@ def test_funding_universe_canary_approval_proposals_uses_history_shortlist(
                     one_day_net_edge_after_round_trip=roundtrip_edge,
                     break_even_days_entry=0.2,
                     break_even_days_round_trip=0.4,
+                    short_spread_rate=spread_rate,
+                    long_spread_rate=spread_rate,
+                    short_daily_volume=liquidity,
+                    long_daily_volume=liquidity,
+                    short_open_interest=liquidity,
+                    long_open_interest=liquidity,
                     capacity=CapacityEstimate(
                         short_bid_notional=capacity + 100.0,
                         long_ask_notional=capacity,
@@ -1329,7 +1390,7 @@ def test_funding_universe_canary_approval_proposals_uses_history_shortlist(
         app.dependency_overrides.clear()
 
     assert response.status_code == 200
-    assert captured["include_symbols"] == ["TON-USD-PERP", "ZRO-USD-PERP"]
+    assert captured["include_symbols"] == ["ZRO-USD-PERP", "TON-USD-PERP"]
     assert captured["limit"] == 50
 
 
@@ -1441,7 +1502,8 @@ def test_funding_universe_canary_approval_proposals_ignores_stale_history_shortl
     store = OpportunityHistoryStore(tmp_path / "history.sqlite3")
     store.append(
         OpportunityRecord(
-            recorded_at=FIXED_APPROVAL_PROPOSAL_NOW - timedelta(hours=2),
+            recorded_at=FIXED_APPROVAL_PROPOSAL_NOW
+            - timedelta(seconds=app_module.DEFAULT_HISTORY_SHORTLIST_MAX_AGE_SECONDS + 1),
             pair=FundingPairSpec(
                 label="ton_extended_paradex",
                 left_venue="extended",

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -13,6 +13,7 @@ from carryme_api.app import (
     get_approved_canary_store,
     get_automation_readiness_checked_at,
     get_balance_accounting_service,
+    get_current_utc_time,
     get_execution_accounting_service,
     get_execution_journal_store,
     get_execution_observation_store,
@@ -105,6 +106,8 @@ from carryme_storage import (
 from fastapi import HTTPException
 from fastapi.testclient import TestClient
 from pydantic import SecretStr, ValidationError
+
+FIXED_APPROVAL_PROPOSAL_NOW = datetime(2026, 4, 3, 12, 0, tzinfo=UTC)
 
 
 def test_health_endpoint() -> None:
@@ -1148,11 +1151,62 @@ def test_funding_universe_canary_approval_proposals_endpoint_uses_candidate_samp
     assert "candidate" not in payload[0]
 
 
+def test_funding_universe_canary_approval_proposals_rejects_unbounded_history_shortlist_age(
+    tmp_path: Path,
+) -> None:
+    called = False
+
+    class StubUniverseService:
+        async def scan_canary_candidates(
+            self, **_: object
+        ) -> list[FundingUniverseCanaryCandidate]:
+            nonlocal called
+            called = True
+            return []
+
+    class StubRouteApprovalService:
+        def propose_canary_route_approvals(
+            self,
+            candidates: list[FundingUniverseCanaryCandidate],
+            *,
+            limit: int,
+        ) -> list[FundingUniverseCanaryApprovalProposal]:
+            assert candidates == []
+            assert limit == 1
+            return []
+
+    history_store = OpportunityHistoryStore(tmp_path / "history.sqlite3")
+    app.dependency_overrides[get_history_store] = lambda: history_store
+    app.dependency_overrides[get_current_utc_time] = lambda: FIXED_APPROVAL_PROPOSAL_NOW
+    app.dependency_overrides[get_opportunity_universe_service] = lambda: StubUniverseService()
+    app.dependency_overrides[get_route_approval_service] = lambda: StubRouteApprovalService()
+    try:
+        client = TestClient(app)
+        response = client.get(
+            "/v1/opportunities/funding-universe/canary/approval-proposals",
+            params={
+                "limit": "1",
+                "history_shortlist_max_age_seconds": str(
+                    app_module.MAX_HISTORY_SHORTLIST_MAX_AGE_SECONDS + 1
+                ),
+            },
+        )
+    finally:
+        app.dependency_overrides.clear()
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == (
+        "history_shortlist_max_age_seconds must be at most "
+        f"{app_module.MAX_HISTORY_SHORTLIST_MAX_AGE_SECONDS}"
+    )
+    assert called is False
+
+
 def test_funding_universe_canary_approval_proposals_uses_history_shortlist(
     tmp_path: Path,
 ) -> None:
     store = OpportunityHistoryStore(tmp_path / "history.sqlite3")
-    now = datetime.now(UTC)
+    now = FIXED_APPROVAL_PROPOSAL_NOW
     for label, symbol, roundtrip_edge, capacity in (
         ("ton_extended_paradex", "TON-USD-PERP", 0.003, 2_500.0),
         ("zro_extended_paradex", "ZRO-USD-PERP", 0.002, 1_500.0),
@@ -1256,6 +1310,7 @@ def test_funding_universe_canary_approval_proposals_uses_history_shortlist(
             return []
 
     app.dependency_overrides[get_history_store] = lambda: store
+    app.dependency_overrides[get_current_utc_time] = lambda: FIXED_APPROVAL_PROPOSAL_NOW
     app.dependency_overrides[get_opportunity_universe_service] = lambda: StubUniverseService()
     app.dependency_overrides[get_route_approval_service] = lambda: StubRouteApprovalService()
     try:
@@ -1280,9 +1335,10 @@ def test_funding_universe_canary_approval_proposals_uses_history_shortlist(
 
 def test_funding_universe_canary_approval_proposals_shortlist_matches_live_policy(
     tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     store = OpportunityHistoryStore(tmp_path / "history.sqlite3")
-    now = datetime.now(UTC)
+    now = FIXED_APPROVAL_PROPOSAL_NOW
     for label, symbol, short_daily_volume, long_daily_volume in (
         ("wif_extended_paradex", "WIF-USD-PERP", 1_000_000.0, 1_000_000.0),
         ("ton_extended_paradex", "TON-USD-PERP", None, 1_000_000.0),
@@ -1324,6 +1380,14 @@ def test_funding_universe_canary_approval_proposals_shortlist_matches_live_polic
             )
         )
     calls: list[dict[str, object]] = []
+    selector_calls: list[dict[str, Any]] = []
+    original_selector = app_module._select_canary_reprice_symbols_from_history
+
+    def spy_selector(*args: Any, **kwargs: Any) -> list[str]:
+        selector_calls.append(dict(kwargs))
+        return original_selector(*args, **kwargs)
+
+    monkeypatch.setattr(app_module, "_select_canary_reprice_symbols_from_history", spy_selector)
 
     class StubUniverseService:
         async def scan_canary_candidates(
@@ -1344,6 +1408,7 @@ def test_funding_universe_canary_approval_proposals_shortlist_matches_live_polic
             return []
 
     app.dependency_overrides[get_history_store] = lambda: store
+    app.dependency_overrides[get_current_utc_time] = lambda: FIXED_APPROVAL_PROPOSAL_NOW
     app.dependency_overrides[get_opportunity_universe_service] = lambda: StubUniverseService()
     app.dependency_overrides[get_route_approval_service] = lambda: StubRouteApprovalService()
     try:
@@ -1361,6 +1426,9 @@ def test_funding_universe_canary_approval_proposals_shortlist_matches_live_polic
         app.dependency_overrides.clear()
 
     assert response.status_code == 200
+    assert len(selector_calls) == 1
+    assert selector_calls[0]["now"] == FIXED_APPROVAL_PROPOSAL_NOW
+    assert selector_calls[0]["exclude_tags"] == ["meme", "political"]
     assert len(calls) == 1
     assert calls[0]["include_symbols"] is None
     assert calls[0]["exclude_tags"] == ["meme", "political"]
@@ -1368,11 +1436,12 @@ def test_funding_universe_canary_approval_proposals_shortlist_matches_live_polic
 
 def test_funding_universe_canary_approval_proposals_ignores_stale_history_shortlist(
     tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     store = OpportunityHistoryStore(tmp_path / "history.sqlite3")
     store.append(
         OpportunityRecord(
-            recorded_at=datetime.now(UTC) - timedelta(hours=2),
+            recorded_at=FIXED_APPROVAL_PROPOSAL_NOW - timedelta(hours=2),
             pair=FundingPairSpec(
                 label="ton_extended_paradex",
                 left_venue="extended",
@@ -1405,6 +1474,14 @@ def test_funding_universe_canary_approval_proposals_ignores_stale_history_shortl
         )
     )
     captured: dict[str, object] = {}
+    selector_calls: list[dict[str, Any]] = []
+    original_selector = app_module._select_canary_reprice_symbols_from_history
+
+    def spy_selector(*args: Any, **kwargs: Any) -> list[str]:
+        selector_calls.append(dict(kwargs))
+        return original_selector(*args, **kwargs)
+
+    monkeypatch.setattr(app_module, "_select_canary_reprice_symbols_from_history", spy_selector)
 
     class StubUniverseService:
         async def scan_canary_candidates(
@@ -1425,6 +1502,7 @@ def test_funding_universe_canary_approval_proposals_ignores_stale_history_shortl
             return []
 
     app.dependency_overrides[get_history_store] = lambda: store
+    app.dependency_overrides[get_current_utc_time] = lambda: FIXED_APPROVAL_PROPOSAL_NOW
     app.dependency_overrides[get_opportunity_universe_service] = lambda: StubUniverseService()
     app.dependency_overrides[get_route_approval_service] = lambda: StubRouteApprovalService()
     try:
@@ -1441,6 +1519,12 @@ def test_funding_universe_canary_approval_proposals_ignores_stale_history_shortl
         app.dependency_overrides.clear()
 
     assert response.status_code == 200
+    assert len(selector_calls) == 1
+    assert selector_calls[0]["now"] == FIXED_APPROVAL_PROPOSAL_NOW
+    assert (
+        selector_calls[0]["max_age_seconds"]
+        == app_module.DEFAULT_HISTORY_SHORTLIST_MAX_AGE_SECONDS
+    )
     assert captured["include_symbols"] is None
 
 
@@ -1450,7 +1534,7 @@ def test_funding_universe_canary_approval_proposals_falls_back_when_shortlist_mi
     store = OpportunityHistoryStore(tmp_path / "history.sqlite3")
     store.append(
         OpportunityRecord(
-            recorded_at=datetime.now(UTC),
+            recorded_at=FIXED_APPROVAL_PROPOSAL_NOW,
             pair=FundingPairSpec(
                 label="ton_extended_paradex",
                 left_venue="extended",
@@ -1542,6 +1626,7 @@ def test_funding_universe_canary_approval_proposals_falls_back_when_shortlist_mi
             return []
 
     app.dependency_overrides[get_history_store] = lambda: store
+    app.dependency_overrides[get_current_utc_time] = lambda: FIXED_APPROVAL_PROPOSAL_NOW
     app.dependency_overrides[get_opportunity_universe_service] = lambda: StubUniverseService()
     app.dependency_overrides[get_route_approval_service] = lambda: StubRouteApprovalService()
     try:
@@ -1568,7 +1653,7 @@ def test_funding_universe_canary_approval_proposals_preserves_explicit_symbols(
     store = OpportunityHistoryStore(tmp_path / "history.sqlite3")
     store.append(
         OpportunityRecord(
-            recorded_at=datetime.now(UTC),
+            recorded_at=FIXED_APPROVAL_PROPOSAL_NOW,
             pair=FundingPairSpec(
                 label="ton_extended_paradex",
                 left_venue="extended",
@@ -1621,6 +1706,7 @@ def test_funding_universe_canary_approval_proposals_preserves_explicit_symbols(
             return []
 
     app.dependency_overrides[get_history_store] = lambda: store
+    app.dependency_overrides[get_current_utc_time] = lambda: FIXED_APPROVAL_PROPOSAL_NOW
     app.dependency_overrides[get_opportunity_universe_service] = lambda: StubUniverseService()
     app.dependency_overrides[get_route_approval_service] = lambda: StubRouteApprovalService()
     try:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1155,6 +1155,7 @@ def test_funding_universe_canary_approval_proposals_rejects_unbounded_history_sh
     tmp_path: Path,
 ) -> None:
     called = False
+    proposal_called = False
 
     class StubUniverseService:
         async def scan_canary_candidates(
@@ -1171,6 +1172,8 @@ def test_funding_universe_canary_approval_proposals_rejects_unbounded_history_sh
             *,
             limit: int,
         ) -> list[FundingUniverseCanaryApprovalProposal]:
+            nonlocal proposal_called
+            proposal_called = True
             assert candidates == []
             assert limit == 1
             return []
@@ -1200,12 +1203,14 @@ def test_funding_universe_canary_approval_proposals_rejects_unbounded_history_sh
         f"{app_module.MAX_HISTORY_SHORTLIST_MAX_AGE_SECONDS}"
     )
     assert called is False
+    assert proposal_called is False
 
 
 def test_funding_universe_canary_approval_proposals_rejects_zero_history_shortlist_age(
     tmp_path: Path,
 ) -> None:
     called = False
+    proposal_called = False
 
     class StubUniverseService:
         async def scan_canary_candidates(
@@ -1222,6 +1227,8 @@ def test_funding_universe_canary_approval_proposals_rejects_zero_history_shortli
             *,
             limit: int,
         ) -> list[FundingUniverseCanaryApprovalProposal]:
+            nonlocal proposal_called
+            proposal_called = True
             assert candidates == []
             assert limit == 1
             return []
@@ -1248,6 +1255,7 @@ def test_funding_universe_canary_approval_proposals_rejects_zero_history_shortli
         response.json()["detail"] == "history_shortlist_max_age_seconds must be at least 1"
     )
     assert called is False
+    assert proposal_called is False
 
 
 def test_funding_universe_canary_approval_proposals_uses_history_shortlist(
@@ -1707,6 +1715,7 @@ def test_funding_universe_canary_approval_proposals_falls_back_when_shortlist_mi
 
     assert response.status_code == 200
     assert [call["include_symbols"] for call in calls] == [["TON-USD-PERP"], None]
+    assert [call["limit"] for call in calls] == [50, 2]
 
 
 def test_funding_universe_canary_approval_proposals_preserves_explicit_symbols(
@@ -1786,6 +1795,95 @@ def test_funding_universe_canary_approval_proposals_preserves_explicit_symbols(
 
     assert response.status_code == 200
     assert captured["include_symbols"] == ["S-USD-PERP"]
+
+
+def test_funding_universe_canary_approval_proposals_can_bypass_history_shortlist(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = OpportunityHistoryStore(tmp_path / "history.sqlite3")
+    store.append(
+        OpportunityRecord(
+            recorded_at=FIXED_APPROVAL_PROPOSAL_NOW,
+            pair=FundingPairSpec(
+                label="ton_extended_paradex",
+                left_venue="extended",
+                left_symbol="TON-USD",
+                left_fee_profile="default",
+                right_venue="paradex",
+                right_symbol="TON-USD-PERP",
+                right_fee_profile="pro_fastfills",
+            ),
+            opportunity=FundingArbOpportunity(
+                canonical_symbol="TON-USD-PERP",
+                long_venue="paradex",
+                short_venue="extended",
+                long_fee_profile="pro_fastfills",
+                short_fee_profile="default",
+                gross_daily_edge=0.004,
+                entry_cost_rate=0.0003,
+                round_trip_cost_rate=0.0006,
+                one_day_net_edge_after_entry=0.0037,
+                one_day_net_edge_after_round_trip=0.0034,
+                break_even_days_entry=0.2,
+                break_even_days_round_trip=0.4,
+                capacity=CapacityEstimate(
+                    short_bid_notional=2_500.0,
+                    long_ask_notional=2_000.0,
+                    max_entry_notional=2_000.0,
+                    limiting_venue="paradex",
+                ),
+            ),
+        )
+    )
+    selector_calls: list[dict[str, Any]] = []
+
+    def spy_selector(*_: Any, **kwargs: Any) -> list[str]:
+        selector_calls.append(dict(kwargs))
+        return ["TON-USD-PERP"]
+
+    monkeypatch.setattr(app_module, "_select_canary_reprice_symbols_from_history", spy_selector)
+    captured: dict[str, object] = {}
+
+    class StubUniverseService:
+        async def scan_canary_candidates(
+            self, **kwargs: object
+        ) -> list[FundingUniverseCanaryCandidate]:
+            captured.update(kwargs)
+            return []
+
+    class StubRouteApprovalService:
+        def propose_canary_route_approvals(
+            self,
+            candidates: list[FundingUniverseCanaryCandidate],
+            *,
+            limit: int,
+        ) -> list[FundingUniverseCanaryApprovalProposal]:
+            assert candidates == []
+            assert limit == 2
+            return []
+
+    app.dependency_overrides[get_history_store] = lambda: store
+    app.dependency_overrides[get_current_utc_time] = lambda: FIXED_APPROVAL_PROPOSAL_NOW
+    app.dependency_overrides[get_opportunity_universe_service] = lambda: StubUniverseService()
+    app.dependency_overrides[get_route_approval_service] = lambda: StubRouteApprovalService()
+    try:
+        client = TestClient(app)
+        response = client.get(
+            "/v1/opportunities/funding-universe/canary/approval-proposals",
+            params=[
+                ("venues", "extended"),
+                ("venues", "paradex"),
+                ("limit", "2"),
+                ("use_history_shortlist", "false"),
+            ],
+        )
+    finally:
+        app.dependency_overrides.clear()
+
+    assert response.status_code == 200
+    assert selector_calls == []
+    assert captured["include_symbols"] is None
 
 
 def test_funding_universe_canary_approval_proposals_filters_fee_overrides_to_selected_venues(

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1252,6 +1252,214 @@ def test_funding_universe_canary_approval_proposals_uses_history_shortlist(
             limit: int,
         ) -> list[FundingUniverseCanaryApprovalProposal]:
             assert candidates == [candidate]
+            assert limit == 1
+            return []
+
+    app.dependency_overrides[get_history_store] = lambda: store
+    app.dependency_overrides[get_opportunity_universe_service] = lambda: StubUniverseService()
+    app.dependency_overrides[get_route_approval_service] = lambda: StubRouteApprovalService()
+    try:
+        client = TestClient(app)
+        response = client.get(
+            "/v1/opportunities/funding-universe/canary/approval-proposals",
+            params=[
+                ("venues", "extended"),
+                ("venues", "paradex"),
+                ("limit", "1"),
+                ("history_shortlist_limit", "2"),
+                ("history_shortlist_sample", "20"),
+            ],
+        )
+    finally:
+        app.dependency_overrides.clear()
+
+    assert response.status_code == 200
+    assert captured["include_symbols"] == ["TON-USD-PERP", "ZRO-USD-PERP"]
+    assert captured["limit"] == 50
+
+
+def test_funding_universe_canary_approval_proposals_shortlist_matches_live_policy(
+    tmp_path: Path,
+) -> None:
+    store = OpportunityHistoryStore(tmp_path / "history.sqlite3")
+    now = datetime(2026, 3, 29, 12, 0, tzinfo=UTC)
+    for label, symbol, short_daily_volume, long_daily_volume in (
+        ("wif_extended_paradex", "WIF-USD-PERP", 1_000_000.0, 1_000_000.0),
+        ("ton_extended_paradex", "TON-USD-PERP", None, 1_000_000.0),
+    ):
+        store.append(
+            OpportunityRecord(
+                recorded_at=now,
+                pair=FundingPairSpec(
+                    label=label,
+                    left_venue="extended",
+                    left_symbol=symbol.removesuffix("-PERP"),
+                    left_fee_profile="default",
+                    right_venue="paradex",
+                    right_symbol=symbol,
+                    right_fee_profile="pro_fastfills",
+                ),
+                opportunity=FundingArbOpportunity(
+                    canonical_symbol=symbol,
+                    long_venue="paradex",
+                    short_venue="extended",
+                    long_fee_profile="pro_fastfills",
+                    short_fee_profile="default",
+                    gross_daily_edge=0.004,
+                    entry_cost_rate=0.0003,
+                    round_trip_cost_rate=0.0006,
+                    one_day_net_edge_after_entry=0.0037,
+                    one_day_net_edge_after_round_trip=0.0034,
+                    break_even_days_entry=0.2,
+                    break_even_days_round_trip=0.4,
+                    short_daily_volume=short_daily_volume,
+                    long_daily_volume=long_daily_volume,
+                    capacity=CapacityEstimate(
+                        short_bid_notional=2_500.0,
+                        long_ask_notional=2_000.0,
+                        max_entry_notional=2_000.0,
+                        limiting_venue="paradex",
+                    ),
+                ),
+            )
+        )
+    calls: list[dict[str, object]] = []
+
+    class StubUniverseService:
+        async def scan_canary_candidates(
+            self, **kwargs: object
+        ) -> list[FundingUniverseCanaryCandidate]:
+            calls.append(kwargs)
+            return []
+
+    class StubRouteApprovalService:
+        def propose_canary_route_approvals(
+            self,
+            candidates: list[FundingUniverseCanaryCandidate],
+            *,
+            limit: int,
+        ) -> list[FundingUniverseCanaryApprovalProposal]:
+            assert candidates == []
+            assert limit == 2
+            return []
+
+    app.dependency_overrides[get_history_store] = lambda: store
+    app.dependency_overrides[get_opportunity_universe_service] = lambda: StubUniverseService()
+    app.dependency_overrides[get_route_approval_service] = lambda: StubRouteApprovalService()
+    try:
+        client = TestClient(app)
+        response = client.get(
+            "/v1/opportunities/funding-universe/canary/approval-proposals",
+            params=[
+                ("venues", "extended"),
+                ("venues", "paradex"),
+                ("limit", "2"),
+                ("min_daily_volume", "100000"),
+            ],
+        )
+    finally:
+        app.dependency_overrides.clear()
+
+    assert response.status_code == 200
+    assert len(calls) == 1
+    assert calls[0]["include_symbols"] is None
+    assert calls[0]["exclude_tags"] == ["meme", "political"]
+
+
+def test_funding_universe_canary_approval_proposals_falls_back_when_shortlist_misses(
+    tmp_path: Path,
+) -> None:
+    store = OpportunityHistoryStore(tmp_path / "history.sqlite3")
+    store.append(
+        OpportunityRecord(
+            recorded_at=datetime(2026, 3, 29, 12, 0, tzinfo=UTC),
+            pair=FundingPairSpec(
+                label="ton_extended_paradex",
+                left_venue="extended",
+                left_symbol="TON-USD",
+                left_fee_profile="default",
+                right_venue="paradex",
+                right_symbol="TON-USD-PERP",
+                right_fee_profile="pro_fastfills",
+            ),
+            opportunity=FundingArbOpportunity(
+                canonical_symbol="TON-USD-PERP",
+                long_venue="paradex",
+                short_venue="extended",
+                long_fee_profile="pro_fastfills",
+                short_fee_profile="default",
+                gross_daily_edge=0.004,
+                entry_cost_rate=0.0003,
+                round_trip_cost_rate=0.0006,
+                one_day_net_edge_after_entry=0.0037,
+                one_day_net_edge_after_round_trip=0.0034,
+                break_even_days_entry=0.2,
+                break_even_days_round_trip=0.4,
+                capacity=CapacityEstimate(
+                    short_bid_notional=2_500.0,
+                    long_ask_notional=2_000.0,
+                    max_entry_notional=2_000.0,
+                    limiting_venue="paradex",
+                ),
+            ),
+        )
+    )
+    fallback_candidate = FundingUniverseCanaryCandidate(
+        opportunity=FundingUniverseOpportunity(
+            opportunity=FundingArbOpportunity(
+                canonical_symbol="ZRO-USD-PERP",
+                long_venue="paradex",
+                short_venue="extended",
+                long_fee_profile="pro_fastfills",
+                short_fee_profile="default",
+                gross_daily_edge=0.004,
+                entry_cost_rate=0.00045,
+                round_trip_cost_rate=0.0009,
+                one_day_net_edge_after_entry=0.00355,
+                one_day_net_edge_after_round_trip=0.0031,
+                break_even_days_entry=0.2,
+                break_even_days_round_trip=0.3,
+                capacity=CapacityEstimate(
+                    short_bid_notional=1_400.0,
+                    long_ask_notional=900.0,
+                    max_entry_notional=900.0,
+                    limiting_venue="paradex",
+                ),
+            ),
+            venue_markets={
+                "extended": FundingUniverseVenueMarket(
+                    venue="extended",
+                    symbol="ZRO-USD",
+                ),
+                "paradex": FundingUniverseVenueMarket(
+                    venue="paradex",
+                    symbol="ZRO-USD-PERP",
+                ),
+            },
+            deployable_notional=900.0,
+            estimated_one_day_pnl_after_round_trip=2.79,
+        ),
+        suggested_canary_notional=25.0,
+    )
+    calls: list[dict[str, object]] = []
+
+    class StubUniverseService:
+        async def scan_canary_candidates(
+            self, **kwargs: object
+        ) -> list[FundingUniverseCanaryCandidate]:
+            calls.append(kwargs)
+            if kwargs["include_symbols"] is None:
+                return [fallback_candidate]
+            return []
+
+    class StubRouteApprovalService:
+        def propose_canary_route_approvals(
+            self,
+            candidates: list[FundingUniverseCanaryCandidate],
+            *,
+            limit: int,
+        ) -> list[FundingUniverseCanaryApprovalProposal]:
+            assert candidates == [fallback_candidate]
             assert limit == 2
             return []
 
@@ -1267,15 +1475,13 @@ def test_funding_universe_canary_approval_proposals_uses_history_shortlist(
                 ("venues", "paradex"),
                 ("limit", "2"),
                 ("history_shortlist_limit", "2"),
-                ("history_shortlist_sample", "20"),
             ],
         )
     finally:
         app.dependency_overrides.clear()
 
     assert response.status_code == 200
-    assert captured["include_symbols"] == ["TON-USD-PERP", "ZRO-USD-PERP"]
-    assert captured["limit"] == 2
+    assert [call["include_symbols"] for call in calls] == [["TON-USD-PERP"], None]
 
 
 def test_funding_universe_canary_approval_proposals_preserves_explicit_symbols(

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -3914,6 +3914,37 @@ def test_scan_exact_canary_candidate_for_approval_skips_route_stability_index(
     assert captured["use_route_stability"] is False
 
 
+def test_scan_canary_candidates_preserves_explicit_empty_exclude_tags(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = OpportunityUniverseService()
+    captured: dict[str, object] = {}
+
+    async def scan(**kwargs: object) -> FundingUniverseScan:
+        captured.update(kwargs)
+        return FundingUniverseScan(
+            venues=["extended", "paradex"],
+            ranking="route_adjusted_quality_pnl",
+            target_notional=5_000.0,
+            overlap_count=0,
+            opportunities=[],
+        )
+
+    monkeypatch.setattr(service, "scan", scan)
+
+    async def run() -> None:
+        candidates = await service.scan_canary_candidates(
+            venues=["extended", "paradex"],
+            exclude_tags=[],
+            limit=5,
+        )
+        assert candidates == []
+
+    asyncio.run(run())
+
+    assert captured["exclude_tags"] == []
+
+
 def test_scan_exact_canary_candidate_for_approval_keeps_execution_quality_when_required(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary
- add a history-backed shortlist for canary approval proposal scans when no explicit `include_symbols` filter is provided
- filter saved candidates by selected venues, symbol policy, round-trip edge, capacity, volume, and open interest before live repricing
- preserve explicit `include_symbols` behavior and keep route approvals as the authorization boundary

## Why
The broad approval-proposal path can spend the opportunity window scanning every overlapping market before repricing. This lets production quickly reprice recent high-signal symbols from persisted history and produce reviewable approval proposals without widening live execution caps or approving anything automatically.

## Safety
- Does not auto-approve routes
- Does not launch trades
- Does not increase notional caps, cooldowns, or approval scope
- Falls back to the existing broad scan when history has no shortlist

## Validation
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run ruff check .`
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run pytest -q tests/test_api.py`
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run mypy src apps packages tests`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Approval-proposals endpoint can use a history-backed symbol shortlist with configurable sampling, limits, age bounds, deterministic time handling, and fallback to broader scans; when exclusion is unset it defaults to excluding ["meme","political"].

* **Bug Fixes**
  * Preserve an explicitly empty exclude-tags list instead of applying defaults.
  * Rejects history-shortlist age values above configured bounds.

* **Tests**
  * New tests for shortlist selection, age validation, fallback behavior, explicit-symbol preservation, exclude-tags handling, and venue filtering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->