### PR TITLE
fix: promote current canary approval proposals

### DIFF
--- a/apps/api/src/carryme_api/app.py
+++ b/apps/api/src/carryme_api/app.py
@@ -189,6 +189,8 @@ MUTATING_HTTP_METHODS = frozenset({"POST", "PUT", "PATCH", "DELETE"})
 DEFAULT_CANARY_EXCLUDE_TAGS = ["meme", "political"]
 DEFAULT_HISTORY_SHORTLIST_MAX_AGE_SECONDS = 3600
 MAX_HISTORY_SHORTLIST_MAX_AGE_SECONDS = 30 * 24 * 60 * 60
+DEFAULT_APPROVAL_PROPOSAL_MAX_AGE_SECONDS = 300
+MAX_APPROVAL_PROPOSAL_MAX_AGE_SECONDS = 3600
 MIN_AWARE_UTC_DATETIME = datetime.min.replace(tzinfo=UTC)
 logger = logging.getLogger(__name__)
 _UNIVERSE_SCAN_SEMAPHORE = asyncio.Semaphore(1)
@@ -432,6 +434,106 @@ def _summarize_canary_approval_proposal(
         pair=proposal.pair,
         approval_payload=proposal.approval_payload,
         existing_approval=proposal.existing_approval,
+    )
+
+
+def _build_approved_route_payload_from_canary_proposal(
+    *,
+    label: str,
+    proposal: FundingUniverseCanaryApprovalProposalSummary,
+    current_time: datetime,
+    max_proposal_age_seconds: int,
+) -> RouteApprovalUpsert:
+    """Return a live-approved route payload from a current operator-reviewed proposal."""
+
+    if max_proposal_age_seconds < 1:
+        raise HTTPException(
+            status_code=400,
+            detail="max_proposal_age_seconds must be at least 1",
+        )
+    if max_proposal_age_seconds > MAX_APPROVAL_PROPOSAL_MAX_AGE_SECONDS:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "max_proposal_age_seconds must be at most "
+                f"{MAX_APPROVAL_PROPOSAL_MAX_AGE_SECONDS}"
+            ),
+        )
+    if proposal.label != label:
+        raise HTTPException(
+            status_code=400,
+            detail="approval proposal label does not match requested route label",
+        )
+    if proposal.pair.label is not None and proposal.pair.label != proposal.label:
+        raise HTTPException(
+            status_code=400,
+            detail="approval proposal pair label does not match requested route label",
+        )
+
+    generated_at = _ensure_aware_utc(proposal.generated_at)
+    checked_at = _ensure_aware_utc(current_time)
+    age_seconds = (checked_at - generated_at).total_seconds()
+    if age_seconds < 0:
+        raise HTTPException(
+            status_code=409,
+            detail="approval proposal was generated in the future",
+        )
+    if age_seconds > max_proposal_age_seconds:
+        raise HTTPException(
+            status_code=409,
+            detail=(
+                "approval proposal is stale "
+                f"({age_seconds:.1f}s > {max_proposal_age_seconds}s)"
+            ),
+        )
+
+    proposal_payload = proposal.approval_payload
+    if proposal_payload.approved:
+        raise HTTPException(
+            status_code=400,
+            detail="approval proposal payload must be unapproved before promotion",
+        )
+
+    identity_fields = (
+        "canonical_symbol",
+        "short_venue",
+        "long_venue",
+        "short_fee_profile",
+        "long_fee_profile",
+    )
+    for field in identity_fields:
+        if getattr(proposal, field) == getattr(proposal_payload, field):
+            continue
+        raise HTTPException(
+            status_code=400,
+            detail=f"approval proposal payload does not match summary field {field}",
+        )
+
+    if (
+        proposal_payload.max_live_notional
+        - proposal.suggested_max_live_notional
+        > 1e-9
+    ):
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "approval proposal payload max_live_notional exceeds the suggested "
+                "proposal cap"
+            ),
+        )
+
+    existing_note = (proposal_payload.note or "").strip()
+    promotion_note = (
+        "Approved from current canary approval proposal "
+        f"generated_at={generated_at.isoformat()} "
+        f"rank={proposal.candidate_rank} status={proposal.approval_status}."
+    )
+    note = f"{existing_note} {promotion_note}".strip()
+    return proposal_payload.model_copy(
+        update={
+            "approved": True,
+            "note": note,
+        }
     )
 
 
@@ -7321,6 +7423,25 @@ def create_app() -> FastAPI:
             raise HTTPException(status_code=400, detail=str(exc)) from exc
         except (ConnectorError, UpstreamDataError, httpx.HTTPError) as exc:
             raise HTTPException(status_code=502, detail=str(exc)) from exc
