### PR TITLE
fix: auto-cleanup partial-fill live routes

### DIFF
--- a/apps/worker/src/carryme_worker/poller.py
+++ b/apps/worker/src/carryme_worker/poller.py
@@ -23,6 +23,10 @@ from carryme_api.app import (
     _build_pair_close_preview_service_for_candidate,
     _build_paired_live_execution_coordinator_for_candidate,
     _execute_guarded_pair_close_from_confirmation,
+    _mark_cleanup_live_submission_completed,
+    _observe_pair_status_for_execution,
+    _release_cleanup_live_submission_reservations,
+    _reserve_cleanup_live_submission_or_existing,
     _run_guarded_canary_lifecycle,
     _select_latest_launch_ready_canary_snapshot,
 )
@@ -35,7 +39,9 @@ from carryme_models import (
     ApprovedCanarySnapshot,
     CanaryLifecycleResult,
     CandidateAlertEvent,
+    CleanupPreviewConfirmationEntry,
     ExecutionAlertEvent,
+    ExecutionCleanupPreview,
     ExecutionJournalEntry,
     ExecutionObservationEntry,
     ExecutionPairStatus,
@@ -2018,6 +2024,232 @@ def _maybe_capture_open_hedge_funding_checkpoint(
             hold_window_hours=hold_window_hours,
         ),
     )
