### PR TITLE
fix: preserve Hyperliquid market metadata

### DIFF
--- a/packages/connectors/src/carryme_connectors/hyperliquid.py
+++ b/packages/connectors/src/carryme_connectors/hyperliquid.py
@@ -71,7 +71,7 @@ class HyperliquidPublicConnector(BaseHttpConnector):
             funding_rate=parse_float(row.get("funding")),
             open_interest=parse_float(row.get("openInterest")),
             daily_volume=parse_float(row.get("dayNtlVlm")),
-            raw=payload,
+            raw=row,
         )
 
     async def fetch_top_of_book(self, symbol: str) -> TopOfBook:

--- a/tests/test_connectors.py
+++ b/tests/test_connectors.py
@@ -237,7 +237,7 @@ def test_hyperliquid_connector_parses_stats_and_top_of_book() -> None:
             return httpx.Response(
                 200,
                 json=[
-                    {"universe": [{"name": "SOL"}, {"name": "STRK"}]},
+                    {"universe": [{"name": "SOL"}, {"name": "STRK", "szDecimals": 0}]},
                     [
                         {},
                         {
@@ -269,7 +269,13 @@ def test_hyperliquid_connector_parses_stats_and_top_of_book() -> None:
         assert stats.funding_rate == pytest.approx(-0.0000418197)
         assert stats.open_interest == pytest.approx(85274675.599999994)
         assert stats.daily_volume == pytest.approx(296593.6985990002)
-        assert isinstance(stats.raw, list)
+        assert stats.raw == {
+            "markPx": "0.03451",
+            "funding": "-0.0000418197",
+            "openInterest": "85274675.599999994",
+            "dayNtlVlm": "296593.6985990002",
+            "szDecimals": 0,
+        }
         assert book.best_bid_price == pytest.approx(0.03452)
         assert book.best_bid_size == pytest.approx(129958.3)
         assert book.best_ask_price == pytest.approx(0.03454)


### PR DESCRIPTION
## Summary
- store the merged Hyperliquid per-market row in MarketStats.raw
- preserve szDecimals metadata for live order previews
- add regression coverage for Hyperliquid market stats raw shape

## Validation
- UV_PROJECT_ENVIRONMENT=.venv-codex uv run pytest -q tests/test_connectors.py -k 'hyperliquid_connector_parses_stats_and_top_of_book'
- UV_PROJECT_ENVIRONMENT=.venv-codex uv run pytest -q tests/test_runtime.py -k 'order_preview_service_builds_hyperliquid_leg'
- UV_PROJECT_ENVIRONMENT=.venv-codex uv run ruff check .
- UV_PROJECT_ENVIRONMENT=.venv-codex uv run mypy src apps packages tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved accuracy of market statistics data retrieval from the Hyperliquid connector. Market information now returns more precise values for pricing, funding, and trading volume data, ensuring better data reliability for trading decisions.

* **Tests**
  * Updated test suite to validate enhanced market data accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->