### PR TITLE
fix: refresh approved snapshot when promoting proposals

### DIFF
--- a/apps/api/src/carryme_api/app.py
+++ b/apps/api/src/carryme_api/app.py
@@ -129,7 +129,10 @@ from carryme_runtime import (
 )
 from carryme_runtime.execution_order_state import ExecutionLegOrderObserver
 from carryme_runtime.pair_close_preview import _pair_close_hash, select_pair_close_preview_venues
-from carryme_runtime.route_approvals import scan_exact_canary_candidate_for_approval
+from carryme_runtime.route_approvals import (
+    scan_exact_canary_candidate_for_approval,
+    scan_live_route_candidate_for_approval,
+)
 from carryme_runtime.universe_policy import passes_symbol_policy
 from carryme_storage import (
     ApprovedCanaryAlertStore,
@@ -534,6 +537,77 @@ def _build_approved_route_payload_from_canary_proposal(
             "approved": True,
             "note": note,
         }
+    )
+
+
+async def _scan_current_approved_canary_snapshot_for_promoted_proposal(
+    *,
+    universe_service: OpportunityUniverseService,
+    approval: RouteApprovalEntry,
+    now: datetime,
+    target_notional: float,
+    canary_max_notional: float,
+    min_capacity_notional: float,
+    min_daily_volume: float,
+    min_open_interest: float,
+    min_roundtrip_edge: float,
+    min_execution_quality_score: float,
+    min_execution_samples: int,
+    min_route_stability_weight: float,
+    min_route_presence_ratio: float,
+    min_route_samples: int,
+    exclude_tags: list[str] | None,
+) -> ApprovedCanarySnapshot:
+    """Return a fresh approved canary snapshot for a just-promoted route."""
+
+    _validate_route_stability_filters(
+        min_route_stability_weight=min_route_stability_weight,
+        min_route_presence_ratio=min_route_presence_ratio,
+        min_route_samples=min_route_samples,
+    )
+    candidate, _ = await _run_bounded_universe_scan(
+        "canary approval proposal promotion refresh",
+        lambda: scan_live_route_candidate_for_approval(
+            scanner=universe_service,
+            approval=approval,
+            venues=[approval.short_venue, approval.long_venue],
+            fee_profile_overrides=None,
+            target_notional=target_notional,
+            canary_max_notional=canary_max_notional,
+            min_capacity_notional=min_capacity_notional,
+            min_daily_volume=min_daily_volume,
+            min_open_interest=min_open_interest,
+            min_roundtrip_edge=min_roundtrip_edge,
+            min_execution_quality_score=min_execution_quality_score,
+            min_execution_samples=min_execution_samples,
+            min_route_stability_weight=min_route_stability_weight,
+            min_route_presence_ratio=min_route_presence_ratio,
+            min_route_samples=min_route_samples,
+            include_symbols=None,
+            exclude_symbols=None,
+            exclude_tags=exclude_tags,
+            limit=1,
+        ),
+    )
+    if candidate is None:
+        raise HTTPException(
+            status_code=409,
+            detail="approved proposal no longer matches a current live canary route",
+        )
+
+    capped_notional = min(candidate.suggested_canary_notional, approval.max_live_notional)
+    if capped_notional <= 0:
+        raise HTTPException(
+            status_code=409,
+            detail="approved proposal no longer permits a positive live notional",
+        )
+    return ApprovedCanarySnapshot(
+        captured_at=now,
+        label=approval.label,
+        candidate=candidate.model_copy(
+            update={"suggested_canary_notional": capped_notional}
+        ),
+        approval=approval,
     )
 
 
@@ -7442,6 +7516,79 @@ def create_app() -> FastAPI:
             max_proposal_age_seconds=max_proposal_age_seconds,
         )
         return service.upsert(label=label, payload=approval_payload)
