### PR TITLE
fix: cache launch-ready proposal approvals

### DIFF
--- a/apps/api/src/carryme_api/app.py
+++ b/apps/api/src/carryme_api/app.py
@@ -98,6 +98,7 @@ from carryme_runtime import (
     HyperliquidLiveExecutionService,
     HyperliquidOrderStateObserver,
     InvalidTradeCandidateError,
+    LaunchReadyAutomationGatePolicy,
     MockExecutionAdapter,
     OpportunityService,
     OpportunityUniverseService,
@@ -114,6 +115,8 @@ from carryme_runtime import (
     SystemStateService,
     UpstreamDataError,
     build_account_preflight_configs,
+    build_approved_snapshot_automation_gate_reason,
+    build_candidate_live_execution_preflight,
     build_execution_pair_status,
     build_live_execution_configs,
     build_live_submission_readiness,
@@ -123,6 +126,8 @@ from carryme_runtime import (
     build_portfolio_plan,
     build_trade_intent,
     build_venue_execution_preflights,
+    list_recent_approved_snapshot_chain,
+    probe_candidate_system_state,
     reconcile_execution,
     require_confirmed_cleanup_preview,
     review_required_pair_requires_continued_monitoring,
@@ -3450,6 +3455,129 @@ def _select_latest_launch_ready_canary_snapshot(
             update={"suggested_canary_notional": capped_notional}
         ),
         approval,
+    )
+
+
+def _build_launch_ready_automation_gate_policy(
+    settings: ApiSettings,
+) -> LaunchReadyAutomationGatePolicy:
+    return LaunchReadyAutomationGatePolicy(
+        min_edge_retention_ratio=settings.stable_launch_ready_min_edge_retention_ratio,
+        max_entry_break_even_funding_windows=(
+            settings.stable_launch_ready_max_entry_break_even_funding_windows
+        ),
+        max_round_trip_break_even_funding_windows=(
+            settings.stable_launch_ready_max_round_trip_break_even_funding_windows
+        ),
+    )
+
+
+async def _build_launch_ready_snapshot_for_approved_snapshot(
+    *,
+    settings: ApiSettings,
+    approved_store: ApprovedCanaryStore,
+    system_state_service: SystemStateService,
+    snapshot: ApprovedCanarySnapshot,
+    now: datetime,
+) -> LaunchReadyCanarySnapshot:
+    snapshot_age_seconds = max(0.0, (now - snapshot.captured_at).total_seconds())
+    if snapshot.captured_at > now:
+        raise HTTPException(
+            status_code=409,
+            detail="Approved canary snapshot timestamp is in the future",
+        )
+    if snapshot_age_seconds > settings.launch_ready_canary_max_snapshot_age_seconds:
+        raise HTTPException(
+            status_code=409,
+            detail=(
+                "Approved canary snapshot is stale "
+                f"({snapshot_age_seconds:.1f}s > "
+                f"{settings.launch_ready_canary_max_snapshot_age_seconds}s)"
+            ),
+        )
+    if not snapshot.approval.approved:
+        raise HTTPException(
+            status_code=409,
+            detail="Approved canary snapshot is not approved for live execution",
+        )
+
+    capped_notional = min(
+        snapshot.candidate.suggested_canary_notional,
+        snapshot.approval.max_live_notional,
+    )
+    if capped_notional <= 0:
+        raise HTTPException(
+            status_code=409,
+            detail="Approved canary snapshot no longer permits a positive live notional",
+        )
+
+    refreshed_candidate = snapshot.candidate.model_copy(
+        update={"suggested_canary_notional": capped_notional}
+    )
+    refreshed_snapshot = snapshot.model_copy(
+        update={"candidate": refreshed_candidate}
+    )
+    recent_approved_chain = list_recent_approved_snapshot_chain(
+        recent_snapshots=[
+            refreshed_snapshot,
+            *approved_store.list_recent(limit=20, label=snapshot.label),
+        ],
+        snapshot=refreshed_snapshot,
+        max_snapshot_age_seconds=settings.launch_ready_canary_max_snapshot_age_seconds,
+    )
+    automation_gate_reason = build_approved_snapshot_automation_gate_reason(
+        snapshot=refreshed_snapshot,
+        recent_chain=recent_approved_chain or [refreshed_snapshot],
+        policy=_build_launch_ready_automation_gate_policy(settings),
+    )
+    if automation_gate_reason is not None:
+        raise HTTPException(
+            status_code=409,
+            detail=(
+                "Approved canary snapshot does not satisfy automated launch gates: "
+                f"{automation_gate_reason}"
+            ),
+        )
+
+    execution_preflight = build_candidate_live_execution_preflight(
+        venue_preflights=build_venue_execution_preflights(
+            build_live_execution_configs(settings)
+        ),
+        candidate=refreshed_candidate,
+        label=snapshot.label,
+    )
+    if not execution_preflight.ready:
+        raise HTTPException(
+            status_code=409,
+            detail={
+                "message": "Approved canary snapshot live execution preflight is not ready",
+                "blocking_reasons": execution_preflight.blocking_reasons,
+                "execution_preflight": execution_preflight.model_dump(mode="json"),
+            },
+        )
+
+    system_state = await probe_candidate_system_state(
+        service=system_state_service,
+        configs=_build_system_state_configs(settings),
+        candidate=refreshed_candidate,
+        label=snapshot.label,
+    )
+    if not system_state.ready:
+        raise HTTPException(
+            status_code=409,
+            detail={
+                "message": "Approved canary snapshot system state is not ready",
+                "blocking_reasons": system_state.blocking_reasons,
+                "system_state": system_state.model_dump(mode="json"),
+            },
+        )
+
+    return LaunchReadyCanarySnapshot(
+        captured_at=now,
+        label=snapshot.label,
+        max_snapshot_age_seconds=settings.launch_ready_canary_max_snapshot_age_seconds,
+        approved_snapshot=refreshed_snapshot,
+        system_state=system_state,
     )
 
 
@@ -7589,6 +7717,102 @@ def create_app() -> FastAPI:
         )
         persisted_approval = approval_service.upsert(label=label, payload=approval_payload)
         return approved_store.append(snapshot.model_copy(update={"approval": persisted_approval}))
+
+    @app.post(
+        "/v1/opportunities/funding-universe/canary/approval-proposals/"
+        "{label}/approve-refresh-and-cache-launch-ready",
+        response_model=LaunchReadyCanarySnapshot,
+    )
+    async def approve_refresh_and_cache_launch_ready_canary_proposal(
+        label: str,
+        universe_service: Annotated[
+            OpportunityUniverseService,
+            Depends(get_opportunity_universe_service),
+        ],
+        approval_service: Annotated[
+            RouteApprovalService,
+            Depends(get_route_approval_service),
+        ],
+        approved_store: Annotated[
+            ApprovedCanaryStore,
+            Depends(get_approved_canary_store),
+        ],
+        launch_ready_store: Annotated[
+            LaunchReadyCanaryStore,
+            Depends(get_launch_ready_canary_store),
+        ],
+        system_state_service: Annotated[
+            SystemStateService,
+            Depends(get_system_state_service),
+        ],
+        settings: Annotated[ApiSettings, Depends(get_api_settings)],
+        payload: Annotated[FundingUniverseCanaryApprovalProposalSummary, Body()],
+        current_time: Annotated[datetime, Depends(get_current_utc_time)],
+        max_proposal_age_seconds: int = DEFAULT_APPROVAL_PROPOSAL_MAX_AGE_SECONDS,
+        target_notional: float = 5_000.0,
+        canary_max_notional: float = 25.0,
+        min_capacity_notional: float = 25.0,
+        min_daily_volume: float = 0.0,
+        min_open_interest: float = 0.0,
+        min_roundtrip_edge: float = 0.0,
+        min_execution_quality_score: float = 0.5,
+        min_execution_samples: int = 0,
+        min_route_stability_weight: float = 0.10,
+        min_route_presence_ratio: float = 0.15,
+        min_route_samples: int = 2,
+        exclude_tags: Annotated[list[str] | None, Query()] = None,
+    ) -> LaunchReadyCanarySnapshot:
+        approval_payload = _build_approved_route_payload_from_canary_proposal(
+            label=label,
+            proposal=payload,
+            current_time=current_time,
+            max_proposal_age_seconds=max_proposal_age_seconds,
+        )
+        candidate_approval = RouteApprovalEntry(
+            updated_at=current_time,
+            label=label,
+            canonical_symbol=approval_payload.canonical_symbol,
+            short_venue=approval_payload.short_venue,
+            long_venue=approval_payload.long_venue,
+            short_fee_profile=approval_payload.short_fee_profile,
+            long_fee_profile=approval_payload.long_fee_profile,
+            approved=True,
+            max_live_notional=approval_payload.max_live_notional,
+            note=approval_payload.note,
+        )
+        snapshot = await _scan_current_approved_canary_snapshot_for_promoted_proposal(
+            universe_service=universe_service,
+            approval=candidate_approval,
+            now=current_time,
+            target_notional=target_notional,
+            canary_max_notional=canary_max_notional,
+            min_capacity_notional=min_capacity_notional,
+            min_daily_volume=min_daily_volume,
+            min_open_interest=min_open_interest,
+            min_roundtrip_edge=min_roundtrip_edge,
+            min_execution_quality_score=min_execution_quality_score,
+            min_execution_samples=min_execution_samples,
+            min_route_stability_weight=min_route_stability_weight,
+            min_route_presence_ratio=min_route_presence_ratio,
+            min_route_samples=min_route_samples,
+            exclude_tags=DEFAULT_CANARY_EXCLUDE_TAGS if exclude_tags is None else exclude_tags,
+        )
+        launch_ready_snapshot = await _build_launch_ready_snapshot_for_approved_snapshot(
+            settings=settings,
+            approved_store=approved_store,
+            system_state_service=system_state_service,
+            snapshot=snapshot,
+            now=current_time,
+        )
+        persisted_approval = approval_service.upsert(label=label, payload=approval_payload)
+        persisted_approved_snapshot = approved_store.append(
+            snapshot.model_copy(update={"approval": persisted_approval})
+        )
+        return launch_ready_store.append(
+            launch_ready_snapshot.model_copy(
+                update={"approved_snapshot": persisted_approved_snapshot}
+            )
+        )
 
     @app.post(
         "/v1/executions/live/canary-cycle/approved-basket",

--- a/apps/api/src/carryme_api/config.py
+++ b/apps/api/src/carryme_api/config.py
@@ -40,6 +40,20 @@ class ApiSettings(BaseSettings):
     hyperliquid_account_address: str | None = None
     hyperliquid_vault_address: str | None = None
     hyperliquid_api_wallet_private_key: str | None = None
+    launch_ready_canary_max_snapshot_age_seconds: int = Field(default=300, gt=0)
+    stable_launch_ready_min_edge_retention_ratio: float = Field(
+        default=0.7,
+        ge=0,
+        le=1,
+    )
+    stable_launch_ready_max_entry_break_even_funding_windows: float = Field(
+        default=6.0,
+        gt=0,
+    )
+    stable_launch_ready_max_round_trip_break_even_funding_windows: float = Field(
+        default=12.0,
+        gt=0,
+    )
 
     model_config = SettingsConfigDict(
         env_prefix="CARRYME_API_",

--- a/apps/worker/src/carryme_worker/poller.py
+++ b/apps/worker/src/carryme_worker/poller.py
@@ -55,7 +55,6 @@ from carryme_models import (
     StableCanaryLaunchRecord,
     StableLaunchReadyAlertEvent,
     SystemStateAlertEvent,
-    VenueExecutionPreflight,
     VenueSystemState,
 )
 from carryme_runtime import (
@@ -89,6 +88,37 @@ from carryme_runtime import (
 from carryme_runtime.balance_accounting import FUNDING_WINDOW_CHECKPOINT_STAGE
 from carryme_runtime.execution_order_state import ExecutionLegOrderObserver
 from carryme_runtime.execution_quality import execution_quality_route_key
+from carryme_runtime.launch_ready import (
+    FUNDING_WINDOW_HOURS_BY_VENUE,
+    LaunchReadyAutomationGatePolicy,
+)
+from carryme_runtime.launch_ready import (
+    approved_snapshot_launch_payload_changed as runtime_launch_payload_changed,
+)
+from carryme_runtime.launch_ready import (
+    approved_snapshot_route_key as runtime_approved_snapshot_route_key,
+)
+from carryme_runtime.launch_ready import (
+    build_approved_snapshot_automation_gate_reason as runtime_build_gate_reason,
+)
+from carryme_runtime.launch_ready import (
+    build_candidate_live_execution_preflight as runtime_build_live_preflight,
+)
+from carryme_runtime.launch_ready import (
+    candidate_execution_venue_names as runtime_candidate_venue_names,
+)
+from carryme_runtime.launch_ready import (
+    effective_funding_window_hours as runtime_effective_window_hours,
+)
+from carryme_runtime.launch_ready import (
+    hold_window_hours as runtime_hold_window_hours,
+)
+from carryme_runtime.launch_ready import (
+    list_recent_approved_snapshot_chain as runtime_snapshot_chain,
+)
+from carryme_runtime.launch_ready import (
+    probe_candidate_system_state as runtime_probe_system_state,
+)
 from carryme_runtime.route_approvals import (
     scan_exact_canary_candidate_for_approval,
     scan_live_route_candidate_for_approval,
@@ -126,11 +156,6 @@ from carryme_worker.notifications import (
 
 logger = logging.getLogger(__name__)
 OBSERVATION_CALL_TIMEOUT_SECONDS = 10.0
-FUNDING_WINDOW_HOURS_BY_VENUE: dict[str, float] = {
-    "extended": 1.0,
-    "paradex": 8.0,
-    "hyperliquid": 8.0,
-}
 
 
 def _build_launch_ready_canary_stability(**kwargs: Any) -> LaunchReadyCanaryStability:
@@ -1266,15 +1291,7 @@ def _build_system_state_configs(settings: WorkerSettings) -> SystemStateConfigMa
 def _candidate_execution_venue_names(candidate: FundingUniverseCanaryCandidate) -> list[str]:
     """Return de-duplicated venue names touched by a canary candidate."""
 
-    venue_names = [
-        candidate.opportunity.opportunity.long_venue,
-        candidate.opportunity.opportunity.short_venue,
-    ]
-    selected_names: list[str] = []
-    for venue in venue_names:
-        if venue not in selected_names:
-            selected_names.append(venue)
-    return selected_names
+    return runtime_candidate_venue_names(candidate)
 
 
 def _build_candidate_live_execution_preflight(
@@ -1285,32 +1302,12 @@ def _build_candidate_live_execution_preflight(
 ) -> PaperTradeExecutionPreflight:
     """Build live-execution readiness for the exact venues touched by one canary."""
 
-    all_statuses = {
-        item.venue: item
-        for item in build_venue_execution_preflights(build_live_execution_configs(settings))
-    }
-    selected: list[VenueExecutionPreflight] = []
-    blocking_reasons: list[str] = []
-    for venue in _candidate_execution_venue_names(candidate):
-        status = all_statuses.get(venue)
-        if status is None:
-            blocking_reasons.append(f"Venue {venue} live execution is not configured")
-            continue
-        selected.append(status)
-        if not status.enabled:
-            blocking_reasons.append(f"Venue {venue} live execution is not enabled")
-        if status.missing_env_vars:
-            blocking_reasons.append(
-                f"Venue {venue} is missing required credentials: "
-                + ", ".join(status.missing_env_vars)
-            )
-
-    return PaperTradeExecutionPreflight(
-        paper_trade_id=0,
+    return runtime_build_live_preflight(
+        venue_preflights=build_venue_execution_preflights(
+            build_live_execution_configs(settings)
+        ),
+        candidate=candidate,
         label=label,
-        ready=not blocking_reasons,
-        venues=selected,
-        blocking_reasons=blocking_reasons,
     )
 
 
@@ -1323,26 +1320,11 @@ async def _probe_candidate_system_state(
 ) -> PaperTradeSystemState:
     """Probe only the venues touched by one canary candidate."""
 
-    all_statuses = {
-        item.venue: item
-        for item in await service.probe_venues(_build_system_state_configs(settings))
-    }
-    selected: list[VenueSystemState] = []
-    blocking_reasons: list[str] = []
-    for venue in _candidate_execution_venue_names(candidate):
-        status = all_statuses.get(venue)
-        if status is None:
-            blocking_reasons.append(f"Venue {venue} system state is unknown")
-            continue
-        selected.append(status)
-        blocking_reasons.extend(status.blocking_reasons)
-
-    return PaperTradeSystemState(
-        paper_trade_id=0,
+    return await runtime_probe_system_state(
+        service=service,
+        configs=_build_system_state_configs(settings),
+        candidate=candidate,
         label=label,
-        ready=not blocking_reasons,
-        venues=selected,
-        blocking_reasons=blocking_reasons,
     )
 
 
@@ -1424,53 +1406,7 @@ def _approved_snapshot_route_key(
 ) -> tuple[str, str, str, str, str, str]:
     """Return the normalized identity key for one approved snapshot route."""
 
-    opportunity = snapshot.candidate.opportunity.opportunity
-    return (
-        snapshot.label,
-        opportunity.canonical_symbol,
-        opportunity.short_venue,
-        opportunity.long_venue,
-        opportunity.short_fee_profile,
-        opportunity.long_fee_profile,
-    )
-
-
-def _normalized_approved_snapshot_launch_payload(
-    snapshot: ApprovedCanarySnapshot,
-) -> dict[str, object]:
-    """Return the approved-snapshot fields that must stay fixed for launch safety."""
-
-    candidate = snapshot.candidate
-    opportunity = candidate.opportunity.opportunity
-    approval = snapshot.approval
-    venue_markets = candidate.opportunity.venue_markets
-    return {
-        "label": snapshot.label,
-        "suggested_canary_notional": candidate.suggested_canary_notional,
-        "route": {
-            "canonical_symbol": opportunity.canonical_symbol,
-            "long_venue": opportunity.long_venue,
-            "short_venue": opportunity.short_venue,
-            "long_fee_profile": opportunity.long_fee_profile,
-            "short_fee_profile": opportunity.short_fee_profile,
-            "venue_markets": tuple(
-                sorted(
-                    (venue, market.symbol)
-                    for venue, market in venue_markets.items()
-                )
-            ),
-        },
-        "approval": {
-            "label": approval.label,
-            "canonical_symbol": approval.canonical_symbol,
-            "short_venue": approval.short_venue,
-            "long_venue": approval.long_venue,
-            "short_fee_profile": approval.short_fee_profile,
-            "long_fee_profile": approval.long_fee_profile,
-            "approved": approval.approved,
-            "max_live_notional": approval.max_live_notional,
-        },
-    }
+    return runtime_approved_snapshot_route_key(snapshot)
 
 
 def _approved_snapshot_launch_payload_changed(
@@ -1479,32 +1415,22 @@ def _approved_snapshot_launch_payload_changed(
 ) -> bool:
     """Return whether a newer approved snapshot invalidates stable launch evidence."""
 
-    return (
-        _normalized_approved_snapshot_launch_payload(previous_snapshot)
-        != _normalized_approved_snapshot_launch_payload(current_snapshot)
+    return runtime_launch_payload_changed(
+        previous_snapshot,
+        current_snapshot,
     )
 
 
 def _effective_funding_window_hours(snapshot: ApprovedCanarySnapshot) -> float:
     """Return the fastest relevant funding interval across the route venues."""
 
-    opportunity = snapshot.candidate.opportunity.opportunity
-    hours = [
-        FUNDING_WINDOW_HOURS_BY_VENUE.get(opportunity.short_venue, 8.0),
-        FUNDING_WINDOW_HOURS_BY_VENUE.get(opportunity.long_venue, 8.0),
-    ]
-    return min(hours)
+    return runtime_effective_window_hours(snapshot)
 
 
 def _hold_window_hours(snapshot: ApprovedCanarySnapshot) -> float:
     """Return the slowest relevant funding interval across the route venues."""
 
-    opportunity = snapshot.candidate.opportunity.opportunity
-    hours = [
-        FUNDING_WINDOW_HOURS_BY_VENUE.get(opportunity.short_venue, 8.0),
-        FUNDING_WINDOW_HOURS_BY_VENUE.get(opportunity.long_venue, 8.0),
-    ]
-    return max(hours)
+    return runtime_hold_window_hours(snapshot)
 
 
 def _list_recent_approved_snapshot_chain(
@@ -1516,20 +1442,11 @@ def _list_recent_approved_snapshot_chain(
 ) -> list[ApprovedCanarySnapshot]:
     """Return the recent same-route approved snapshot chain for one label."""
 
-    route_key = _approved_snapshot_route_key(snapshot)
-    recent_snapshots = store.list_recent(limit=limit, label=snapshot.label)
-    chain: list[ApprovedCanarySnapshot] = []
-    for recent_snapshot in recent_snapshots:
-        if _approved_snapshot_route_key(recent_snapshot) != route_key:
-            break
-        age_seconds = max(
-            0.0,
-            (snapshot.captured_at - recent_snapshot.captured_at).total_seconds(),
-        )
-        if age_seconds > max_snapshot_age_seconds:
-            break
-        chain.append(recent_snapshot)
-    return chain
+    return runtime_snapshot_chain(
+        recent_snapshots=store.list_recent(limit=limit, label=snapshot.label),
+        snapshot=snapshot,
+        max_snapshot_age_seconds=max_snapshot_age_seconds,
+    )
 
 
 def _build_approved_snapshot_automation_gate_reason(
@@ -1540,67 +1457,19 @@ def _build_approved_snapshot_automation_gate_reason(
 ) -> str | None:
     """Return the blocking reason for unattended launch-readiness, if any."""
 
-    opportunity = snapshot.candidate.opportunity.opportunity
-    current_entry_edge = opportunity.one_day_net_edge_after_entry
-    current_round_trip_edge = opportunity.one_day_net_edge_after_round_trip
-
-    max_entry_edge = max(
-        item.candidate.opportunity.opportunity.one_day_net_edge_after_entry
-        for item in recent_chain
+    return runtime_build_gate_reason(
+        snapshot=snapshot,
+        recent_chain=recent_chain,
+        policy=LaunchReadyAutomationGatePolicy(
+            min_edge_retention_ratio=settings.stable_launch_ready_min_edge_retention_ratio,
+            max_entry_break_even_funding_windows=(
+                settings.stable_launch_ready_max_entry_break_even_funding_windows
+            ),
+            max_round_trip_break_even_funding_windows=(
+                settings.stable_launch_ready_max_round_trip_break_even_funding_windows
+            ),
+        ),
     )
-    max_round_trip_edge = max(
-        item.candidate.opportunity.opportunity.one_day_net_edge_after_round_trip
-        for item in recent_chain
-    )
-    if max_entry_edge <= 0 or max_round_trip_edge <= 0:
-        return "recent approved snapshot chain has non-positive net edge"
-
-    min_retention_ratio = settings.stable_launch_ready_min_edge_retention_ratio
-    entry_retention_ratio = current_entry_edge / max_entry_edge
-    if entry_retention_ratio < min_retention_ratio:
-        return (
-            "entry edge retention "
-            f"{entry_retention_ratio:.2f} below minimum {min_retention_ratio:.2f}"
-        )
-
-    round_trip_retention_ratio = current_round_trip_edge / max_round_trip_edge
-    if round_trip_retention_ratio < min_retention_ratio:
-        return (
-            "round-trip edge retention "
-            f"{round_trip_retention_ratio:.2f} below minimum {min_retention_ratio:.2f}"
-        )
-
-    break_even_days_entry = opportunity.break_even_days_entry
-    break_even_days_round_trip = opportunity.break_even_days_round_trip
-    if break_even_days_entry is None or break_even_days_round_trip is None:
-        return "approved canary snapshot is missing break-even timing"
-
-    funding_window_hours = _effective_funding_window_hours(snapshot)
-    entry_break_even_windows = break_even_days_entry * 24.0 / funding_window_hours
-    if (
-        entry_break_even_windows
-        > settings.stable_launch_ready_max_entry_break_even_funding_windows
-    ):
-        return (
-            "entry break-even funding windows "
-            f"{entry_break_even_windows:.2f} exceeds maximum "
-            f"{settings.stable_launch_ready_max_entry_break_even_funding_windows:.2f}"
-        )
-
-    round_trip_break_even_windows = (
-        break_even_days_round_trip * 24.0 / funding_window_hours
-    )
-    if (
-        round_trip_break_even_windows
-        > settings.stable_launch_ready_max_round_trip_break_even_funding_windows
-    ):
-        return (
-            "round-trip break-even funding windows "
-            f"{round_trip_break_even_windows:.2f} exceeds maximum "
-            f"{settings.stable_launch_ready_max_round_trip_break_even_funding_windows:.2f}"
-        )
-
-    return None
 
 
 def _approved_snapshot_matches_paper_trade(

--- a/packages/runtime/src/carryme_runtime/__init__.py
+++ b/packages/runtime/src/carryme_runtime/__init__.py
@@ -36,6 +36,20 @@ from carryme_runtime.extended_live_execution import ExtendedLiveExecutionService
 from carryme_runtime.hyperliquid_cleanup_preview import HyperliquidCleanupPreviewService
 from carryme_runtime.hyperliquid_live_execution import HyperliquidLiveExecutionService
 from carryme_runtime.intents import InvalidTradeCandidateError, build_trade_intent
+from carryme_runtime.launch_ready import (
+    FUNDING_WINDOW_HOURS_BY_VENUE,
+    LaunchReadyAutomationGatePolicy,
+    approved_snapshot_launch_payload_changed,
+    approved_snapshot_route_key,
+    build_approved_snapshot_automation_gate_reason,
+    build_candidate_live_execution_preflight,
+    candidate_execution_venue_names,
+    effective_funding_window_hours,
+    hold_window_hours,
+    list_recent_approved_snapshot_chain,
+    normalized_approved_snapshot_launch_payload,
+    probe_candidate_system_state,
+)
 from carryme_runtime.opportunities import (
     OpportunityService,
     UpstreamDataError,
@@ -115,6 +129,8 @@ __all__ = [
     "require_confirmed_preview",
     "ConnectorError",
     "InvalidTradeCandidateError",
+    "FUNDING_WINDOW_HOURS_BY_VENUE",
+    "LaunchReadyAutomationGatePolicy",
     "OpportunityService",
     "UpstreamDataError",
     "OpportunityUniverseService",
@@ -125,8 +141,18 @@ __all__ = [
     "VenueSystemProbe",
     "build_opportunity_record_from_universe_opportunity",
     "build_pair_spec_from_universe_opportunity",
+    "approved_snapshot_launch_payload_changed",
+    "approved_snapshot_route_key",
+    "build_approved_snapshot_automation_gate_reason",
+    "build_candidate_live_execution_preflight",
+    "candidate_execution_venue_names",
+    "effective_funding_window_hours",
     "fetch_live_market_stats",
     "fetch_live_snapshot",
     "filter_candidate_records",
+    "hold_window_hours",
+    "list_recent_approved_snapshot_chain",
     "list_live_symbols",
+    "normalized_approved_snapshot_launch_payload",
+    "probe_candidate_system_state",
 ]

--- a/packages/runtime/src/carryme_runtime/launch_ready.py
+++ b/packages/runtime/src/carryme_runtime/launch_ready.py
@@ -1,0 +1,287 @@
+"""Shared launch-ready canary gating helpers."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+
+from carryme_models import (
+    ApprovedCanarySnapshot,
+    FundingUniverseCanaryCandidate,
+    PaperTradeExecutionPreflight,
+    PaperTradeSystemState,
+    VenueExecutionPreflight,
+    VenueSystemState,
+)
+
+from carryme_runtime.system_state import SystemStateConfigMap, SystemStateService
+
+FUNDING_WINDOW_HOURS_BY_VENUE: dict[str, float] = {
+    "extended": 1.0,
+    "paradex": 8.0,
+    "hyperliquid": 8.0,
+}
+
+
+@dataclass(frozen=True)
+class LaunchReadyAutomationGatePolicy:
+    """Configuration for unattended launch-ready edge and break-even gates."""
+
+    min_edge_retention_ratio: float = 0.7
+    max_entry_break_even_funding_windows: float = 6.0
+    max_round_trip_break_even_funding_windows: float = 12.0
+
+
+def candidate_execution_venue_names(
+    candidate: FundingUniverseCanaryCandidate,
+) -> list[str]:
+    """Return de-duplicated venue names touched by a canary candidate."""
+
+    venue_names = [
+        candidate.opportunity.opportunity.long_venue,
+        candidate.opportunity.opportunity.short_venue,
+    ]
+    selected_names: list[str] = []
+    for venue in venue_names:
+        if venue not in selected_names:
+            selected_names.append(venue)
+    return selected_names
+
+
+def build_candidate_live_execution_preflight(
+    *,
+    venue_preflights: Iterable[VenueExecutionPreflight],
+    candidate: FundingUniverseCanaryCandidate,
+    label: str,
+) -> PaperTradeExecutionPreflight:
+    """Build live-execution readiness for the exact venues touched by one canary."""
+
+    all_statuses = {item.venue: item for item in venue_preflights}
+    selected: list[VenueExecutionPreflight] = []
+    blocking_reasons: list[str] = []
+    for venue in candidate_execution_venue_names(candidate):
+        status = all_statuses.get(venue)
+        if status is None:
+            blocking_reasons.append(f"Venue {venue} live execution is not configured")
+            continue
+        selected.append(status)
+        if not status.enabled:
+            blocking_reasons.append(f"Venue {venue} live execution is not enabled")
+        if status.missing_env_vars:
+            blocking_reasons.append(
+                f"Venue {venue} is missing required credentials: "
+                + ", ".join(status.missing_env_vars)
+            )
+
+    return PaperTradeExecutionPreflight(
+        paper_trade_id=0,
+        label=label,
+        ready=not blocking_reasons,
+        venues=selected,
+        blocking_reasons=blocking_reasons,
+    )
+
+
+async def probe_candidate_system_state(
+    *,
+    service: SystemStateService,
+    configs: SystemStateConfigMap,
+    candidate: FundingUniverseCanaryCandidate,
+    label: str,
+) -> PaperTradeSystemState:
+    """Probe only the venues touched by one canary candidate."""
+
+    all_statuses = {item.venue: item for item in await service.probe_venues(configs)}
+    selected: list[VenueSystemState] = []
+    blocking_reasons: list[str] = []
+    for venue in candidate_execution_venue_names(candidate):
+        status = all_statuses.get(venue)
+        if status is None:
+            blocking_reasons.append(f"Venue {venue} system state is unknown")
+            continue
+        selected.append(status)
+        blocking_reasons.extend(status.blocking_reasons)
+
+    return PaperTradeSystemState(
+        paper_trade_id=0,
+        label=label,
+        ready=not blocking_reasons,
+        venues=selected,
+        blocking_reasons=blocking_reasons,
+    )
+
+
+def approved_snapshot_route_key(
+    snapshot: ApprovedCanarySnapshot,
+) -> tuple[str, str, str, str, str, str]:
+    """Return the normalized identity key for one approved snapshot route."""
+
+    opportunity = snapshot.candidate.opportunity.opportunity
+    return (
+        snapshot.label,
+        opportunity.canonical_symbol,
+        opportunity.short_venue,
+        opportunity.long_venue,
+        opportunity.short_fee_profile,
+        opportunity.long_fee_profile,
+    )
+
+
+def normalized_approved_snapshot_launch_payload(
+    snapshot: ApprovedCanarySnapshot,
+) -> dict[str, object]:
+    """Return the approved-snapshot fields that must stay fixed for launch safety."""
+
+    candidate = snapshot.candidate
+    opportunity = candidate.opportunity.opportunity
+    approval = snapshot.approval
+    venue_markets = candidate.opportunity.venue_markets
+    return {
+        "label": snapshot.label,
+        "suggested_canary_notional": candidate.suggested_canary_notional,
+        "route": {
+            "canonical_symbol": opportunity.canonical_symbol,
+            "long_venue": opportunity.long_venue,
+            "short_venue": opportunity.short_venue,
+            "long_fee_profile": opportunity.long_fee_profile,
+            "short_fee_profile": opportunity.short_fee_profile,
+            "venue_markets": tuple(
+                sorted(
+                    (venue, market.symbol)
+                    for venue, market in venue_markets.items()
+                )
+            ),
+        },
+        "approval": {
+            "label": approval.label,
+            "canonical_symbol": approval.canonical_symbol,
+            "short_venue": approval.short_venue,
+            "long_venue": approval.long_venue,
+            "short_fee_profile": approval.short_fee_profile,
+            "long_fee_profile": approval.long_fee_profile,
+            "approved": approval.approved,
+            "max_live_notional": approval.max_live_notional,
+        },
+    }
+
+
+def approved_snapshot_launch_payload_changed(
+    previous_snapshot: ApprovedCanarySnapshot,
+    current_snapshot: ApprovedCanarySnapshot,
+) -> bool:
+    """Return whether a newer approved snapshot invalidates stable launch evidence."""
+
+    return (
+        normalized_approved_snapshot_launch_payload(previous_snapshot)
+        != normalized_approved_snapshot_launch_payload(current_snapshot)
+    )
+
+
+def effective_funding_window_hours(snapshot: ApprovedCanarySnapshot) -> float:
+    """Return the fastest relevant funding interval across the route venues."""
+
+    opportunity = snapshot.candidate.opportunity.opportunity
+    hours = [
+        FUNDING_WINDOW_HOURS_BY_VENUE.get(opportunity.short_venue, 8.0),
+        FUNDING_WINDOW_HOURS_BY_VENUE.get(opportunity.long_venue, 8.0),
+    ]
+    return min(hours)
+
+
+def hold_window_hours(snapshot: ApprovedCanarySnapshot) -> float:
+    """Return the slowest relevant funding interval across the route venues."""
+
+    opportunity = snapshot.candidate.opportunity.opportunity
+    hours = [
+        FUNDING_WINDOW_HOURS_BY_VENUE.get(opportunity.short_venue, 8.0),
+        FUNDING_WINDOW_HOURS_BY_VENUE.get(opportunity.long_venue, 8.0),
+    ]
+    return max(hours)
+
+
+def list_recent_approved_snapshot_chain(
+    *,
+    recent_snapshots: Iterable[ApprovedCanarySnapshot],
+    snapshot: ApprovedCanarySnapshot,
+    max_snapshot_age_seconds: int,
+) -> list[ApprovedCanarySnapshot]:
+    """Return the recent same-route approved snapshot chain for one label."""
+
+    route_key = approved_snapshot_route_key(snapshot)
+    chain: list[ApprovedCanarySnapshot] = []
+    for recent_snapshot in recent_snapshots:
+        if approved_snapshot_route_key(recent_snapshot) != route_key:
+            break
+        age_seconds = max(
+            0.0,
+            (snapshot.captured_at - recent_snapshot.captured_at).total_seconds(),
+        )
+        if age_seconds > max_snapshot_age_seconds:
+            break
+        chain.append(recent_snapshot)
+    return chain
+
+
+def build_approved_snapshot_automation_gate_reason(
+    *,
+    snapshot: ApprovedCanarySnapshot,
+    recent_chain: list[ApprovedCanarySnapshot],
+    policy: LaunchReadyAutomationGatePolicy,
+) -> str | None:
+    """Return the blocking reason for unattended launch-readiness, if any."""
+
+    opportunity = snapshot.candidate.opportunity.opportunity
+    current_entry_edge = opportunity.one_day_net_edge_after_entry
+    current_round_trip_edge = opportunity.one_day_net_edge_after_round_trip
+
+    max_entry_edge = max(
+        item.candidate.opportunity.opportunity.one_day_net_edge_after_entry
+        for item in recent_chain
+    )
+    max_round_trip_edge = max(
+        item.candidate.opportunity.opportunity.one_day_net_edge_after_round_trip
+        for item in recent_chain
+    )
+    if max_entry_edge <= 0 or max_round_trip_edge <= 0:
+        return "recent approved snapshot chain has non-positive net edge"
+
+    min_retention_ratio = policy.min_edge_retention_ratio
+    entry_retention_ratio = current_entry_edge / max_entry_edge
+    if entry_retention_ratio < min_retention_ratio:
+        return (
+            "entry edge retention "
+            f"{entry_retention_ratio:.2f} below minimum {min_retention_ratio:.2f}"
+        )
+
+    round_trip_retention_ratio = current_round_trip_edge / max_round_trip_edge
+    if round_trip_retention_ratio < min_retention_ratio:
+        return (
+            "round-trip edge retention "
+            f"{round_trip_retention_ratio:.2f} below minimum {min_retention_ratio:.2f}"
+        )
+
+    break_even_days_entry = opportunity.break_even_days_entry
+    break_even_days_round_trip = opportunity.break_even_days_round_trip
+    if break_even_days_entry is None or break_even_days_round_trip is None:
+        return "approved canary snapshot is missing break-even timing"
+
+    funding_window_hours = effective_funding_window_hours(snapshot)
+    entry_break_even_windows = break_even_days_entry * 24.0 / funding_window_hours
+    if entry_break_even_windows > policy.max_entry_break_even_funding_windows:
+        return (
+            "entry break-even funding windows "
+            f"{entry_break_even_windows:.2f} exceeds maximum "
+            f"{policy.max_entry_break_even_funding_windows:.2f}"
+        )
+
+    round_trip_break_even_windows = (
+        break_even_days_round_trip * 24.0 / funding_window_hours
+    )
+    if round_trip_break_even_windows > policy.max_round_trip_break_even_funding_windows:
+        return (
+            "round-trip break-even funding windows "
+            f"{round_trip_break_even_windows:.2f} exceeds maximum "
+            f"{policy.max_round_trip_break_even_funding_windows:.2f}"
+        )
+
+    return None

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1491,6 +1491,197 @@ def test_approve_and_refresh_canary_approval_proposal_rejects_decayed_route(
     assert approved_store.latest(label="arb_extended_paradex") is None
 
 
+def test_approve_refresh_and_cache_launch_ready_canary_proposal_saves_ready_snapshot(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    database_path = tmp_path / "history.sqlite3"
+    approved_store = ApprovedCanaryStore(database_path)
+    launch_ready_store = LaunchReadyCanaryStore(database_path)
+    captured_upsert: dict[str, object] = {}
+    captured_system_state_configs: dict[str, dict[str, bool]] = {}
+
+    class StubUniverseService:
+        pass
+
+    class StubRouteApprovalService:
+        def upsert(self, *, label: str, payload: RouteApprovalUpsert) -> RouteApprovalEntry:
+            captured_upsert["label"] = label
+            captured_upsert["payload"] = payload
+            return RouteApprovalEntry(
+                updated_at=FIXED_APPROVAL_PROPOSAL_NOW,
+                label=label,
+                canonical_symbol=payload.canonical_symbol,
+                short_venue=payload.short_venue,
+                long_venue=payload.long_venue,
+                short_fee_profile=payload.short_fee_profile,
+                long_fee_profile=payload.long_fee_profile,
+                approved=payload.approved,
+                max_live_notional=payload.max_live_notional,
+                note=payload.note,
+            )
+
+    class StubSystemStateService:
+        async def probe_venues(
+            self,
+            configs: dict[str, dict[str, bool]],
+        ) -> list[VenueSystemState]:
+            captured_system_state_configs.update(configs)
+            return [
+                VenueSystemState(
+                    venue="extended",
+                    enabled=True,
+                    checked=False,
+                    healthy=True,
+                    status=None,
+                ),
+                VenueSystemState(
+                    venue="paradex",
+                    enabled=True,
+                    checked=True,
+                    healthy=True,
+                    status="ok",
+                ),
+                VenueSystemState(
+                    venue="hyperliquid",
+                    enabled=False,
+                    checked=False,
+                    healthy=True,
+                    status=None,
+                ),
+            ]
+
+    async def fake_scan_live_route_candidate_for_approval(
+        **kwargs: object,
+    ) -> tuple[FundingUniverseCanaryCandidate | None, int]:
+        approval = cast(RouteApprovalEntry, kwargs["approval"])
+        assert approval.approved is True
+        assert approval.max_live_notional == 11.0
+        return _arb_extended_paradex_canary_candidate(suggested_canary_notional=25.0), 1
+
+    monkeypatch.setattr(
+        "carryme_api.app.scan_live_route_candidate_for_approval",
+        fake_scan_live_route_candidate_for_approval,
+    )
+    app.dependency_overrides[get_current_utc_time] = lambda: FIXED_APPROVAL_PROPOSAL_NOW
+    app.dependency_overrides[get_api_settings] = lambda: ApiSettings(
+        database_path=str(database_path),
+        extended_live_enabled=True,
+        extended_api_key="extended-key",
+        extended_stark_private_key="0x123",
+        paradex_live_enabled=True,
+        paradex_account_address="0xabc",
+        paradex_private_key="0xdef",
+    )
+    app.dependency_overrides[get_opportunity_universe_service] = lambda: StubUniverseService()
+    app.dependency_overrides[get_route_approval_service] = lambda: StubRouteApprovalService()
+    app.dependency_overrides[get_approved_canary_store] = lambda: approved_store
+    app.dependency_overrides[get_launch_ready_canary_store] = lambda: launch_ready_store
+    app.dependency_overrides[get_system_state_service] = lambda: StubSystemStateService()
+    try:
+        client = TestClient(app)
+        response = client.post(
+            "/v1/opportunities/funding-universe/canary/approval-proposals/"
+            "arb_extended_paradex/approve-refresh-and-cache-launch-ready",
+            json=_canary_approval_proposal_summary_payload(
+                approval_payload_overrides={"max_live_notional": 11.0}
+            ),
+        )
+    finally:
+        app.dependency_overrides.clear()
+
+    assert response.status_code == 200
+    assert captured_upsert["label"] == "arb_extended_paradex"
+    upsert_payload = cast(RouteApprovalUpsert, captured_upsert["payload"])
+    assert upsert_payload.approved is True
+    assert captured_system_state_configs["extended"]["enabled"] is True
+    assert captured_system_state_configs["paradex"]["enabled"] is True
+
+    payload = response.json()
+    assert payload["launch_ready_snapshot_id"] == 1
+    assert payload["label"] == "arb_extended_paradex"
+    assert payload["approved_snapshot"]["snapshot_id"] == 1
+    assert payload["approved_snapshot"]["candidate"]["suggested_canary_notional"] == 11.0
+    assert payload["approved_snapshot"]["approval"]["max_live_notional"] == 11.0
+    assert payload["system_state"]["ready"] is True
+    assert approved_store.latest(label="arb_extended_paradex") is not None
+    assert launch_ready_store.latest(label="arb_extended_paradex") is not None
+
+
+def test_approve_refresh_and_cache_launch_ready_canary_proposal_rejects_missing_credentials(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    database_path = tmp_path / "history.sqlite3"
+    approved_store = ApprovedCanaryStore(database_path)
+    launch_ready_store = LaunchReadyCanaryStore(database_path)
+    upsert_called = False
+
+    class StubUniverseService:
+        pass
+
+    class StubRouteApprovalService:
+        def upsert(self, *, label: str, payload: RouteApprovalUpsert) -> RouteApprovalEntry:
+            nonlocal upsert_called
+            _ = label
+            _ = payload
+            upsert_called = True
+            raise AssertionError("unlaunchable route must not be persisted")
+
+    class FailingSystemStateService:
+        async def probe_venues(
+            self,
+            configs: dict[str, dict[str, bool]],
+        ) -> list[VenueSystemState]:
+            _ = configs
+            raise AssertionError("system-state probe should not run before credential gate")
+
+    async def fake_scan_live_route_candidate_for_approval(
+        **_: object,
+    ) -> tuple[FundingUniverseCanaryCandidate | None, int]:
+        return _arb_extended_paradex_canary_candidate(), 1
+
+    monkeypatch.setattr(
+        "carryme_api.app.scan_live_route_candidate_for_approval",
+        fake_scan_live_route_candidate_for_approval,
+    )
+    app.dependency_overrides[get_current_utc_time] = lambda: FIXED_APPROVAL_PROPOSAL_NOW
+    app.dependency_overrides[get_api_settings] = lambda: ApiSettings(
+        database_path=str(database_path),
+        extended_live_enabled=True,
+        extended_api_key="extended-key",
+        paradex_live_enabled=True,
+        paradex_account_address="0xabc",
+        paradex_private_key="0xdef",
+    )
+    app.dependency_overrides[get_opportunity_universe_service] = lambda: StubUniverseService()
+    app.dependency_overrides[get_route_approval_service] = lambda: StubRouteApprovalService()
+    app.dependency_overrides[get_approved_canary_store] = lambda: approved_store
+    app.dependency_overrides[get_launch_ready_canary_store] = lambda: launch_ready_store
+    app.dependency_overrides[get_system_state_service] = lambda: FailingSystemStateService()
+    try:
+        client = TestClient(app)
+        response = client.post(
+            "/v1/opportunities/funding-universe/canary/approval-proposals/"
+            "arb_extended_paradex/approve-refresh-and-cache-launch-ready",
+            json=_canary_approval_proposal_summary_payload(),
+        )
+    finally:
+        app.dependency_overrides.clear()
+
+    assert response.status_code == 409
+    detail = response.json()["detail"]
+    assert detail["message"] == (
+        "Approved canary snapshot live execution preflight is not ready"
+    )
+    assert "CARRYME_API_EXTENDED_STARK_PRIVATE_KEY" in " ".join(
+        detail["blocking_reasons"]
+    )
+    assert upsert_called is False
+    assert approved_store.latest(label="arb_extended_paradex") is None
+    assert launch_ready_store.latest(label="arb_extended_paradex") is None
+
+
 def test_funding_universe_canary_approval_proposals_rejects_unbounded_history_shortlist_age(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary
- add a protected approve-refresh-and-cache-launch-ready endpoint for current canary approval proposals
- share launch-ready live credential, system-state, edge-retention, and break-even gates between API and worker paths
- fail closed without persisting approval/snapshots when a freshly promoted route is not launch-ready

## Validation
- UV_PROJECT_ENVIRONMENT=.venv-codex uv run pytest -q tests/test_api.py -k 'approve_refresh_and_cache_launch_ready or approve_and_refresh_canary_approval_proposal or approve_canary_approval_proposal'
- UV_PROJECT_ENVIRONMENT=.venv-codex uv run pytest -q tests/test_api.py
- UV_PROJECT_ENVIRONMENT=.venv-codex uv run pytest -q tests/test_worker.py -k 'cache_launch_ready_canaries_once or probe_candidate_system_state or stable_launch_ready'
- UV_PROJECT_ENVIRONMENT=.venv-codex uv run ruff check .
- UV_PROJECT_ENVIRONMENT=.venv-codex uv run mypy src apps packages tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automated launch readiness gates validate canary eligibility before execution
  * New approval endpoint refreshes canary snapshots and performs pre-launch system readiness checks
  * Configurable launch readiness tuning parameters for edge retention and break-even thresholds

* **Tests**
  * Added validation tests for canary launch approval workflow

<!-- end of auto-generated comment: release notes by coderabbit.ai -->