### PR TITLE
fix: make stable launch loss breaker route-aware

### DIFF
--- a/apps/worker/src/carryme_worker/config.py
+++ b/apps/worker/src/carryme_worker/config.py
@@ -11,6 +11,7 @@ from pydantic import AliasChoices, Field, ValidationInfo, field_validator, model
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 LogLevel = Literal["CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG"]
+StableCanaryLaunchLossScope = Literal["global", "label"]
 
 
 class WorkerSettings(BaseSettings):
@@ -60,6 +61,7 @@ class WorkerSettings(BaseSettings):
         default=None,
         ge=1,
     )
+    stable_canary_launch_consecutive_loss_scope: StableCanaryLaunchLossScope = "global"
     stable_canary_launch_global_cooldown_seconds: int | None = Field(
         default=None,
         ge=0,

--- a/apps/worker/src/carryme_worker/poller.py
+++ b/apps/worker/src/carryme_worker/poller.py
@@ -586,6 +586,9 @@ def _build_stable_launch_hold_mode_blocker(settings: WorkerSettings) -> str | No
     return None
 
 
+StableLaunchLossOutcome = tuple[int, str | None, float]
+
+
 def _list_recent_closed_live_trade_outcomes(
     *,
     settings: WorkerSettings,
@@ -593,14 +596,14 @@ def _list_recent_closed_live_trade_outcomes(
     observation_store: ExecutionObservationStore,
     balance_service: BalanceAccountingService,
     now: datetime,
-) -> list[tuple[int, str | None, float]]:
+) -> list[StableLaunchLossOutcome]:
     """Return recent closed live paper trades with realized total collateral deltas."""
 
     limit = settings.stable_canary_launch_recent_closed_trade_limit
     page_size = max(limit * 4, 20)
     offset = 0
     seen_paper_trade_ids: set[int] = set()
-    outcomes: list[tuple[int, str | None, float]] = []
+    outcomes: list[StableLaunchLossOutcome] = []
 
     while len(outcomes) < limit:
         batch = execution_store.list_recent(limit=page_size, offset=offset)
@@ -645,6 +648,8 @@ def _build_stable_launch_loss_circuit_breaker_reason(
     balance_service: BalanceAccountingService,
     now: datetime,
     candidate_label: str | None = None,
+    recent_outcomes: list[StableLaunchLossOutcome] | None = None,
+    check_consecutive_losses: bool = True,
 ) -> str | None:
     """Return the deterministic reason unattended launch is blocked by recent losses."""
 
@@ -653,13 +658,15 @@ def _build_stable_launch_loss_circuit_breaker_reason(
     if max_negative_total is None and max_consecutive_losses is None:
         return None
 
-    outcomes = _list_recent_closed_live_trade_outcomes(
-        settings=settings,
-        execution_store=execution_store,
-        observation_store=observation_store,
-        balance_service=balance_service,
-        now=now,
-    )
+    outcomes = recent_outcomes
+    if outcomes is None:
+        outcomes = _list_recent_closed_live_trade_outcomes(
+            settings=settings,
+            execution_store=execution_store,
+            observation_store=observation_store,
+            balance_service=balance_service,
+            now=now,
+        )
     if not outcomes:
         return None
 
@@ -671,13 +678,16 @@ def _build_stable_launch_loss_circuit_breaker_reason(
                 f"loss={total_negative_collateral:.6f} > max={max_negative_total:.6f}"
             )
 
-    if max_consecutive_losses is None:
+    if max_consecutive_losses is None or not check_consecutive_losses:
         return None
 
     scoped_outcomes = outcomes
     if settings.stable_canary_launch_consecutive_loss_scope == "label":
         if candidate_label is None:
-            return None
+            return (
+                "Stable launch consecutive losing trades scope=label requires "
+                "candidate label"
+            )
         scoped_outcomes = [
             (paper_trade_id, label, delta)
             for paper_trade_id, label, delta in outcomes
@@ -2984,6 +2994,18 @@ async def launch_latest_stable_canary_once(
         store=RouteApprovalStore(runtime_settings.database_path)
     )
     timestamp = now or _utc_now()
+    recent_closed_trade_outcomes: list[StableLaunchLossOutcome] | None = None
+    if (
+        settings.stable_canary_launch_max_recent_negative_total_collateral is not None
+        or settings.stable_canary_launch_max_consecutive_losing_trades is not None
+    ):
+        recent_closed_trade_outcomes = _list_recent_closed_live_trade_outcomes(
+            settings=settings,
+            execution_store=execution_store,
+            observation_store=observation_store,
+            balance_service=balance_service,
+            now=timestamp,
+        )
 
     blocking_live_executions = _list_blocking_live_executions_for_stable_launch(
         settings=settings,
@@ -3010,6 +3032,10 @@ async def launch_latest_stable_canary_once(
         observation_store=observation_store,
         balance_service=balance_service,
         now=timestamp,
+        recent_outcomes=recent_closed_trade_outcomes,
+        check_consecutive_losses=(
+            settings.stable_canary_launch_consecutive_loss_scope == "global"
+        ),
     )
     if loss_circuit_breaker_reason is not None:
         return StableCanaryLaunchSummary(
@@ -3098,6 +3124,7 @@ async def launch_latest_stable_canary_once(
             balance_service=balance_service,
             now=timestamp,
             candidate_label=candidate_snapshot.label,
+            recent_outcomes=recent_closed_trade_outcomes,
         )
         if loss_circuit_breaker_reason is not None:
             skipped_candidates.append(

--- a/apps/worker/src/carryme_worker/poller.py
+++ b/apps/worker/src/carryme_worker/poller.py
@@ -3117,27 +3117,28 @@ async def launch_latest_stable_canary_once(
 
     for candidate_stability in stable_candidates:
         candidate_snapshot = candidate_stability.snapshot
-        loss_circuit_breaker_reason = _build_stable_launch_loss_circuit_breaker_reason(
-            settings=settings,
-            execution_store=execution_store,
-            observation_store=observation_store,
-            balance_service=balance_service,
-            now=timestamp,
-            candidate_label=candidate_snapshot.label,
-            recent_outcomes=recent_closed_trade_outcomes,
-        )
-        if loss_circuit_breaker_reason is not None:
-            skipped_candidates.append(
-                _StableCanaryCandidateSkip(
-                    label=candidate_snapshot.label,
-                    launch_ready_snapshot_id=candidate_snapshot.launch_ready_snapshot_id,
-                    approved_snapshot_id=(
-                        candidate_snapshot.approved_snapshot.snapshot_id
-                    ),
-                    detail=loss_circuit_breaker_reason,
-                )
+        if settings.stable_canary_launch_consecutive_loss_scope == "label":
+            loss_circuit_breaker_reason = _build_stable_launch_loss_circuit_breaker_reason(
+                settings=settings,
+                execution_store=execution_store,
+                observation_store=observation_store,
+                balance_service=balance_service,
+                now=timestamp,
+                candidate_label=candidate_snapshot.label,
+                recent_outcomes=recent_closed_trade_outcomes,
             )
-            continue
+            if loss_circuit_breaker_reason is not None:
+                skipped_candidates.append(
+                    _StableCanaryCandidateSkip(
+                        label=candidate_snapshot.label,
+                        launch_ready_snapshot_id=candidate_snapshot.launch_ready_snapshot_id,
+                        approved_snapshot_id=(
+                            candidate_snapshot.approved_snapshot.snapshot_id
+                        ),
+                        detail=loss_circuit_breaker_reason,
+                    )
+                )
+                continue
         try:
             latest_launch_ready_snapshot, candidate_selected, candidate_approval = (
                 _select_latest_launch_ready_canary_snapshot(

--- a/apps/worker/src/carryme_worker/poller.py
+++ b/apps/worker/src/carryme_worker/poller.py
@@ -593,14 +593,14 @@ def _list_recent_closed_live_trade_outcomes(
     observation_store: ExecutionObservationStore,
     balance_service: BalanceAccountingService,
     now: datetime,
-) -> list[tuple[int, float]]:
+) -> list[tuple[int, str | None, float]]:
     """Return recent closed live paper trades with realized total collateral deltas."""
 
     limit = settings.stable_canary_launch_recent_closed_trade_limit
     page_size = max(limit * 4, 20)
     offset = 0
     seen_paper_trade_ids: set[int] = set()
-    outcomes: list[tuple[int, float]] = []
+    outcomes: list[tuple[int, str | None, float]] = []
 
     while len(outcomes) < limit:
         batch = execution_store.list_recent(limit=page_size, offset=offset)
@@ -624,7 +624,10 @@ def _list_recent_closed_live_trade_outcomes(
             attribution = balance_service.summarize_paper_trade_attribution(paper_trade_id)
             if attribution is None or attribution.total_collateral_delta is None:
                 continue
-            outcomes.append((paper_trade_id, attribution.total_collateral_delta))
+            label = None
+            if execution.paper_trade is not None:
+                label = execution.paper_trade.intent.label
+            outcomes.append((paper_trade_id, label, attribution.total_collateral_delta))
             if len(outcomes) >= limit:
                 break
 
@@ -641,6 +644,7 @@ def _build_stable_launch_loss_circuit_breaker_reason(
     observation_store: ExecutionObservationStore,
     balance_service: BalanceAccountingService,
     now: datetime,
+    candidate_label: str | None = None,
 ) -> str | None:
     """Return the deterministic reason unattended launch is blocked by recent losses."""
 
@@ -660,7 +664,7 @@ def _build_stable_launch_loss_circuit_breaker_reason(
         return None
 
     if max_negative_total is not None:
-        total_negative_collateral = -sum(min(delta, 0.0) for _, delta in outcomes)
+        total_negative_collateral = -sum(min(delta, 0.0) for _, _, delta in outcomes)
         if total_negative_collateral - max_negative_total > 1e-9:
             return (
                 "Stable launch recent negative collateral budget exceeded: "
@@ -670,16 +674,29 @@ def _build_stable_launch_loss_circuit_breaker_reason(
     if max_consecutive_losses is None:
         return None
 
+    scoped_outcomes = outcomes
+    if settings.stable_canary_launch_consecutive_loss_scope == "label":
+        if candidate_label is None:
+            return None
+        scoped_outcomes = [
+            (paper_trade_id, label, delta)
+            for paper_trade_id, label, delta in outcomes
+            if label == candidate_label
+        ]
+
     consecutive_losses = 0
-    for _, delta in outcomes:
+    for _, _, delta in scoped_outcomes:
         if delta < 0:
             consecutive_losses += 1
         else:
             break
     if consecutive_losses >= max_consecutive_losses:
+        scope_detail = ""
+        if settings.stable_canary_launch_consecutive_loss_scope == "label":
+            scope_detail = f" for label={candidate_label}"
         return (
             "Stable launch consecutive losing trades threshold reached: "
-            f"losses={consecutive_losses} >= max={max_consecutive_losses}"
+            f"losses={consecutive_losses} >= max={max_consecutive_losses}{scope_detail}"
         )
 
     return None
@@ -3074,6 +3091,26 @@ async def launch_latest_stable_canary_once(
 
     for candidate_stability in stable_candidates:
         candidate_snapshot = candidate_stability.snapshot
+        loss_circuit_breaker_reason = _build_stable_launch_loss_circuit_breaker_reason(
+            settings=settings,
+            execution_store=execution_store,
+            observation_store=observation_store,
+            balance_service=balance_service,
+            now=timestamp,
+            candidate_label=candidate_snapshot.label,
+        )
+        if loss_circuit_breaker_reason is not None:
+            skipped_candidates.append(
+                _StableCanaryCandidateSkip(
+                    label=candidate_snapshot.label,
+                    launch_ready_snapshot_id=candidate_snapshot.launch_ready_snapshot_id,
+                    approved_snapshot_id=(
+                        candidate_snapshot.approved_snapshot.snapshot_id
+                    ),
+                    detail=loss_circuit_breaker_reason,
+                )
+            )
+            continue
         try:
             latest_launch_ready_snapshot, candidate_selected, candidate_approval = (
                 _select_latest_launch_ready_canary_snapshot(

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -9112,6 +9112,20 @@ def test_stable_launch_label_loss_scope_ignores_other_label_loss_streak(
 
     assert reason is None
 
+    missing_label_reason = _build_stable_launch_loss_circuit_breaker_reason(
+        settings=settings,
+        execution_store=ExecutionJournalStore(settings.database_path),
+        observation_store=ExecutionObservationStore(settings.database_path),
+        balance_service=BalanceAccountingService(
+            store=BalanceSnapshotStore(settings.database_path)
+        ),
+        now=datetime(2026, 4, 4, 10, 10, tzinfo=UTC),
+    )
+
+    assert missing_label_reason == (
+        "Stable launch consecutive losing trades scope=label requires candidate label"
+    )
+
 
 def test_stable_launch_label_loss_scope_blocks_same_label_loss_streak(
     tmp_path: Path,

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -125,6 +125,7 @@ from carryme_worker.poller import (
     _build_open_hedge_auto_close_reason,
     _build_open_hedge_profit_protection_reason,
     _build_order_state_observers,
+    _build_stable_launch_loss_circuit_breaker_reason,
     _execution_requires_continued_monitoring,
     _list_ranked_stable_launch_ready_stabilities,
     _maybe_auto_close_open_hedged_execution,
@@ -286,6 +287,10 @@ def _clear_worker_env(monkeypatch: pytest.MonkeyPatch) -> None:
         "CARRYME_WORKER_STABLE_CANARY_LAUNCH_BLOCK_ADVERSE_LATEST_OUTCOME",
         raising=False,
     )
+    monkeypatch.delenv(
+        "CARRYME_WORKER_STABLE_CANARY_LAUNCH_CONSECUTIVE_LOSS_SCOPE",
+        raising=False,
+    )
     monkeypatch.delenv("CARRYME_WORKER_PARADEX_RECV_WINDOW_MS", raising=False)
     monkeypatch.delenv("CARRYME_WORKER_EXTENDED_API_KEY", raising=False)
     monkeypatch.delenv("CARRYME_WORKER_EXTENDED_STARK_PRIVATE_KEY", raising=False)
@@ -339,6 +344,7 @@ def test_worker_defaults(monkeypatch: pytest.MonkeyPatch) -> None:
     assert settings.stable_canary_launch_recent_closed_trade_limit == 10
     assert settings.stable_canary_launch_max_recent_negative_total_collateral is None
     assert settings.stable_canary_launch_max_consecutive_losing_trades is None
+    assert settings.stable_canary_launch_consecutive_loss_scope == "global"
     assert settings.stable_canary_launch_global_cooldown_seconds is None
     assert settings.stable_canary_launch_label_cooldown_seconds is None
     assert settings.stable_canary_launch_recent_launch_window_seconds is None
@@ -8994,6 +9000,154 @@ def test_launch_latest_stable_canary_once_skips_when_recent_negative_collateral_
     assert summary.detail == (
         "Stable launch recent negative collateral budget exceeded: "
         "loss=0.110000 > max=0.100000"
+    )
+
+
+def _append_closed_live_trade_with_collateral_delta(
+    *,
+    settings: WorkerSettings,
+    paper_trade_id: int,
+    label: str,
+    executed_at: datetime,
+    collateral_delta: float,
+) -> None:
+    execution_store = ExecutionJournalStore(settings.database_path)
+    observation_store = ExecutionObservationStore(settings.database_path)
+    snapshot_store = BalanceSnapshotStore(settings.database_path)
+    execution = execution_store.append(
+        ExecutionJournalEntry(
+            executed_at=executed_at,
+            adapter="paired_live:extended_then_paradex",
+            mode="live",
+            status="submitted",
+            paper_trade_id=paper_trade_id,
+            preview_hash=f"closed-loss-preview-{paper_trade_id}",
+            confirmation_entry_id=paper_trade_id + 100,
+            paper_trade=_build_auto_close_paper_trade(
+                entry_id=paper_trade_id,
+                created_at=executed_at - timedelta(minutes=5),
+                label=label,
+            ),
+            legs=[_build_auto_close_execution_leg()],
+        )
+    )
+    observation_store.append(
+        ExecutionObservationEntry(
+            observed_at=executed_at + timedelta(minutes=1),
+            context="worker_execution_monitor",
+            execution_entry_id=execution.entry_id,
+            paper_trade_id=paper_trade_id,
+            preview_hash=execution.preview_hash,
+            order_state=ExecutionOrderState(
+                execution_entry_id=execution.entry_id,
+                paper_trade_id=paper_trade_id,
+                preview_hash=execution.preview_hash,
+                legs=[],
+                notes=[],
+            ),
+            pair_status=_build_auto_close_pair_status(
+                execution=execution,
+                derived_state="closed",
+                recommended_action="no_action",
+            ),
+        )
+    )
+    for venue in ("extended", "paradex"):
+        snapshot_store.append(
+            VenueBalanceSnapshot(
+                captured_at=executed_at - timedelta(minutes=5),
+                paper_trade_id=paper_trade_id,
+                label=label,
+                stage="pre_open",
+                venue=venue,
+                total_collateral=500.0,
+            )
+        )
+        snapshot_store.append(
+            VenueBalanceSnapshot(
+                captured_at=executed_at + timedelta(minutes=5),
+                paper_trade_id=paper_trade_id,
+                label=label,
+                stage="post_close",
+                venue=venue,
+                total_collateral=500.0 + (collateral_delta / 2.0),
+            )
+        )
+
+
+def test_stable_launch_label_loss_scope_ignores_other_label_loss_streak(
+    tmp_path: Path,
+) -> None:
+    settings = WorkerSettings(
+        database_path=str(tmp_path / "history.sqlite3"),
+        stable_canary_launch_max_consecutive_losing_trades=2,
+        stable_canary_launch_consecutive_loss_scope="label",
+        stable_canary_launch_recent_closed_trade_limit=5,
+    )
+    _append_closed_live_trade_with_collateral_delta(
+        settings=settings,
+        paper_trade_id=91,
+        label="dot_extended_paradex",
+        executed_at=datetime(2026, 4, 4, 10, 0, tzinfo=UTC),
+        collateral_delta=-0.03,
+    )
+    _append_closed_live_trade_with_collateral_delta(
+        settings=settings,
+        paper_trade_id=92,
+        label="bera_extended_paradex",
+        executed_at=datetime(2026, 4, 4, 10, 2, tzinfo=UTC),
+        collateral_delta=-0.04,
+    )
+
+    reason = _build_stable_launch_loss_circuit_breaker_reason(
+        settings=settings,
+        execution_store=ExecutionJournalStore(settings.database_path),
+        observation_store=ExecutionObservationStore(settings.database_path),
+        balance_service=BalanceAccountingService(
+            store=BalanceSnapshotStore(settings.database_path)
+        ),
+        now=datetime(2026, 4, 4, 10, 10, tzinfo=UTC),
+        candidate_label="strk_paradex_hyperliquid",
+    )
+
+    assert reason is None
+
+
+def test_stable_launch_label_loss_scope_blocks_same_label_loss_streak(
+    tmp_path: Path,
+) -> None:
+    settings = WorkerSettings(
+        database_path=str(tmp_path / "history.sqlite3"),
+        stable_canary_launch_max_consecutive_losing_trades=2,
+        stable_canary_launch_consecutive_loss_scope="label",
+        stable_canary_launch_recent_closed_trade_limit=5,
+    )
+    for paper_trade_id, executed_at in (
+        (101, datetime(2026, 4, 4, 10, 0, tzinfo=UTC)),
+        (102, datetime(2026, 4, 4, 10, 2, tzinfo=UTC)),
+    ):
+        _append_closed_live_trade_with_collateral_delta(
+            settings=settings,
+            paper_trade_id=paper_trade_id,
+            label="strk_paradex_hyperliquid",
+            executed_at=executed_at,
+            collateral_delta=-0.03,
+        )
+
+    reason = _build_stable_launch_loss_circuit_breaker_reason(
+        settings=settings,
+        execution_store=ExecutionJournalStore(settings.database_path),
+        observation_store=ExecutionObservationStore(settings.database_path),
+        balance_service=BalanceAccountingService(
+            store=BalanceSnapshotStore(settings.database_path)
+        ),
+        now=datetime(2026, 4, 4, 10, 10, tzinfo=UTC),
+        candidate_label="strk_paradex_hyperliquid",
+    )
+
+    assert reason == (
+        "Stable launch consecutive losing trades threshold reached: "
+        "losses=2 >= max=2 for label=strk_paradex_hyperliquid"
     )
 
 


### PR DESCRIPTION
## Summary
- add an explicit stable launch consecutive-loss scope setting
- keep the default global loss breaker unchanged
- allow opt-in label-scoped consecutive-loss checks so unrelated failed routes do not block a new route

## Production note
To use this for the STRK Hyperliquid canary after merge, set:
`CARRYME_WORKER_STABLE_CANARY_LAUNCH_CONSECUTIVE_LOSS_SCOPE=label`
on `carryme-stable-launch`, then redeploy that worker.

## Validation
- UV_PROJECT_ENVIRONMENT=.venv-codex uv run pytest -q tests/test_worker.py -k 'loss_scope or losing_trades_threshold or recent_negative_collateral_budget or worker_defaults'
- UV_PROJECT_ENVIRONMENT=.venv-codex uv run pytest -q tests/test_worker.py
- UV_PROJECT_ENVIRONMENT=.venv-codex uv run ruff check .
- UV_PROJECT_ENVIRONMENT=.venv-codex uv run mypy src apps packages tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable stable-canary loss detection scope: choose global tracking or per-label scoped tracking for consecutive loss detection (default: global). Circuit evaluation can now consider recent outcomes scoped to a candidate’s label.

* **Tests**
  * Added tests verifying label-scoped consecutive-loss behavior: cross-label isolation and same-label blocking when thresholds are reached.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->