+
+    @app.post(
+        "/v1/opportunities/funding-universe/canary/approval-proposals/"
+        "{label}/approve-and-refresh",
+        response_model=ApprovedCanarySnapshot,
+    )
+    async def approve_and_refresh_funding_universe_canary_approval_proposal(
+        label: str,
+        universe_service: Annotated[
+            OpportunityUniverseService,
+            Depends(get_opportunity_universe_service),
+        ],
+        approval_service: Annotated[
+            RouteApprovalService,
+            Depends(get_route_approval_service),
+        ],
+        approved_store: Annotated[
+            ApprovedCanaryStore,
+            Depends(get_approved_canary_store),
+        ],
+        payload: Annotated[FundingUniverseCanaryApprovalProposalSummary, Body()],
+        current_time: Annotated[datetime, Depends(get_current_utc_time)],
+        max_proposal_age_seconds: int = DEFAULT_APPROVAL_PROPOSAL_MAX_AGE_SECONDS,
+        target_notional: float = 5_000.0,
+        canary_max_notional: float = 25.0,
+        min_capacity_notional: float = 25.0,
+        min_daily_volume: float = 0.0,
+        min_open_interest: float = 0.0,
+        min_roundtrip_edge: float = 0.0,
+        min_execution_quality_score: float = 0.5,
+        min_execution_samples: int = 0,
+        min_route_stability_weight: float = 0.10,
+        min_route_presence_ratio: float = 0.15,
+        min_route_samples: int = 2,
+        exclude_tags: Annotated[list[str] | None, Query()] = None,
+    ) -> ApprovedCanarySnapshot:
+        approval_payload = _build_approved_route_payload_from_canary_proposal(
+            label=label,
+            proposal=payload,
+            current_time=current_time,
+            max_proposal_age_seconds=max_proposal_age_seconds,
+        )
+        candidate_approval = RouteApprovalEntry(
+            updated_at=current_time,
+            label=label,
+            canonical_symbol=approval_payload.canonical_symbol,
+            short_venue=approval_payload.short_venue,
+            long_venue=approval_payload.long_venue,
+            short_fee_profile=approval_payload.short_fee_profile,
+            long_fee_profile=approval_payload.long_fee_profile,
+            approved=True,
+            max_live_notional=approval_payload.max_live_notional,
+            note=approval_payload.note,
+        )
+        snapshot = await _scan_current_approved_canary_snapshot_for_promoted_proposal(
+            universe_service=universe_service,
+            approval=candidate_approval,
+            now=current_time,
+            target_notional=target_notional,
+            canary_max_notional=canary_max_notional,
+            min_capacity_notional=min_capacity_notional,
+            min_daily_volume=min_daily_volume,
+            min_open_interest=min_open_interest,
+            min_roundtrip_edge=min_roundtrip_edge,
+            min_execution_quality_score=min_execution_quality_score,
+            min_execution_samples=min_execution_samples,
+            min_route_stability_weight=min_route_stability_weight,
+            min_route_presence_ratio=min_route_presence_ratio,
+            min_route_samples=min_route_samples,
+            exclude_tags=DEFAULT_CANARY_EXCLUDE_TAGS if exclude_tags is None else exclude_tags,
+        )
+        persisted_approval = approval_service.upsert(label=label, payload=approval_payload)
+        return approved_store.append(snapshot.model_copy(update={"approval": persisted_approval}))
 
     @app.post(
         "/v1/executions/live/canary-cycle/approved-basket",

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -157,6 +157,49 @@ def _canary_approval_proposal_summary_payload(
     }
 
 
+def _arb_extended_paradex_canary_candidate(
+    *,
+    suggested_canary_notional: float = 25.0,
+) -> FundingUniverseCanaryCandidate:
+    return FundingUniverseCanaryCandidate(
+        opportunity=FundingUniverseOpportunity(
+            opportunity=FundingArbOpportunity(
+                canonical_symbol="ARB-USD-PERP",
+                long_venue="paradex",
+                short_venue="extended",
+                long_fee_profile="pro_fastfills",
+                short_fee_profile="default",
+                gross_daily_edge=0.004,
+                entry_cost_rate=0.00045,
+                round_trip_cost_rate=0.0009,
+                one_day_net_edge_after_entry=0.00355,
+                one_day_net_edge_after_round_trip=0.0031,
+                break_even_days_entry=0.2,
+                break_even_days_round_trip=0.3,
+                capacity=CapacityEstimate(
+                    short_bid_notional=1400.0,
+                    long_ask_notional=900.0,
+                    max_entry_notional=900.0,
+                    limiting_venue="paradex",
+                ),
+            ),
+            venue_markets={
+                "extended": FundingUniverseVenueMarket(
+                    venue="extended",
+                    symbol="ARB-USD",
+                ),
+                "paradex": FundingUniverseVenueMarket(
+                    venue="paradex",
+                    symbol="ARB-USD-PERP",
+                ),
+            },
+            deployable_notional=900.0,
+            estimated_one_day_pnl_after_round_trip=2.79,
+        ),
+        suggested_canary_notional=suggested_canary_notional,
+    )
+
+
 def test_health_endpoint() -> None:
     client = TestClient(app)
 
@@ -1327,6 +1370,125 @@ def test_approve_canary_approval_proposal_rejects_cap_above_proposal() -> None:
         "approval proposal payload max_live_notional exceeds the suggested proposal cap"
     )
     assert called is False