+
+
+def _route_position_venues_for_cleanup(
+    *,
+    execution: ExecutionJournalEntry,
+    pair_status: ExecutionPairStatus,
+) -> list[str]:
+    """Return route venues that currently show an open position."""
+
+    route_legs = [
+        execution.paper_trade.intent.long_leg,
+        execution.paper_trade.intent.short_leg,
+    ]
+    position_symbols_by_venue = {
+        venue.venue: set(venue.position_symbols)
+        for venue in pair_status.reconciliation.venues
+    }
+    venues: list[str] = []
+    for leg in route_legs:
+        if leg.venue in venues:
+            continue
+        venue_positions = position_symbols_by_venue.get(leg.venue, set())
+        if leg.symbol in venue_positions:
+            venues.append(leg.venue)
+    return venues
+
+
+def _scoped_pair_status_for_cleanup_venue(
+    pair_status: ExecutionPairStatus,
+    *,
+    venue_name: str,
+) -> ExecutionPairStatus:
+    """Scope a multi-position partial-fill status to one venue cleanup preview."""
+
+    scoped_venues = []
+    for venue in pair_status.reconciliation.venues:
+        keep_venue = venue.venue == venue_name
+        scoped_venues.append(
+            venue.model_copy(
+                update={
+                    "position_symbols": venue.position_symbols if keep_venue else [],
+                    "matched_leg_symbols": venue.matched_leg_symbols if keep_venue else [],
+                    "unmatched_leg_symbols": [],
+                }
+            )
+        )
+    reconciliation = pair_status.reconciliation.model_copy(
+        update={
+            "recommended_action": "close_open_leg",
+            "venues": scoped_venues,
+        }
+    )
+    return pair_status.model_copy(
+        update={
+            "recommended_action": "close_open_leg",
+            "reconciliation": reconciliation,
+        }
+    )
+
+
+async def _maybe_auto_cleanup_partial_fill_execution(
+    *,
+    settings: WorkerSettings,
+    execution: ExecutionJournalEntry,
+    pair_status: ExecutionPairStatus,
+    approved_store: ApprovedCanaryStore,
+    execution_store: ExecutionJournalStore,
+    observation_store: ExecutionObservationStore,
+    account_service: AccountPreflightService,
+    order_state_service: ExecutionOrderStateService,
+    approval_service: RouteApprovalService | None = None,
+    scanner: OpportunityUniverseService | None = None,
+    logger: logging.Logger,
+    now: datetime,
+) -> list[ExecutionJournalEntry]:
+    """Flatten live route exposure after a partial fill makes the hedge unsafe."""
+
+    if (
+        not settings.execution_auto_pair_close_enabled
+        and not settings.execution_auto_pair_close_shadow_mode
+    ):
+        return []
+    if pair_status.derived_state != "cleanup_needed":
+        return []
+    if not any(leg.derived_state == "partial_fill" for leg in pair_status.order_state.legs):
+        return []
+
+    paper_trade = execution.paper_trade
+    if paper_trade is None or paper_trade.entry_id is None:
+        return []
+
+    cleanup_venues = _route_position_venues_for_cleanup(
+        execution=execution,
+        pair_status=pair_status,
+    )
+    if not cleanup_venues:
+        return []
+
+    if settings.execution_auto_pair_close_shadow_mode:
+        logger.info(
+            "shadow partial-fill cleanup for paper_trade_id=%s venues=%s",
+            paper_trade.entry_id,
+            ",".join(cleanup_venues),
+        )
+        return []
+
+    latest_snapshot, snapshot_source = await _resolve_auto_close_snapshot(
+        settings=settings,
+        execution=execution,
+        approved_store=approved_store,
+        approval_service=approval_service,
+        scanner=scanner,
+        logger=logger,
+        now=now,
+    )
+    if latest_snapshot is None:
+        logger.warning(
+            "skipping partial-fill cleanup for paper_trade_id=%s because no route snapshot "
+            "could be resolved",
+            paper_trade.entry_id,
+        )
+        return []
+
+    api_settings = _build_api_settings_from_worker_settings(settings)
+    cleanup_preview_service = _build_cleanup_preview_router_for_candidate(
+        api_settings,
+        latest_snapshot.candidate,
+    )
+    cleanup_live_router = _build_cleanup_live_execution_router_for_candidate(
+        api_settings,
+        latest_snapshot.candidate,
+    )
+    confirmation_store = CleanupPreviewConfirmationStore(api_settings.database_path)
+
+    cleanup_previews: list[ExecutionCleanupPreview] = []
+    for venue_name in cleanup_venues:
+        cleanup_previews.append(
+            await cleanup_preview_service.preview_from_execution(
+                entry=execution,
+                pair_status=_scoped_pair_status_for_cleanup_venue(
+                    pair_status,
+                    venue_name=venue_name,
+                ),
+                slippage_tolerance_bps=25,
+            )
+        )
+    # If a later cleanup fails, closing the largest leg first leaves less net exposure.
+    cleanup_previews.sort(key=lambda preview: preview.leg.target_notional, reverse=True)
+
+    saved_entries: list[ExecutionJournalEntry] = []
+    for cleanup_preview in cleanup_previews:
+        confirmation = confirmation_store.append(
+            CleanupPreviewConfirmationEntry(
+                confirmed_at=datetime.now(UTC),
+                paper_trade_id=paper_trade.entry_id,
+                label=paper_trade.intent.label,
+                preview_hash=cleanup_preview.preview_hash,
+                preview=cleanup_preview,
+                note=(
+                    "worker partial-fill auto-cleanup "
+                    f"[{snapshot_source or 'unknown'}]"
+                ),
+            )
+        )
+        existing_entry = _reserve_cleanup_live_submission_or_existing(
+            paper_trade=paper_trade,
+            confirmation=confirmation,
+            execution_store=execution_store,
+        )
+        if existing_entry is not None:
+            saved_entries.append(existing_entry)
+            continue
+        try:
+            journal_entry = await cleanup_live_router.submit_confirmed_cleanup_preview(
+                paper_trade=paper_trade,
+                confirmation=confirmation,
+            )
+        except (ConnectorError, UpstreamDataError, httpx.HTTPError, ValueError):
+            _release_cleanup_live_submission_reservations(
+                paper_trade=paper_trade,
+                confirmation=confirmation,
+                execution_store=execution_store,
+            )
+            raise
+        saved_entry = execution_store.append(journal_entry)
+        if saved_entry.entry_id is None:
+            raise RuntimeError("Cleanup execution journal append did not return an id")
+        _mark_cleanup_live_submission_completed(
+            paper_trade=paper_trade,
+            confirmation=confirmation,
+            execution_store=execution_store,
+            execution_entry_id=saved_entry.entry_id,
+        )
+        saved_entries.append(saved_entry)
+        try:
+            latest_status = await _observe_pair_status_for_execution(
+                paper_trade=paper_trade,
+                execution=saved_entry,
+                settings=api_settings,
+                account_service=account_service,
+                order_state_service=order_state_service,
+                observation_store=observation_store,
+                observation_context="worker_partial_fill_cleanup_poll",
+                poll_attempts=3,
+                poll_interval_seconds=1.0,
+            )
+            if latest_status.derived_state == "closed":
+                break
+        except Exception:
+            logger.warning(
+                "partial-fill cleanup observation failed for paper_trade_id=%s "
+                "execution_entry_id=%s",
+                paper_trade.entry_id,
+                saved_entry.entry_id,
+                exc_info=True,
+            )
+
+    if saved_entries:
+        logger.info(
+            "partial-fill auto-cleanup submitted %s cleanup executions for "
+            "paper_trade_id=%s venues=%s",
+            len(saved_entries),
+            paper_trade.entry_id,
+            ",".join(entry.legs[0].venue for entry in saved_entries if entry.legs),
+        )
+    return saved_entries
 
 
 async def _maybe_auto_close_open_hedged_execution(
@@ -4790,6 +5022,30 @@ async def observe_live_executions_once(
         except Exception:
             loop_logger.warning(
                 "Failed to capture funding checkpoint for execution entry_id=%s paper_trade_id=%s",
+                execution.entry_id,
+                execution.paper_trade_id,
+                exc_info=True,
+            )
+        try:
+            cleanup_entries = await _maybe_auto_cleanup_partial_fill_execution(
+                settings=settings,
+                execution=execution,
+                pair_status=pair_status,
+                approved_store=approved_snapshot_store,
+                execution_store=journal_store,
+                observation_store=history_store,
+                account_service=account_probe_service,
+                order_state_service=state_service,
+                approval_service=auto_close_approval_service,
+                scanner=auto_close_scanner,
+                logger=loop_logger,
+                now=timestamp,
+            )
+            if cleanup_entries:
+                continue
+        except Exception:
+            loop_logger.warning(
+                "Failed to auto-cleanup partial-fill execution entry_id=%s paper_trade_id=%s",
                 execution.entry_id,
                 execution.paper_trade_id,
                 exc_info=True,

--- a/apps/worker/src/carryme_worker/poller.py
+++ b/apps/worker/src/carryme_worker/poller.py
@@ -2037,16 +2037,21 @@ def _route_position_venues_for_cleanup(
         execution.paper_trade.intent.long_leg,
         execution.paper_trade.intent.short_leg,
     ]
-    position_symbols_by_venue = {
-        venue.venue: set(venue.position_symbols)
-        for venue in pair_status.reconciliation.venues
-    }
+    matched_symbols_by_venue: dict[str, set[str]] = {}
+    for venue in pair_status.reconciliation.venues:
+        # Reconciliation is the source of truth when present. Fall back to exact
+        # raw symbols only for legacy/partial observations that did not populate
+        # matched or unmatched route-leg symbols.
+        if venue.matched_leg_symbols or venue.unmatched_leg_symbols:
+            matched_symbols_by_venue[venue.venue] = set(venue.matched_leg_symbols)
+        else:
+            matched_symbols_by_venue[venue.venue] = set(venue.position_symbols)
     venues: list[str] = []
     for leg in route_legs:
         if leg.venue in venues:
             continue
-        venue_positions = position_symbols_by_venue.get(leg.venue, set())
-        if leg.symbol in venue_positions:
+        venue_matches = matched_symbols_by_venue.get(leg.venue, set())
+        if leg.symbol in venue_matches:
             venues.append(leg.venue)
     return venues
 
@@ -2152,32 +2157,63 @@ async def _maybe_auto_cleanup_partial_fill_execution(
         api_settings,
         latest_snapshot.candidate,
     )
-    cleanup_live_router = _build_cleanup_live_execution_router_for_candidate(
-        api_settings,
-        latest_snapshot.candidate,
-    )
     confirmation_store = CleanupPreviewConfirmationStore(api_settings.database_path)
 
     cleanup_previews: list[ExecutionCleanupPreview] = []
     for venue_name in cleanup_venues:
-        cleanup_previews.append(
-            await cleanup_preview_service.preview_from_execution(
-                entry=execution,
-                pair_status=_scoped_pair_status_for_cleanup_venue(
-                    pair_status,
-                    venue_name=venue_name,
+        try:
+            async with asyncio.timeout(settings.execution_auto_pair_close_timeout_seconds):
+                cleanup_previews.append(
+                    await cleanup_preview_service.preview_from_execution(
+                        entry=execution,
+                        pair_status=_scoped_pair_status_for_cleanup_venue(
+                            pair_status,
+                            venue_name=venue_name,
+                        ),
+                        slippage_tolerance_bps=25,
+                    )
+                )
+        except TimeoutError:
+            logger.warning(
+                (
+                    "timed out building partial-fill cleanup preview for paper_trade_id=%s "
+                    "venue=%s after %.1f seconds"
                 ),
-                slippage_tolerance_bps=25,
+                paper_trade.entry_id,
+                venue_name,
+                settings.execution_auto_pair_close_timeout_seconds,
             )
-        )
+            continue
     # If a later cleanup fails, closing the largest leg first leaves less net exposure.
     cleanup_previews.sort(key=lambda preview: preview.leg.target_notional, reverse=True)
 
     saved_entries: list[ExecutionJournalEntry] = []
+    cleanup_live_router = None
     for cleanup_preview in cleanup_previews:
+        existing_entry = execution_store.find_by_paper_trade_preview_hash(
+            paper_trade_id=paper_trade.entry_id,
+            preview_hash=cleanup_preview.preview_hash,
+        )
+        if existing_entry is not None:
+            saved_entries.append(existing_entry)
+            continue
+        if execution_store.has_pending_cleanup_live_submission(
+            paper_trade_id=paper_trade.entry_id,
+            preview_hash=cleanup_preview.preview_hash,
+        ):
+            logger.warning(
+                (
+                    "skipping partial-fill cleanup for paper_trade_id=%s preview_hash=%s "
+                    "because a cleanup submission is reserved but not journaled; "
+                    "manual reconciliation is required"
+                ),
+                paper_trade.entry_id,
+                cleanup_preview.preview_hash,
+            )
+            return saved_entries
         confirmation = confirmation_store.append(
             CleanupPreviewConfirmationEntry(
-                confirmed_at=datetime.now(UTC),
+                confirmed_at=now,
                 paper_trade_id=paper_trade.entry_id,
                 label=paper_trade.intent.label,
                 preview_hash=cleanup_preview.preview_hash,
@@ -2196,11 +2232,29 @@ async def _maybe_auto_cleanup_partial_fill_execution(
         if existing_entry is not None:
             saved_entries.append(existing_entry)
             continue
-        try:
-            journal_entry = await cleanup_live_router.submit_confirmed_cleanup_preview(
-                paper_trade=paper_trade,
-                confirmation=confirmation,
+        if cleanup_live_router is None:
+            cleanup_live_router = _build_cleanup_live_execution_router_for_candidate(
+                api_settings,
+                latest_snapshot.candidate,
             )
+        try:
+            async with asyncio.timeout(settings.execution_auto_pair_close_timeout_seconds):
+                journal_entry = await cleanup_live_router.submit_confirmed_cleanup_preview(
+                    paper_trade=paper_trade,
+                    confirmation=confirmation,
+                )
+        except TimeoutError:
+            logger.warning(
+                (
+                    "timed out submitting partial-fill cleanup for paper_trade_id=%s "
+                    "preview_hash=%s after %.1f seconds; keeping submission reservation "
+                    "for manual reconciliation before retry"
+                ),
+                paper_trade.entry_id,
+                confirmation.preview_hash,
+                settings.execution_auto_pair_close_timeout_seconds,
+            )
+            return saved_entries
         except (ConnectorError, UpstreamDataError, httpx.HTTPError, ValueError):
             _release_cleanup_live_submission_reservations(
                 paper_trade=paper_trade,

--- a/packages/storage/src/carryme_storage/executions.py
+++ b/packages/storage/src/carryme_storage/executions.py
@@ -654,6 +654,34 @@ class ExecutionJournalStore:
         rowcount = getattr(result, "rowcount", None)
         return isinstance(rowcount, int) and rowcount > 0
 
+    def has_pending_cleanup_live_submission(
+        self,
+        *,
+        paper_trade_id: int,
+        preview_hash: str,
+    ) -> bool:
+        """Return whether one cleanup submission is reserved but not journaled."""
+
+        self.initialize()
+        if paper_trade_id < 1:
+            raise ValueError("paper_trade_id must be positive")
+        normalized_preview_hash = preview_hash.strip()
+        if not normalized_preview_hash:
+            raise ValueError("preview_hash must be non-empty")
+        with self.database.begin() as connection:
+            row = connection.execute(
+                """
+                SELECT 1
+                FROM cleanup_live_submission_reservations
+                WHERE paper_trade_id = ?
+                  AND preview_hash = ?
+                  AND execution_entry_id IS NULL
+                LIMIT 1
+                """,
+                (paper_trade_id, normalized_preview_hash),
+            ).fetchone()
+        return row is not None
+
     def find_by_paper_trade_preview_hash(
         self,
         *,

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -61,6 +61,7 @@ from carryme_storage import (
     ApprovedCanaryAlertStore,
     ApprovedCanaryStore,
     BalanceSnapshotStore,
+    CleanupPreviewConfirmationStore,
     ExecutionAlertStore,
     ExecutionJournalStore,
     ExecutionObservationStore,
@@ -11430,9 +11431,11 @@ def test_maybe_auto_cleanup_partial_fill_execution_flattens_each_open_route_leg(
     )
     execution_store = ExecutionJournalStore(settings.database_path)
     observation_store = ExecutionObservationStore(settings.database_path)
+    confirmation_store = CleanupPreviewConfirmationStore(settings.database_path)
     execution = execution_store.append(_build_partial_fill_cleanup_execution())
     pair_status = _build_partial_fill_cleanup_pair_status(execution)
     submitted_venues: list[str] = []
+    now = datetime(2026, 4, 5, 10, 2, tzinfo=UTC)
 
     class FakeCleanupPreviewRouter:
         async def preview_from_execution(
@@ -11551,7 +11554,7 @@ def test_maybe_auto_cleanup_partial_fill_execution_flattens_each_open_route_leg(
                 account_service=cast(AccountPreflightService, object()),
                 order_state_service=cast(ExecutionOrderStateService, object()),
                 logger=logging.getLogger("test"),
-                now=datetime(2026, 4, 5, 10, 2, tzinfo=UTC),
+                now=now,
             )
         )
 
@@ -11562,6 +11565,134 @@ def test_maybe_auto_cleanup_partial_fill_execution_flattens_each_open_route_leg(
         "paradex_cleanup_live",
     ]
     assert all(entry.entry_id is not None for entry in result)
+    assert all(entry.confirmation_entry_id is not None for entry in result)
+    confirmations = confirmation_store.list_recent(paper_trade_id=31)
+    assert len(confirmations) == 2
+    assert {entry.confirmed_at for entry in confirmations} == {now}
+
+
+def test_maybe_auto_cleanup_partial_fill_execution_skips_pending_reservation(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    settings = WorkerSettings(
+        database_path=str(tmp_path / "history.sqlite3"),
+        execution_auto_pair_close_enabled=True,
+    )
+    execution_store = ExecutionJournalStore(settings.database_path)
+    observation_store = ExecutionObservationStore(settings.database_path)
+    confirmation_store = CleanupPreviewConfirmationStore(settings.database_path)
+    execution = execution_store.append(_build_partial_fill_cleanup_execution())
+    pair_status = _build_partial_fill_cleanup_pair_status(execution).model_copy(
+        update={
+            "reconciliation": _build_partial_fill_cleanup_pair_status(
+                execution
+            ).reconciliation.model_copy(
+                update={
+                    "venues": [
+                        ExecutionVenueReconciliation(
+                            venue="extended",
+                            authenticated=True,
+                            ready=True,
+                            position_symbols=["JUP-PERP"],
+                            matched_leg_symbols=["JUP-USD"],
+                            unmatched_leg_symbols=[],
+                        ),
+                        ExecutionVenueReconciliation(
+                            venue="paradex",
+                            authenticated=True,
+                            ready=True,
+                            position_symbols=[],
+                            matched_leg_symbols=[],
+                            unmatched_leg_symbols=["JUP-USD-PERP"],
+                        ),
+                    ]
+                }
+            )
+        }
+    )
+    execution_store.reserve_cleanup_live_submission(
+        paper_trade_id=31,
+        preview_hash="extended-cleanup-preview",
+        confirmation_entry_id=99,
+    )
+
+    class FakeCleanupPreviewRouter:
+        async def preview_from_execution(
+            self,
+            *,
+            entry: ExecutionJournalEntry,
+            pair_status: ExecutionPairStatus,
+            slippage_tolerance_bps: int,
+        ) -> ExecutionCleanupPreview:
+            _ = pair_status, slippage_tolerance_bps
+            leg = next(result for result in entry.legs if result.venue == "extended")
+            return ExecutionCleanupPreview(
+                execution_entry_id=entry.entry_id,
+                paper_trade_id=entry.paper_trade_id,
+                generated_at=datetime(2026, 4, 5, 10, 2, tzinfo=UTC),
+                preview_hash="extended-cleanup-preview",
+                reason="close_open_leg",
+                leg=VenueOrderPreview(
+                    venue="extended",
+                    symbol=leg.symbol,
+                    fee_profile=leg.fee_profile,
+                    side="buy",
+                    target_notional=70.0,
+                    effective_notional=70.0,
+                    quantity=1.0,
+                    quantity_text="1",
+                    reference_price=1.0,
+                    reference_price_source="best_ask",
+                    worst_acceptable_price=1.0,
+                    worst_price_text="1",
+                    reduce_only=True,
+                    endpoint_path_hint="/orders",
+                    auth_scheme="test",
+                    payload={"reduce_only": True},
+                ),
+            )
+
+    async def fake_resolve_snapshot(**_: object) -> tuple[ApprovedCanarySnapshot, str]:
+        return (
+            _build_auto_close_snapshot(captured_at=datetime(2026, 4, 5, 10, 1, tzinfo=UTC)),
+            "approved_snapshot",
+        )
+
+    with pytest.MonkeyPatch.context() as monkeypatch:
+        monkeypatch.setattr(
+            "carryme_worker.poller._resolve_auto_close_snapshot",
+            fake_resolve_snapshot,
+        )
+        monkeypatch.setattr(
+            "carryme_worker.poller._build_cleanup_preview_router_for_candidate",
+            lambda *args, **kwargs: FakeCleanupPreviewRouter(),
+        )
+        monkeypatch.setattr(
+            "carryme_worker.poller._build_cleanup_live_execution_router_for_candidate",
+            lambda *args, **kwargs: (_ for _ in ()).throw(
+                AssertionError("pending reservation must block live cleanup submission")
+            ),
+        )
+        caplog.set_level(logging.WARNING)
+        result = asyncio.run(
+            _maybe_auto_cleanup_partial_fill_execution(
+                settings=settings,
+                execution=execution,
+                pair_status=pair_status,
+                approved_store=ApprovedCanaryStore(settings.database_path),
+                execution_store=execution_store,
+                observation_store=observation_store,
+                account_service=cast(AccountPreflightService, object()),
+                order_state_service=cast(ExecutionOrderStateService, object()),
+                logger=logging.getLogger("test"),
+                now=datetime(2026, 4, 5, 10, 2, tzinfo=UTC),
+            )
+        )
+
+    assert result == []
+    assert confirmation_store.list_recent(paper_trade_id=31) == []
+    assert "reserved but not journaled" in caplog.text
 
 
 def test_maybe_auto_cleanup_partial_fill_execution_shadow_mode_does_not_submit(

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -15,7 +15,9 @@ from carryme_models import (
     ApprovedCanarySnapshot,
     CandidateAlertEvent,
     CapacityEstimate,
+    CleanupPreviewConfirmationEntry,
     ExecutionAlertEvent,
+    ExecutionCleanupPreview,
     ExecutionJournalEntry,
     ExecutionLegOrderState,
     ExecutionLegResult,
@@ -45,6 +47,7 @@ from carryme_models import (
     TradeLegIntent,
     VenueAccountPreflight,
     VenueBalanceSnapshot,
+    VenueOrderPreview,
     VenueSystemState,
 )
 from carryme_runtime import (
@@ -128,6 +131,7 @@ from carryme_worker.poller import (
     _build_stable_launch_loss_circuit_breaker_reason,
     _execution_requires_continued_monitoring,
     _list_ranked_stable_launch_ready_stabilities,
+    _maybe_auto_cleanup_partial_fill_execution,
     _maybe_auto_close_open_hedged_execution,
     _probe_candidate_system_state,
     _with_current_execution_quality,
@@ -11315,6 +11319,290 @@ def _build_auto_close_execution_leg() -> ExecutionLegResult:
         simulated=False,
         external_reference="ext-order-auto-close",
     )
+
+
+def _build_partial_fill_cleanup_execution() -> ExecutionJournalEntry:
+    paper_trade = _build_auto_close_paper_trade(
+        entry_id=31,
+        created_at=datetime(2026, 4, 5, 10, 0, tzinfo=UTC),
+    )
+    return ExecutionJournalEntry(
+        entry_id=101,
+        executed_at=datetime(2026, 4, 5, 10, 1, tzinfo=UTC),
+        adapter="paired_live:extended_then_paradex",
+        mode="live",
+        status="submitted",
+        paper_trade_id=31,
+        preview_hash="partial-entry-preview",
+        confirmation_entry_id=31,
+        paper_trade=paper_trade,
+        legs=[
+            ExecutionLegResult(
+                venue="extended",
+                symbol="JUP-USD",
+                fee_profile="default",
+                side="sell",
+                target_notional=25.0,
+                status="submitted",
+                simulated=False,
+                external_reference="extended-entry",
+            ),
+            ExecutionLegResult(
+                venue="paradex",
+                symbol="JUP-USD-PERP",
+                fee_profile="pro_fastfills",
+                side="buy",
+                target_notional=25.0,
+                status="submitted",
+                simulated=False,
+                external_reference="paradex-entry",
+            ),
+        ],
+    )
+
+
+def _build_partial_fill_cleanup_pair_status(
+    execution: ExecutionJournalEntry,
+) -> ExecutionPairStatus:
+    return ExecutionPairStatus(
+        execution_entry_id=execution.entry_id,
+        paper_trade_id=execution.paper_trade_id,
+        preview_hash=execution.preview_hash,
+        derived_state="cleanup_needed",
+        recommended_action="manual_review_required",
+        order_state=ExecutionOrderState(
+            execution_entry_id=execution.entry_id,
+            paper_trade_id=execution.paper_trade_id,
+            preview_hash=execution.preview_hash,
+            legs=[
+                ExecutionLegOrderState(
+                    venue="extended",
+                    supported=True,
+                    derived_state="filled",
+                    external_reference="extended-entry",
+                ),
+                ExecutionLegOrderState(
+                    venue="paradex",
+                    supported=True,
+                    derived_state="partial_fill",
+                    external_reference="paradex-entry",
+                ),
+            ],
+            notes=[],
+        ),
+        reconciliation=ExecutionReconciliation(
+            execution_entry_id=execution.entry_id,
+            paper_trade_id=execution.paper_trade_id,
+            preview_hash=execution.preview_hash,
+            status="submitted",
+            recommended_action="monitor_open_hedge",
+            matched_all_leg_symbols=True,
+            venues=[
+                ExecutionVenueReconciliation(
+                    venue="extended",
+                    authenticated=True,
+                    ready=True,
+                    position_symbols=["JUP-USD"],
+                    matched_leg_symbols=["JUP-USD"],
+                    unmatched_leg_symbols=[],
+                ),
+                ExecutionVenueReconciliation(
+                    venue="paradex",
+                    authenticated=True,
+                    ready=True,
+                    position_symbols=["JUP-USD-PERP"],
+                    matched_leg_symbols=["JUP-USD-PERP"],
+                    unmatched_leg_symbols=[],
+                ),
+            ],
+            notes=[],
+        ),
+        notes=["At least one leg is partially filled; do not assume the pair is hedged."],
+    )
+
+
+def test_maybe_auto_cleanup_partial_fill_execution_flattens_each_open_route_leg(
+    tmp_path: Path,
+) -> None:
+    settings = WorkerSettings(
+        database_path=str(tmp_path / "history.sqlite3"),
+        execution_auto_pair_close_enabled=True,
+    )
+    execution_store = ExecutionJournalStore(settings.database_path)
+    observation_store = ExecutionObservationStore(settings.database_path)
+    execution = execution_store.append(_build_partial_fill_cleanup_execution())
+    pair_status = _build_partial_fill_cleanup_pair_status(execution)
+    submitted_venues: list[str] = []
+
+    class FakeCleanupPreviewRouter:
+        async def preview_from_execution(
+            self,
+            *,
+            entry: ExecutionJournalEntry,
+            pair_status: ExecutionPairStatus,
+            slippage_tolerance_bps: int,
+        ) -> ExecutionCleanupPreview:
+            _ = slippage_tolerance_bps
+            open_venues = [
+                venue
+                for venue in pair_status.reconciliation.venues
+                if venue.position_symbols
+            ]
+            assert len(open_venues) == 1
+            target_venue = open_venues[0].venue
+            target_leg = next(leg for leg in entry.legs if leg.venue == target_venue)
+            target_notional = 70.0 if target_venue == "extended" else 25.0
+            side = "buy" if target_leg.side == "sell" else "sell"
+            return ExecutionCleanupPreview(
+                execution_entry_id=entry.entry_id,
+                paper_trade_id=entry.paper_trade_id,
+                generated_at=datetime(2026, 4, 5, 10, 2, tzinfo=UTC),
+                preview_hash=f"{target_venue}-cleanup-preview",
+                reason="close_open_leg",
+                leg=VenueOrderPreview(
+                    venue=target_venue,
+                    symbol=target_leg.symbol,
+                    fee_profile=target_leg.fee_profile,
+                    side=cast(Literal["buy", "sell"], side),
+                    target_notional=target_notional,
+                    effective_notional=target_notional,
+                    quantity=1.0,
+                    quantity_text="1",
+                    reference_price=1.0,
+                    reference_price_source="best_ask" if side == "buy" else "best_bid",
+                    worst_acceptable_price=1.0,
+                    worst_price_text="1",
+                    reduce_only=True,
+                    endpoint_path_hint="/orders",
+                    auth_scheme="test",
+                    payload={"reduce_only": True},
+                ),
+            )
+
+    class FakeCleanupLiveRouter:
+        async def submit_confirmed_cleanup_preview(
+            self,
+            *,
+            paper_trade: PaperTradeEntry,
+            confirmation: CleanupPreviewConfirmationEntry,
+            executed_at: datetime | None = None,
+        ) -> ExecutionJournalEntry:
+            _ = executed_at
+            leg = confirmation.preview.leg
+            submitted_venues.append(leg.venue)
+            return ExecutionJournalEntry(
+                executed_at=datetime(2026, 4, 5, 10, 3, tzinfo=UTC),
+                adapter=f"{leg.venue}_cleanup_live",
+                mode="live",
+                status="submitted",
+                paper_trade_id=paper_trade.entry_id,
+                preview_hash=confirmation.preview_hash,
+                confirmation_entry_id=confirmation.entry_id,
+                paper_trade=paper_trade,
+                legs=[
+                    ExecutionLegResult(
+                        venue=leg.venue,
+                        symbol=leg.symbol,
+                        fee_profile=leg.fee_profile,
+                        side=leg.side,
+                        target_notional=leg.target_notional,
+                        status="submitted",
+                        simulated=False,
+                        external_reference=f"{leg.venue}-cleanup-order",
+                        request_payload=leg.payload,
+                    )
+                ],
+            )
+
+    async def fake_resolve_snapshot(**_: object) -> tuple[ApprovedCanarySnapshot, str]:
+        return (
+            _build_auto_close_snapshot(captured_at=datetime(2026, 4, 5, 10, 1, tzinfo=UTC)),
+            "approved_snapshot",
+        )
+
+    async def fake_observe_pair_status(**_: object) -> ExecutionPairStatus:
+        return pair_status
+
+    with pytest.MonkeyPatch.context() as monkeypatch:
+        monkeypatch.setattr(
+            "carryme_worker.poller._resolve_auto_close_snapshot",
+            fake_resolve_snapshot,
+        )
+        monkeypatch.setattr(
+            "carryme_worker.poller._build_cleanup_preview_router_for_candidate",
+            lambda *args, **kwargs: FakeCleanupPreviewRouter(),
+        )
+        monkeypatch.setattr(
+            "carryme_worker.poller._build_cleanup_live_execution_router_for_candidate",
+            lambda *args, **kwargs: FakeCleanupLiveRouter(),
+        )
+        monkeypatch.setattr(
+            "carryme_worker.poller._observe_pair_status_for_execution",
+            fake_observe_pair_status,
+        )
+        result = asyncio.run(
+            _maybe_auto_cleanup_partial_fill_execution(
+                settings=settings,
+                execution=execution,
+                pair_status=pair_status,
+                approved_store=ApprovedCanaryStore(settings.database_path),
+                execution_store=execution_store,
+                observation_store=observation_store,
+                account_service=cast(AccountPreflightService, object()),
+                order_state_service=cast(ExecutionOrderStateService, object()),
+                logger=logging.getLogger("test"),
+                now=datetime(2026, 4, 5, 10, 2, tzinfo=UTC),
+            )
+        )
+
+    assert [entry.legs[0].venue for entry in result] == ["extended", "paradex"]
+    assert submitted_venues == ["extended", "paradex"]
+    assert [entry.adapter for entry in result] == [
+        "extended_cleanup_live",
+        "paradex_cleanup_live",
+    ]
+    assert all(entry.entry_id is not None for entry in result)
+
+
+def test_maybe_auto_cleanup_partial_fill_execution_shadow_mode_does_not_submit(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    settings = WorkerSettings(
+        database_path=str(tmp_path / "history.sqlite3"),
+        execution_auto_pair_close_enabled=False,
+        execution_auto_pair_close_shadow_mode=True,
+    )
+    execution_store = ExecutionJournalStore(settings.database_path)
+    observation_store = ExecutionObservationStore(settings.database_path)
+    execution = execution_store.append(_build_partial_fill_cleanup_execution())
+    pair_status = _build_partial_fill_cleanup_pair_status(execution)
+
+    with pytest.MonkeyPatch.context() as monkeypatch:
+        monkeypatch.setattr(
+            "carryme_worker.poller._build_cleanup_live_execution_router_for_candidate",
+            lambda *args, **kwargs: (_ for _ in ()).throw(
+                AssertionError("shadow partial-fill cleanup must not submit live orders")
+            ),
+        )
+        caplog.set_level(logging.INFO)
+        result = asyncio.run(
+            _maybe_auto_cleanup_partial_fill_execution(
+                settings=settings,
+                execution=execution,
+                pair_status=pair_status,
+                approved_store=ApprovedCanaryStore(settings.database_path),
+                execution_store=execution_store,
+                observation_store=observation_store,
+                account_service=cast(AccountPreflightService, object()),
+                order_state_service=cast(ExecutionOrderStateService, object()),
+                logger=logging.getLogger("test"),
+                now=datetime(2026, 4, 5, 10, 2, tzinfo=UTC),
+            )
+        )
+
+    assert result == []
+    assert "shadow partial-fill cleanup for paper_trade_id=31" in caplog.text
 
 
 def test_launch_latest_stable_canary_once_shadow_mode_skips_live_submission(


### PR DESCRIPTION
## Summary
- add worker-side partial-fill auto-cleanup for live routes that become unsafe before they are hedged
- scope cleanup previews per venue, sort reduce-only cleanups by largest notional first, journal confirmations/executions, and reuse existing cleanup submission reservations
- keep shadow-mode behavior non-mutating and covered by tests

## Root Cause
The execution monitor correctly detected the TIA partial-fill imbalance as `cleanup_needed`, but the pair status stayed on `manual_review_required`. That emitted an alert without automatically flattening the live exposure, which is unsafe for unattended multi-route mode.

## Validation
- `uv run ruff check .`
- `uv run mypy src apps packages tests`
- `uv run pytest tests/test_worker.py -q -k 'auto_cleanup_partial_fill or observe_live_executions_once_triggers_auto_close or maybe_auto_close_open_hedged_execution'`
- `uv run pytest -q`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automated cleanup for partially-filled hedged positions across multiple execution venues
  * Intelligent multi-venue coordination for consolidating open positions
  * Shadow mode support for safely testing cleanup operations

* **Reliability**
  * Avoids duplicate cleanup submissions by detecting pending cleanup reservations not yet finalized

* **Tests**
  * Extended test coverage for partial-fill auto-cleanup scenarios, reservation handling, and shadow-mode behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->