### PR TITLE
fix: read Hyperliquid unified account collateral

### DIFF
--- a/packages/runtime/src/carryme_runtime/account_preflight.py
+++ b/packages/runtime/src/carryme_runtime/account_preflight.py
@@ -926,9 +926,7 @@ def _pick_hyperliquid_usdc_spot_balance(
     for row in balances:
         if not isinstance(row, dict):
             continue
-        coin = row.get("coin")
-        token = row.get("token")
-        if coin != "USDC" and token != 0:
+        if not _hyperliquid_spot_balance_is_usdc(row):
             continue
         total = _pick_float(
             row,
@@ -944,6 +942,16 @@ def _pick_hyperliquid_usdc_spot_balance(
     raise UpstreamDataError(
         "hyperliquid spotClearinghouseState payload did not contain a USDC balance"
     )
+
+
+def _hyperliquid_spot_balance_is_usdc(row: dict[str, Any]) -> bool:
+    token = row.get("token")
+    token_is_zero = False
+    if isinstance(token, str):
+        token_is_zero = token.strip() == "0"
+    elif not isinstance(token, bool) and isinstance(token, int):
+        token_is_zero = token == 0
+    return row.get("coin") == "USDC" and token_is_zero
 
 
 def _extract_hyperliquid_position_symbols(positions: list[Any]) -> list[str]:

--- a/packages/runtime/src/carryme_runtime/account_preflight.py
+++ b/packages/runtime/src/carryme_runtime/account_preflight.py
@@ -32,6 +32,16 @@ AUTH_READ_RETRY_ATTEMPTS = 3
 AUTH_READ_RETRY_BACKOFF_SECONDS = 0.25
 
 
+@dataclass(frozen=True)
+class HyperliquidAccountState:
+    """Raw account reads needed to classify Hyperliquid live collateral."""
+
+    state: dict[str, Any]
+    open_orders: list[dict[str, Any]]
+    abstraction_mode: str | None = None
+    spot_state: dict[str, Any] | None = None
+
+
 class VenueAccountConfig(TypedDict):
     """Configured authenticated-read credentials for one venue."""
 
@@ -510,7 +520,7 @@ class HyperliquidAccountProbe:
             )
 
         try:
-            state, open_orders = await asyncio.wait_for(
+            account_state = await asyncio.wait_for(
                 asyncio.to_thread(
                     _fetch_hyperliquid_account_state,
                     cast(str, account_address),
@@ -551,6 +561,8 @@ class HyperliquidAccountProbe:
             )
 
         try:
+            state = account_state.state
+            open_orders = account_state.open_orders
             margin_summary = state.get("marginSummary")
             if not isinstance(margin_summary, dict):
                 margin_summary = {}
@@ -569,6 +581,38 @@ class HyperliquidAccountProbe:
                 context="hyperliquid account collateral",
             )
             total_collateral = margin_collateral if margin_collateral is not None else withdrawable
+            available_to_trade = withdrawable
+            free_collateral = withdrawable
+            balance_assets = ["USDC"] if total_collateral is not None else []
+            account_status = account_state.abstraction_mode
+            notes = [
+                (
+                    "Hyperliquid account preflight completed using the official SDK "
+                    "Info.user_state/open_orders flow. Account reads are address-based; the "
+                    "API wallet private key remains required for live submission."
+                ),
+                (
+                    "If this account is a subaccount or vault, live actions may also require "
+                    "CARRYME_API_HYPERLIQUID_VAULT_ADDRESS to target the correct account."
+                ),
+                f"Observed {len(open_orders)} currently open Hyperliquid orders.",
+            ]
+            if _hyperliquid_uses_unified_spot_collateral(account_state.abstraction_mode):
+                spot_total, spot_hold = _pick_hyperliquid_usdc_spot_balance(
+                    account_state.spot_state,
+                )
+                total_collateral = spot_total
+                available_to_trade = max(spot_total - spot_hold, 0.0)
+                free_collateral = available_to_trade
+                balance_assets = ["USDC"]
+                notes.insert(
+                    1,
+                    (
+                        "Hyperliquid account is in unified account mode; collateral is read "
+                        "from spotClearinghouseState because per-dex clearinghouseState "
+                        "collateral is not meaningful in this mode."
+                    ),
+                )
             return VenueAccountPreflight(
                 venue=self.venue,
                 enabled=enabled,
@@ -576,25 +620,15 @@ class HyperliquidAccountProbe:
                 ready=True,
                 credential_mode="api_wallet",
                 account_identifier=account_address,
+                account_status=account_status,
                 total_collateral=total_collateral,
-                available_to_trade=withdrawable,
-                free_collateral=withdrawable,
+                available_to_trade=available_to_trade,
+                free_collateral=free_collateral,
                 balance_count=1 if total_collateral is not None else 0,
                 position_count=len([item for item in positions if isinstance(item, dict)]),
-                balance_assets=["USDC"] if total_collateral is not None else [],
+                balance_assets=balance_assets,
                 position_symbols=_extract_hyperliquid_position_symbols(positions),
-                notes=[
-                    (
-                        "Hyperliquid account preflight completed using the official SDK "
-                        "Info.user_state/open_orders flow. Account reads are address-based; the "
-                        "API wallet private key remains required for live submission."
-                    ),
-                    (
-                        "If this account is a subaccount or vault, live actions may also require "
-                        "CARRYME_API_HYPERLIQUID_VAULT_ADDRESS to target the correct account."
-                    ),
-                    f"Observed {len(open_orders)} currently open Hyperliquid orders.",
-                ],
+                notes=notes,
             )
         except (UpstreamDataError, ValidationError) as exc:
             return VenueAccountPreflight(
@@ -840,7 +874,7 @@ def _pick_float(data: dict[str, Any], *keys: str, context: str) -> float | None:
 
 def _fetch_hyperliquid_account_state(
     account_address: str,
-) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+) -> HyperliquidAccountState:
     info = build_hyperliquid_info(base_url=ACCOUNT_CONNECTOR_BASE_URLS["hyperliquid"])
     state = info.user_state(account_address)
     open_orders = info.open_orders(account_address)
@@ -848,7 +882,68 @@ def _fetch_hyperliquid_account_state(
         raise ConnectorError("Hyperliquid user_state payload must be an object")
     if not isinstance(open_orders, list):
         raise ConnectorError("Hyperliquid open_orders payload must be a list")
-    return state, [item for item in open_orders if isinstance(item, dict)]
+    abstraction_mode = _fetch_hyperliquid_abstraction_mode(info, account_address)
+    spot_state = None
+    if _hyperliquid_uses_unified_spot_collateral(abstraction_mode):
+        spot_state = info.spot_user_state(account_address)
+        if not isinstance(spot_state, dict):
+            raise ConnectorError("Hyperliquid spot_user_state payload must be an object")
+    return HyperliquidAccountState(
+        state=state,
+        open_orders=[item for item in open_orders if isinstance(item, dict)],
+        abstraction_mode=abstraction_mode,
+        spot_state=spot_state,
+    )
+
+
+def _fetch_hyperliquid_abstraction_mode(info: Any, account_address: str) -> str | None:
+    payload = info.post("/info", {"type": "userAbstraction", "user": account_address})
+    if payload is None:
+        return None
+    if isinstance(payload, str):
+        normalized = payload.strip()
+        return normalized or None
+    raise ConnectorError("Hyperliquid userAbstraction payload must be a string or null")
+
+
+def _hyperliquid_uses_unified_spot_collateral(abstraction_mode: str | None) -> bool:
+    normalized = (abstraction_mode or "").strip()
+    return normalized in {"unifiedAccount", "portfolio"}
+
+
+def _pick_hyperliquid_usdc_spot_balance(
+    spot_state: dict[str, Any] | None,
+) -> tuple[float, float]:
+    if spot_state is None:
+        raise UpstreamDataError(
+            "hyperliquid unified account collateral requires spotClearinghouseState"
+        )
+    balances = spot_state.get("balances")
+    if not isinstance(balances, list):
+        raise UpstreamDataError(
+            "hyperliquid spotClearinghouseState payload field 'balances' must be a list"
+        )
+    for row in balances:
+        if not isinstance(row, dict):
+            continue
+        coin = row.get("coin")
+        token = row.get("token")
+        if coin != "USDC" and token != 0:
+            continue
+        total = _pick_float(
+            row,
+            "total",
+            context="hyperliquid unified USDC balance",
+        )
+        hold = _pick_float(
+            row,
+            "hold",
+            context="hyperliquid unified USDC hold",
+        )
+        return total or 0.0, hold or 0.0
+    raise UpstreamDataError(
+        "hyperliquid spotClearinghouseState payload did not contain a USDC balance"
+    )
 
 
 def _extract_hyperliquid_position_symbols(positions: list[Any]) -> list[str]:

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -6295,8 +6295,20 @@ def test_hyperliquid_account_probe_reads_unified_account_spot_collateral(
             return {
                 "balances": [
                     {
-                        "coin": "USDC",
+                        "coin": "PURR",
                         "token": 0,
+                        "total": "999.0",
+                        "hold": "0.0",
+                    },
+                    {
+                        "coin": "USDC",
+                        "token": 1,
+                        "total": "888.0",
+                        "hold": "0.0",
+                    },
+                    {
+                        "coin": "USDC",
+                        "token": "0",
                         "total": "124.72",
                         "hold": "4.72",
                         "entryNtl": "0.0",
@@ -6329,6 +6341,73 @@ def test_hyperliquid_account_probe_reads_unified_account_spot_collateral(
         assert result.free_collateral == 120.0
         assert result.balance_assets == ["USDC"]
         assert any("unified account mode" in note for note in result.notes)
+
+    asyncio.run(run())
+
+
+@pytest.mark.parametrize(
+    ("spot_state", "expected_fragment"),
+    [
+        (
+            {"balances": [{"coin": "PURR", "token": 0, "total": "999.0", "hold": "0.0"}]},
+            "did not contain a USDC balance",
+        ),
+        (
+            {"balances": "not-a-list"},
+            "field 'balances' must be a list",
+        ),
+    ],
+)
+def test_hyperliquid_account_probe_rejects_malformed_unified_spot_collateral(
+    monkeypatch: pytest.MonkeyPatch,
+    spot_state: dict[str, object],
+    expected_fragment: str,
+) -> None:
+    class StubInfo:
+        def user_state(self, address: str) -> dict[str, object]:
+            assert address == "0xhyper"
+            return {
+                "marginSummary": {
+                    "accountValue": "0.0",
+                    "totalRawUsd": "0.0",
+                },
+                "withdrawable": "0.0",
+                "assetPositions": [],
+            }
+
+        def open_orders(self, address: str) -> list[dict[str, object]]:
+            assert address == "0xhyper"
+            return []
+
+        def post(self, path: str, payload: dict[str, object]) -> str:
+            assert path == "/info"
+            assert payload == {"type": "userAbstraction", "user": "0xhyper"}
+            return "unifiedAccount"
+
+        def spot_user_state(self, address: str) -> dict[str, object]:
+            assert address == "0xhyper"
+            return spot_state
+
+    monkeypatch.setattr(
+        "carryme_runtime.account_preflight.build_hyperliquid_info",
+        lambda *, base_url, timeout=15.0: StubInfo(),
+    )
+
+    async def run() -> None:
+        probe = HyperliquidAccountProbe()
+        result = await probe.probe(
+            {
+                "enabled": True,
+                "credentials": {
+                    "account_address": "0xhyper",
+                    "api_wallet_private_key": "0xwallet",
+                },
+            }
+        )
+        assert result.venue == "hyperliquid"
+        assert result.authenticated is False
+        assert result.ready is False
+        assert any(expected_fragment in reason for reason in result.blocking_reasons)
 
     asyncio.run(run())
 

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -6229,6 +6229,11 @@ def test_hyperliquid_account_probe_reads_sdk_state(
             assert address == "0xhyper"
             return [{"coin": "ARB", "oid": 123}]
 
+        def post(self, path: str, payload: dict[str, object]) -> str:
+            assert path == "/info"
+            assert payload == {"type": "userAbstraction", "user": "0xhyper"}
+            return "standard"
+
     monkeypatch.setattr(
         "carryme_runtime.account_preflight.build_hyperliquid_info",
         lambda *, base_url, timeout=15.0: StubInfo(),
@@ -6249,6 +6254,7 @@ def test_hyperliquid_account_probe_reads_sdk_state(
         assert result.authenticated is True
         assert result.ready is True
         assert result.account_identifier == "0xhyper"
+        assert result.account_status == "standard"
         assert result.total_collateral == 9.8
         assert result.available_to_trade == 8.15
         assert result.free_collateral == 8.15
@@ -6256,6 +6262,73 @@ def test_hyperliquid_account_probe_reads_sdk_state(
         assert result.position_symbols == ["ARB", "STRK"]
         assert result.position_count == 2
         assert "Observed 1 currently open Hyperliquid orders." in result.notes
+
+    asyncio.run(run())
+
+
+def test_hyperliquid_account_probe_reads_unified_account_spot_collateral(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class StubInfo:
+        def user_state(self, address: str) -> dict[str, object]:
+            assert address == "0xhyper"
+            return {
+                "marginSummary": {
+                    "accountValue": "0.0",
+                    "totalRawUsd": "0.0",
+                },
+                "withdrawable": "0.0",
+                "assetPositions": [],
+            }
+
+        def open_orders(self, address: str) -> list[dict[str, object]]:
+            assert address == "0xhyper"
+            return []
+
+        def post(self, path: str, payload: dict[str, object]) -> str:
+            assert path == "/info"
+            assert payload == {"type": "userAbstraction", "user": "0xhyper"}
+            return "unifiedAccount"
+
+        def spot_user_state(self, address: str) -> dict[str, object]:
+            assert address == "0xhyper"
+            return {
+                "balances": [
+                    {
+                        "coin": "USDC",
+                        "token": 0,
+                        "total": "124.72",
+                        "hold": "4.72",
+                        "entryNtl": "0.0",
+                    }
+                ]
+            }
+
+    monkeypatch.setattr(
+        "carryme_runtime.account_preflight.build_hyperliquid_info",
+        lambda *, base_url, timeout=15.0: StubInfo(),
+    )
+
+    async def run() -> None:
+        probe = HyperliquidAccountProbe()
+        result = await probe.probe(
+            {
+                "enabled": True,
+                "credentials": {
+                    "account_address": "0xhyper",
+                    "api_wallet_private_key": "0xwallet",
+                },
+            }
+        )
+        assert result.venue == "hyperliquid"
+        assert result.authenticated is True
+        assert result.ready is True
+        assert result.account_status == "unifiedAccount"
+        assert result.total_collateral == 124.72
+        assert result.available_to_trade == 120.0
+        assert result.free_collateral == 120.0
+        assert result.balance_assets == ["USDC"]
+        assert any("unified account mode" in note for note in result.notes)
 
     asyncio.run(run())
 
@@ -6314,6 +6387,11 @@ def test_hyperliquid_account_probe_rejects_malformed_sdk_payload(
         def open_orders(self, address: str) -> list[dict[str, object]]:
             assert address == "0xhyper"
             return []
+
+        def post(self, path: str, payload: dict[str, object]) -> str:
+            assert path == "/info"
+            assert payload == {"type": "userAbstraction", "user": "0xhyper"}
+            return "standard"
 
     monkeypatch.setattr(
         "carryme_runtime.account_preflight.build_hyperliquid_info",


### PR DESCRIPTION
## Summary
- detect Hyperliquid account abstraction mode during account preflight
- read USDC collateral from spotClearinghouseState for unified/portfolio accounts
- keep standard account behavior on clearinghouseState

## Validation
- UV_PROJECT_ENVIRONMENT=.venv-codex uv run pytest -q tests/test_runtime.py -k 'hyperliquid_account_probe'
- UV_PROJECT_ENVIRONMENT=.venv-codex uv run pytest -q tests/test_api.py -k 'account_preflight or hyperliquid'
- UV_PROJECT_ENVIRONMENT=.venv-codex uv run ruff check .
- UV_PROJECT_ENVIRONMENT=.venv-codex uv run mypy src apps packages tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Account preflight now returns richer structured account state, including account type classification and contextual notes.
  * Added unified-account (spot) support: collateral, available-to-trade, free collateral and derived asset list are computed correctly in unified mode.

* **Tests**
  * Expanded account probe tests to cover standard and unified-account scenarios and verify collateral, status, and notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->