+
+
+def test_approve_and_refresh_canary_approval_proposal_saves_fresh_snapshot(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    approved_store = ApprovedCanaryStore(tmp_path / "history.sqlite3")
+    captured_scan: dict[str, object] = {}
+    captured_upsert: dict[str, object] = {}
+
+    class StubUniverseService:
+        pass
+
+    class StubRouteApprovalService:
+        def upsert(self, *, label: str, payload: RouteApprovalUpsert) -> RouteApprovalEntry:
+            captured_upsert["label"] = label
+            captured_upsert["payload"] = payload
+            return RouteApprovalEntry(
+                updated_at=FIXED_APPROVAL_PROPOSAL_NOW,
+                label=label,
+                canonical_symbol=payload.canonical_symbol,
+                short_venue=payload.short_venue,
+                long_venue=payload.long_venue,
+                short_fee_profile=payload.short_fee_profile,
+                long_fee_profile=payload.long_fee_profile,
+                approved=payload.approved,
+                max_live_notional=payload.max_live_notional,
+                note=payload.note,
+            )
+
+    async def fake_scan_live_route_candidate_for_approval(
+        **kwargs: object,
+    ) -> tuple[FundingUniverseCanaryCandidate | None, int]:
+        captured_scan.update(kwargs)
+        approval = cast(RouteApprovalEntry, kwargs["approval"])
+        assert approval.approved is True
+        assert approval.max_live_notional == 11.0
+        assert kwargs["venues"] == ["extended", "paradex"]
+        assert kwargs["include_symbols"] is None
+        assert kwargs["exclude_tags"] == app_module.DEFAULT_CANARY_EXCLUDE_TAGS
+        return _arb_extended_paradex_canary_candidate(suggested_canary_notional=25.0), 1
+
+    monkeypatch.setattr(
+        "carryme_api.app.scan_live_route_candidate_for_approval",
+        fake_scan_live_route_candidate_for_approval,
+    )
+    app.dependency_overrides[get_current_utc_time] = lambda: FIXED_APPROVAL_PROPOSAL_NOW
+    app.dependency_overrides[get_opportunity_universe_service] = lambda: StubUniverseService()
+    app.dependency_overrides[get_route_approval_service] = lambda: StubRouteApprovalService()
+    app.dependency_overrides[get_approved_canary_store] = lambda: approved_store
+    try:
+        client = TestClient(app)
+        response = client.post(
+            "/v1/opportunities/funding-universe/canary/approval-proposals/"
+            "arb_extended_paradex/approve-and-refresh",
+            json=_canary_approval_proposal_summary_payload(
+                approval_payload_overrides={"max_live_notional": 11.0}
+            ),
+        )
+    finally:
+        app.dependency_overrides.clear()
+
+    assert response.status_code == 200
+    assert captured_upsert["label"] == "arb_extended_paradex"
+    upsert_payload = cast(RouteApprovalUpsert, captured_upsert["payload"])
+    assert upsert_payload.approved is True
+    payload = response.json()
+    assert payload["snapshot_id"] == 1
+    assert payload["label"] == "arb_extended_paradex"
+    assert payload["candidate"]["suggested_canary_notional"] == 11.0
+    assert payload["approval"]["max_live_notional"] == 11.0
+    assert approved_store.latest(label="arb_extended_paradex") is not None
+
+
+def test_approve_and_refresh_canary_approval_proposal_rejects_decayed_route(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    approved_store = ApprovedCanaryStore(tmp_path / "history.sqlite3")
+    upsert_called = False
+
+    class StubUniverseService:
+        pass
+
+    class StubRouteApprovalService:
+        def upsert(self, *, label: str, payload: RouteApprovalUpsert) -> RouteApprovalEntry:
+            nonlocal upsert_called
+            upsert_called = True
+            raise AssertionError("decayed route must not be approved or snapshotted")
+
+    async def fake_scan_live_route_candidate_for_approval(
+        **_: object,
+    ) -> tuple[FundingUniverseCanaryCandidate | None, int]:
+        return None, 0
+
+    monkeypatch.setattr(
+        "carryme_api.app.scan_live_route_candidate_for_approval",
+        fake_scan_live_route_candidate_for_approval,
+    )
+    app.dependency_overrides[get_current_utc_time] = lambda: FIXED_APPROVAL_PROPOSAL_NOW
+    app.dependency_overrides[get_opportunity_universe_service] = lambda: StubUniverseService()
+    app.dependency_overrides[get_route_approval_service] = lambda: StubRouteApprovalService()
+    app.dependency_overrides[get_approved_canary_store] = lambda: approved_store
+    try:
+        client = TestClient(app)
+        response = client.post(
+            "/v1/opportunities/funding-universe/canary/approval-proposals/"
+            "arb_extended_paradex/approve-and-refresh",
+            json=_canary_approval_proposal_summary_payload(),
+        )
+    finally:
+        app.dependency_overrides.clear()
+
+    assert response.status_code == 409
+    assert response.json()["detail"] == (
+        "approved proposal no longer matches a current live canary route"
+    )
+    assert upsert_called is False
+    assert approved_store.latest(label="arb_extended_paradex") is None
 
 
 def test_funding_universe_canary_approval_proposals_rejects_unbounded_history_shortlist_age(


### PR DESCRIPTION
## Summary
- add an operator-protected `approve-and-refresh` path for fresh canary approval proposals
- revalidate the exact proposed live route before persisting the route approval
- save a fresh approved canary snapshot immediately after promotion so launch-ready cache does not need to wait on the next approved-scan cycle

## Why
PR #245 made proposal approval safer and faster, but production still had a delay: after approval, a background approved-canary scan had to run before the route could become launch-ready. This PR keeps the same approval boundary while eliminating that waiting period for routes that still revalidate live.

## Safety
- stale or malformed proposal payloads still fail through the shared proposal validation helper
- the live route is re-scanned before the approval is persisted
- if the exact route no longer matches, the endpoint returns `409` and does not write approval or snapshot state
- saved snapshots cap `suggested_canary_notional` to the approved route cap

## Validation
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run pytest -q tests/test_api.py -k 'approve_and_refresh or approve_canary_approval_proposal'`
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run pytest -q tests/test_api.py`
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run ruff check .`
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run mypy src apps packages tests`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added endpoint to approve and refresh funding universe canary approval proposals with a single operation, automatically validating route availability and persisting updated snapshots with current parameters.
  * Improved error handling for scenarios where routes are no longer available, with appropriate response codes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->