+
+    @app.post(
+        "/v1/opportunities/funding-universe/canary/approval-proposals/{label}/approve",
+        response_model=RouteApprovalEntry,
+    )
+    def approve_funding_universe_canary_approval_proposal(
+        label: str,
+        service: Annotated[RouteApprovalService, Depends(get_route_approval_service)],
+        payload: Annotated[FundingUniverseCanaryApprovalProposalSummary, Body()],
+        current_time: Annotated[datetime, Depends(get_current_utc_time)],
+        max_proposal_age_seconds: int = DEFAULT_APPROVAL_PROPOSAL_MAX_AGE_SECONDS,
+    ) -> RouteApprovalEntry:
+        approval_payload = _build_approved_route_payload_from_canary_proposal(
+            label=label,
+            proposal=payload,
+            current_time=current_time,
+            max_proposal_age_seconds=max_proposal_age_seconds,
+        )
+        return service.upsert(label=label, payload=approval_payload)
 
     @app.post(
         "/v1/executions/live/canary-cycle/approved-basket",

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -110,6 +110,53 @@ from pydantic import SecretStr, ValidationError
 FIXED_APPROVAL_PROPOSAL_NOW = datetime(2026, 4, 3, 12, 0, tzinfo=UTC)
 
 
+def _canary_approval_proposal_summary_payload(
+    *,
+    generated_at: datetime = FIXED_APPROVAL_PROPOSAL_NOW,
+    label: str = "arb_extended_paradex",
+    pair_label: str | None = "arb_extended_paradex",
+    approval_payload_overrides: dict[str, object] | None = None,
+) -> dict[str, object]:
+    approval_payload: dict[str, object] = {
+        "canonical_symbol": "ARB-USD-PERP",
+        "short_venue": "extended",
+        "long_venue": "paradex",
+        "short_fee_profile": "default",
+        "long_fee_profile": "pro_fastfills",
+        "approved": False,
+        "max_live_notional": 25.0,
+        "note": "Review before approving live canary route.",
+    }
+    approval_payload.update(approval_payload_overrides or {})
+    return {
+        "generated_at": generated_at.isoformat(),
+        "candidate_rank": 1,
+        "label": label,
+        "canonical_symbol": "ARB-USD-PERP",
+        "short_venue": "extended",
+        "long_venue": "paradex",
+        "short_fee_profile": "default",
+        "long_fee_profile": "pro_fastfills",
+        "approval_status": "missing",
+        "suggested_canary_notional": 25.0,
+        "suggested_max_live_notional": 25.0,
+        "deployable_notional": 900.0,
+        "estimated_one_day_pnl_after_round_trip": 2.79,
+        "route_adjusted_quality_score": 0.75,
+        "pair": {
+            "label": pair_label,
+            "left_venue": "extended",
+            "left_symbol": "ARB-USD",
+            "left_fee_profile": "default",
+            "right_venue": "paradex",
+            "right_symbol": "ARB-USD-PERP",
+            "right_fee_profile": "pro_fastfills",
+        },
+        "approval_payload": approval_payload,
+        "existing_approval": None,
+    }
+
+
 def test_health_endpoint() -> None:
     client = TestClient(app)
 
@@ -1149,6 +1196,137 @@ def test_funding_universe_canary_approval_proposals_endpoint_uses_candidate_samp
     assert payload[0]["suggested_canary_notional"] == 25.0
     assert payload[0]["approval_payload"]["approved"] is False
     assert "candidate" not in payload[0]
+
+
+def test_approve_canary_approval_proposal_promotes_current_payload() -> None:
+    captured: dict[str, object] = {}
+
+    class StubRouteApprovalService:
+        def upsert(self, *, label: str, payload: RouteApprovalUpsert) -> RouteApprovalEntry:
+            captured["label"] = label
+            captured["payload"] = payload
+            return RouteApprovalEntry(
+                updated_at=FIXED_APPROVAL_PROPOSAL_NOW,
+                label=label,
+                canonical_symbol=payload.canonical_symbol,
+                short_venue=payload.short_venue,
+                long_venue=payload.long_venue,
+                short_fee_profile=payload.short_fee_profile,
+                long_fee_profile=payload.long_fee_profile,
+                approved=payload.approved,
+                max_live_notional=payload.max_live_notional,
+                note=payload.note,
+            )
+
+    app.dependency_overrides[get_current_utc_time] = lambda: FIXED_APPROVAL_PROPOSAL_NOW
+    app.dependency_overrides[get_route_approval_service] = lambda: StubRouteApprovalService()
+    try:
+        client = TestClient(app)
+        response = client.post(
+            "/v1/opportunities/funding-universe/canary/approval-proposals/"
+            "arb_extended_paradex/approve",
+            json=_canary_approval_proposal_summary_payload(),
+        )
+    finally:
+        app.dependency_overrides.clear()
+
+    assert response.status_code == 200
+    assert captured["label"] == "arb_extended_paradex"
+    promoted = cast(RouteApprovalUpsert, captured["payload"])
+    assert promoted.approved is True
+    assert promoted.max_live_notional == 25.0
+    assert promoted.canonical_symbol == "ARB-USD-PERP"
+    assert promoted.note is not None
+    assert "Approved from current canary approval proposal" in promoted.note
+    assert response.json()["approved"] is True
+
+
+def test_approve_canary_approval_proposal_rejects_stale_payload() -> None:
+    called = False
+
+    class StubRouteApprovalService:
+        def upsert(self, *, label: str, payload: RouteApprovalUpsert) -> RouteApprovalEntry:
+            nonlocal called
+            called = True
+            raise AssertionError("stale proposal must not be promoted")
+
+    app.dependency_overrides[get_current_utc_time] = lambda: FIXED_APPROVAL_PROPOSAL_NOW
+    app.dependency_overrides[get_route_approval_service] = lambda: StubRouteApprovalService()
+    try:
+        client = TestClient(app)
+        response = client.post(
+            "/v1/opportunities/funding-universe/canary/approval-proposals/"
+            "arb_extended_paradex/approve",
+            json=_canary_approval_proposal_summary_payload(
+                generated_at=FIXED_APPROVAL_PROPOSAL_NOW - timedelta(seconds=301)
+            ),
+        )
+    finally:
+        app.dependency_overrides.clear()
+
+    assert response.status_code == 409
+    assert response.json()["detail"] == "approval proposal is stale (301.0s > 300s)"
+    assert called is False
+
+
+def test_approve_canary_approval_proposal_rejects_identity_mismatch() -> None:
+    called = False
+
+    class StubRouteApprovalService:
+        def upsert(self, *, label: str, payload: RouteApprovalUpsert) -> RouteApprovalEntry:
+            nonlocal called
+            called = True
+            raise AssertionError("mismatched proposal must not be promoted")
+
+    app.dependency_overrides[get_current_utc_time] = lambda: FIXED_APPROVAL_PROPOSAL_NOW
+    app.dependency_overrides[get_route_approval_service] = lambda: StubRouteApprovalService()
+    try:
+        client = TestClient(app)
+        response = client.post(
+            "/v1/opportunities/funding-universe/canary/approval-proposals/"
+            "arb_extended_paradex/approve",
+            json=_canary_approval_proposal_summary_payload(
+                approval_payload_overrides={"long_fee_profile": "vip"}
+            ),
+        )
+    finally:
+        app.dependency_overrides.clear()
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == (
+        "approval proposal payload does not match summary field long_fee_profile"
+    )
+    assert called is False
+
+
+def test_approve_canary_approval_proposal_rejects_cap_above_proposal() -> None:
+    called = False
+
+    class StubRouteApprovalService:
+        def upsert(self, *, label: str, payload: RouteApprovalUpsert) -> RouteApprovalEntry:
+            nonlocal called
+            called = True
+            raise AssertionError("cap-widening proposal must not be promoted")
+
+    app.dependency_overrides[get_current_utc_time] = lambda: FIXED_APPROVAL_PROPOSAL_NOW
+    app.dependency_overrides[get_route_approval_service] = lambda: StubRouteApprovalService()
+    try:
+        client = TestClient(app)
+        response = client.post(
+            "/v1/opportunities/funding-universe/canary/approval-proposals/"
+            "arb_extended_paradex/approve",
+            json=_canary_approval_proposal_summary_payload(
+                approval_payload_overrides={"max_live_notional": 30.0}
+            ),
+        )
+    finally:
+        app.dependency_overrides.clear()
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == (
+        "approval proposal payload max_live_notional exceeds the suggested proposal cap"
+    )
+    assert called is False
 
 
 def test_funding_universe_canary_approval_proposals_rejects_unbounded_history_shortlist_age(


### PR DESCRIPTION
## Summary
- add a protected endpoint to promote a current canary approval proposal into a live route approval
- reject stale, future-dated, label-mismatched, identity-mismatched, pre-approved, or cap-widening proposal payloads
- preserve the existing operator-token middleware and `RouteApprovalService.upsert` as the write path for route approvals

## Why
Dynamic discovery can now surface better current routes, but manually copying proposal JSON into the generic route-approval PUT is slow and error-prone during short-lived funding opportunities. This keeps route approvals as the authorization boundary while making the operator promotion step deterministic and bounded.

## Validation
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run pytest -q tests/test_api.py -k 'approval_proposal'`
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run pytest -q tests/test_api.py`
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run ruff check .`
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run mypy src apps packages tests`

## Notes
- The default proposal freshness window is 300 seconds and cannot be raised above 3600 seconds.
- The endpoint never raises `max_live_notional` above the proposal payload cap.
- This does not auto-approve discoveries in the background; a mutating operator-authenticated request is still required.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new operator endpoint for approving funding universe canary proposals with built-in validation of proposal age, consistency, and notional constraints.

* **Tests**
  * Added comprehensive test coverage for the approval endpoint, including validation of edge cases and error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->