### PR TITLE
fix: gate paired live execution on first leg fills

### DIFF
--- a/packages/runtime/src/carryme_runtime/execution_accounting.py
+++ b/packages/runtime/src/carryme_runtime/execution_accounting.py
@@ -339,6 +339,9 @@ class ExecutionAccountingService:
             ]
             if events:
                 return events
+        response_events = self._extract_hyperliquid_submission_fill_events(payload)
+        if response_events:
+            return response_events
         observed = payload.get("observed_order_state")
         if isinstance(observed, dict):
             event = self._fill_event_from_state(observed)
@@ -353,6 +356,43 @@ class ExecutionAccountingService:
             return []
         event = self._fill_event_from_state(observed)
         return [event] if event is not None else []
+
+    def _extract_hyperliquid_submission_fill_events(
+        self,
+        payload: dict[str, Any],
+    ) -> list[dict[str, float]]:
+        response = payload.get("response")
+        if not isinstance(response, dict):
+            return []
+        data = response.get("data")
+        if not isinstance(data, dict):
+            return []
+        statuses = data.get("statuses")
+        if not isinstance(statuses, list):
+            return []
+
+        events: list[dict[str, float]] = []
+        for status in statuses:
+            if not isinstance(status, dict):
+                continue
+            filled = status.get("filled")
+            if not isinstance(filled, dict):
+                continue
+            filled_size = parse_float(filled.get("totalSz"))
+            if filled_size is None:
+                filled_size = parse_float(filled.get("sz"))
+            avg_fill_price = parse_float(filled.get("avgPx"))
+            if filled_size is None or filled_size <= 0:
+                continue
+            if avg_fill_price is None:
+                continue
+            events.append(
+                {
+                    "filled_size": filled_size,
+                    "filled_notional": filled_size * avg_fill_price,
+                }
+            )
+        return events
 
     def _fill_event_from_state(self, state: dict[str, Any]) -> dict[str, float] | None:
         derived_state = state.get("derived_state")

--- a/packages/runtime/src/carryme_runtime/execution_order_state.py
+++ b/packages/runtime/src/carryme_runtime/execution_order_state.py
@@ -561,9 +561,7 @@ def _extract_hyperliquid_order_update(
 ) -> ExecutionLegOrderState | None:
     if _coerce_int(_string_value(payload, "oid") or "") != oid:
         return None
-    status = _string_value(payload, "status")
-    order = payload.get("order")
-    order_payload = order if isinstance(order, dict) else {}
+    order_payload, status = _hyperliquid_order_payload_and_status(payload)
     remaining_size = _string_value(order_payload, "sz") or _string_value(payload, "sz")
     size = _string_value(order_payload, "origSz") or _string_value(payload, "origSz")
     avg_fill_price = _string_value(order_payload, "avgPx") or _string_value(payload, "avgPx")
@@ -595,9 +593,7 @@ def _build_hyperliquid_order_state(
     observation_source: ObservationSource,
     notes: list[str] | None = None,
 ) -> ExecutionLegOrderState:
-    order = payload.get("order")
-    order_payload = order if isinstance(order, dict) else {}
-    status = _string_value(payload, "status") or _string_value(order_payload, "status")
+    order_payload, status = _hyperliquid_order_payload_and_status(payload)
     remaining_size = _string_value(order_payload, "sz")
     size = _string_value(order_payload, "origSz")
     avg_fill_price = _string_value(order_payload, "avgPx")
@@ -620,6 +616,41 @@ def _build_hyperliquid_order_state(
         raw_response=payload,
         notes=notes or [],
     )
+
+
+def _hyperliquid_order_payload_and_status(
+    payload: dict[str, Any],
+) -> tuple[dict[str, Any], str | None]:
+    top_level_status = _string_value(payload, "status")
+    order = payload.get("order")
+    if not isinstance(order, dict):
+        return {}, top_level_status
+
+    nested_order = order.get("order")
+    if isinstance(nested_order, dict):
+        nested_status = _string_value(order, "status")
+        return nested_order, _prefer_hyperliquid_order_status(
+            top_level_status=top_level_status,
+            nested_status=nested_status,
+        )
+
+    nested_status = _string_value(order, "status")
+    return order, _prefer_hyperliquid_order_status(
+        top_level_status=top_level_status,
+        nested_status=nested_status,
+    )
+
+
+def _prefer_hyperliquid_order_status(
+    *,
+    top_level_status: str | None,
+    nested_status: str | None,
+) -> str | None:
+    if top_level_status is None:
+        return nested_status
+    if top_level_status.lower() == "order" and nested_status is not None:
+        return nested_status
+    return top_level_status
 
 
 def _fetch_hyperliquid_order_state(account_address: str, oid: int) -> dict[str, Any]:

--- a/packages/runtime/src/carryme_runtime/paired_live_execution.py
+++ b/packages/runtime/src/carryme_runtime/paired_live_execution.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import UTC, datetime
-from typing import Literal, Protocol
+from typing import Any, Literal, Protocol
 
 import httpx
 from carryme_connectors import ConnectorError
@@ -14,6 +14,8 @@ from carryme_models import (
     PaperTradeEntry,
     PreviewConfirmationEntry,
 )
+
+ObservedFillState = Literal["filled", "partial_fill", "unfilled", "unknown"]
 
 
 class SingleVenueLiveExecutionService(Protocol):
@@ -78,6 +80,22 @@ class PairedLiveExecutionCoordinator:
                 adapter=f"paired_live:{normalized_first}_then_{second_venue}",
                 mode="live",
                 status="rejected",
+                paper_trade_id=paper_trade.entry_id,
+                preview_hash=confirmation.preview_hash,
+                confirmation_entry_id=confirmation.entry_id,
+                paper_trade=paper_trade,
+                legs=legs,
+            )
+        first_fill_state = self._submission_observed_fill_state(first_result)
+        if first_fill_state in {"unfilled", "partial_fill"}:
+            guarded_status: Literal["rejected", "partial"] = (
+                "partial" if first_fill_state == "partial_fill" else "rejected"
+            )
+            return ExecutionJournalEntry(
+                executed_at=timestamp,
+                adapter=f"paired_live:{normalized_first}_then_{second_venue}",
+                mode="live",
+                status=guarded_status,
                 paper_trade_id=paper_trade.entry_id,
                 preview_hash=confirmation.preview_hash,
                 confirmation_entry_id=confirmation.entry_id,
@@ -173,3 +191,55 @@ class PairedLiveExecutionCoordinator:
             preview_venues,
             key=lambda venue: (venue_priority.get(venue, 100), preview_venues.index(venue)),
         )
+
+    @staticmethod
+    def _submission_observed_fill_state(entry: ExecutionJournalEntry) -> ObservedFillState:
+        states = [
+            PairedLiveExecutionCoordinator._leg_observed_fill_state(leg)
+            for leg in entry.legs
+        ]
+        concrete_states = [state for state in states if state != "unknown"]
+        if not concrete_states:
+            return "unknown"
+        if any(state == "partial_fill" for state in concrete_states):
+            return "partial_fill"
+        has_filled = any(state == "filled" for state in concrete_states)
+        has_unfilled = any(state == "unfilled" for state in concrete_states)
+        if has_filled and has_unfilled:
+            return "partial_fill"
+        if has_unfilled:
+            return "unfilled"
+        if has_filled:
+            return "filled"
+        return "unknown"
+
+    @staticmethod
+    def _leg_observed_fill_state(leg: ExecutionLegResult) -> ObservedFillState:
+        payload = leg.response_payload if isinstance(leg.response_payload, dict) else {}
+        observed_state = _observed_fill_state(payload.get("observed_order_state"))
+        if observed_state != "unknown":
+            return observed_state
+
+        attempt_history = payload.get("attempt_history")
+        if not isinstance(attempt_history, list):
+            return "unknown"
+        for attempt in reversed(attempt_history):
+            if not isinstance(attempt, dict):
+                continue
+            observed_state = _observed_fill_state(attempt.get("observed_order_state"))
+            if observed_state != "unknown":
+                return observed_state
+        return "unknown"
+
+
+def _observed_fill_state(value: Any) -> ObservedFillState:
+    if not isinstance(value, dict):
+        return "unknown"
+    derived_state = value.get("derived_state")
+    if derived_state == "filled":
+        return "filled"
+    if derived_state == "partial_fill":
+        return "partial_fill"
+    if derived_state == "unfilled":
+        return "unfilled"
+    return "unknown"

--- a/packages/runtime/src/carryme_runtime/paired_live_execution.py
+++ b/packages/runtime/src/carryme_runtime/paired_live_execution.py
@@ -226,6 +226,13 @@ class PairedLiveExecutionCoordinator:
 
         attempt_history = payload.get("attempt_history")
         if not isinstance(attempt_history, list):
+            logger.warning(
+                "missing observed order state in live execution leg payload venue=%r "
+                "external_reference=%r payload=%r",
+                leg.venue,
+                leg.external_reference,
+                payload,
+            )
             return "unknown"
         for attempt in reversed(attempt_history):
             if not isinstance(attempt, dict):

--- a/packages/runtime/src/carryme_runtime/paired_live_execution.py
+++ b/packages/runtime/src/carryme_runtime/paired_live_execution.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import Any, Literal, Protocol
@@ -16,6 +17,7 @@ from carryme_models import (
 )
 
 ObservedFillState = Literal["filled", "partial_fill", "unfilled", "open", "unknown"]
+logger = logging.getLogger(__name__)
 
 
 class SingleVenueLiveExecutionService(Protocol):
@@ -89,7 +91,7 @@ class PairedLiveExecutionCoordinator:
         first_fill_state = self._submission_observed_fill_state(first_result)
         if first_fill_state != "filled":
             guarded_status: Literal["rejected", "partial"] = (
-                "partial" if first_fill_state == "partial_fill" else "rejected"
+                "rejected" if first_fill_state == "unfilled" else "partial"
             )
             return ExecutionJournalEntry(
                 executed_at=timestamp,
@@ -246,4 +248,10 @@ def _observed_fill_state(value: Any) -> ObservedFillState:
         return "unfilled"
     if derived_state == "open":
         return "open"
+    if derived_state is not None:
+        logger.warning(
+            "unexpected observed order derived_state=%r in payload=%r",
+            derived_state,
+            value,
+        )
     return "unknown"

--- a/packages/runtime/src/carryme_runtime/paired_live_execution.py
+++ b/packages/runtime/src/carryme_runtime/paired_live_execution.py
@@ -90,14 +90,11 @@ class PairedLiveExecutionCoordinator:
             )
         first_fill_state = self._submission_observed_fill_state(first_result)
         if first_fill_state != "filled":
-            guarded_status: Literal["rejected", "partial"] = (
-                "rejected" if first_fill_state == "unfilled" else "partial"
-            )
             return ExecutionJournalEntry(
                 executed_at=timestamp,
                 adapter=f"paired_live:{normalized_first}_then_{second_venue}",
                 mode="live",
-                status=guarded_status,
+                status="partial",
                 paper_trade_id=paper_trade.entry_id,
                 preview_hash=confirmation.preview_hash,
                 confirmation_entry_id=confirmation.entry_id,
@@ -226,16 +223,32 @@ class PairedLiveExecutionCoordinator:
 
         attempt_history = payload.get("attempt_history")
         if not isinstance(attempt_history, list):
-            logger.warning(
-                "missing observed order state in live execution leg payload venue=%r "
-                "external_reference=%r payload=%r",
-                leg.venue,
-                leg.external_reference,
-                payload,
-            )
+            if attempt_history is None:
+                logger.warning(
+                    "missing observed order state in live execution leg payload venue=%r "
+                    "external_reference=%r payload_keys=%s",
+                    leg.venue,
+                    leg.external_reference,
+                    sorted(str(key) for key in payload),
+                )
+            else:
+                logger.warning(
+                    "malformed attempt_history in live execution leg payload venue=%r "
+                    "external_reference=%r type=%s",
+                    leg.venue,
+                    leg.external_reference,
+                    type(attempt_history).__name__,
+                )
             return "unknown"
         for attempt in reversed(attempt_history):
             if not isinstance(attempt, dict):
+                logger.warning(
+                    "malformed attempt_history entry in live execution leg payload venue=%r "
+                    "external_reference=%r type=%s",
+                    leg.venue,
+                    leg.external_reference,
+                    type(attempt).__name__,
+                )
                 continue
             observed_state = _observed_fill_state(attempt.get("observed_order_state"))
             if observed_state != "unknown":
@@ -245,6 +258,11 @@ class PairedLiveExecutionCoordinator:
 
 def _observed_fill_state(value: Any) -> ObservedFillState:
     if not isinstance(value, dict):
+        if value is not None:
+            logger.warning(
+                "malformed observed order state payload type=%s",
+                type(value).__name__,
+            )
         return "unknown"
     derived_state = value.get("derived_state")
     if derived_state == "filled":
@@ -255,10 +273,12 @@ def _observed_fill_state(value: Any) -> ObservedFillState:
         return "unfilled"
     if derived_state == "open":
         return "open"
+    if derived_state in {"unknown", "unsupported"}:
+        return "unknown"
     if derived_state is not None:
         logger.warning(
-            "unexpected observed order derived_state=%r in payload=%r",
+            "unexpected observed order derived_state=%r payload_keys=%s",
             derived_state,
-            value,
+            sorted(str(key) for key in value),
         )
     return "unknown"

--- a/packages/runtime/src/carryme_runtime/paired_live_execution.py
+++ b/packages/runtime/src/carryme_runtime/paired_live_execution.py
@@ -15,7 +15,7 @@ from carryme_models import (
     PreviewConfirmationEntry,
 )
 
-ObservedFillState = Literal["filled", "partial_fill", "unfilled", "unknown"]
+ObservedFillState = Literal["filled", "partial_fill", "unfilled", "open", "unknown"]
 
 
 class SingleVenueLiveExecutionService(Protocol):
@@ -87,7 +87,7 @@ class PairedLiveExecutionCoordinator:
                 legs=legs,
             )
         first_fill_state = self._submission_observed_fill_state(first_result)
-        if first_fill_state in {"unfilled", "partial_fill"}:
+        if first_fill_state != "filled":
             guarded_status: Literal["rejected", "partial"] = (
                 "partial" if first_fill_state == "partial_fill" else "rejected"
             )
@@ -203,6 +203,8 @@ class PairedLiveExecutionCoordinator:
             return "unknown"
         if any(state == "partial_fill" for state in concrete_states):
             return "partial_fill"
+        if any(state == "open" for state in concrete_states):
+            return "open"
         has_filled = any(state == "filled" for state in concrete_states)
         has_unfilled = any(state == "unfilled" for state in concrete_states)
         if has_filled and has_unfilled:
@@ -242,4 +244,6 @@ def _observed_fill_state(value: Any) -> ObservedFillState:
         return "partial_fill"
     if derived_state == "unfilled":
         return "unfilled"
+    if derived_state == "open":
+        return "open"
     return "unknown"

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -9103,6 +9103,183 @@ def test_paired_live_execution_coordinator_auto_prefers_paradex_first() -> None:
     asyncio.run(run())
 
 
+@pytest.mark.parametrize(
+    ("first_leg_state", "expected_status"),
+    [
+        ("unfilled", "rejected"),
+        ("partial_fill", "partial"),
+    ],
+)
+def test_paired_live_execution_coordinator_stops_when_first_leg_not_fully_filled(
+    first_leg_state: str,
+    expected_status: str,
+) -> None:
+    paper_trade = PaperTradeEntry(
+        entry_id=15,
+        created_at=datetime(2026, 5, 2, 20, 0, tzinfo=UTC),
+        note="candidate accepted",
+        intent=FundingPairTradeIntent(
+            label="zro_paradex_hyperliquid",
+            canonical_symbol="ZRO-USD-PERP",
+            source_recorded_at=datetime(2026, 5, 2, 19, 58, tzinfo=UTC),
+            one_day_net_edge_after_entry=0.00055,
+            break_even_days_entry=0.45,
+            capacity_limit_notional=250.0,
+            target_notional=100.0,
+            capacity_fraction=0.25,
+            max_target_notional=100.0,
+            long_leg=TradeLegIntent(
+                venue="paradex",
+                symbol="ZRO-USD-PERP",
+                fee_profile="pro",
+                side="buy",
+                target_notional=100.0,
+            ),
+            short_leg=TradeLegIntent(
+                venue="hyperliquid",
+                symbol="ZRO",
+                fee_profile="tier0",
+                side="sell",
+                target_notional=100.0,
+            ),
+        ),
+    )
+    remaining_size = "71.2" if first_leg_state == "unfilled" else "35.6"
+    avg_fill_price = "" if first_leg_state == "unfilled" else "1.4007"
+    confirmation = PreviewConfirmationEntry(
+        entry_id=12,
+        confirmed_at=datetime(2026, 5, 2, 20, 1, tzinfo=UTC),
+        paper_trade_id=15,
+        label="zro_paradex_hyperliquid",
+        preview_hash="zro-preview-hash",
+        preview=PaperTradeOrderPreview(
+            paper_trade_id=15,
+            label="zro_paradex_hyperliquid",
+            generated_at=datetime(2026, 5, 2, 20, 0, tzinfo=UTC),
+            slippage_tolerance_bps=10,
+            preview_hash="zro-preview-hash",
+            legs=[
+                VenueOrderPreview(
+                    venue="paradex",
+                    symbol="ZRO-USD-PERP",
+                    fee_profile="pro",
+                    side="buy",
+                    target_notional=100.0,
+                    quantity=71.2,
+                    quantity_text="71.2",
+                    reference_price=1.4007,
+                    reference_price_source="best_ask",
+                    worst_acceptable_price=1.4021,
+                    worst_price_text="1.4021",
+                    endpoint_path_hint="/v1/orders",
+                    auth_scheme="main account address + subkey private key",
+                    payload={"market": "ZRO-USD-PERP"},
+                    notes=[],
+                ),
+                VenueOrderPreview(
+                    venue="hyperliquid",
+                    symbol="ZRO",
+                    fee_profile="tier0",
+                    side="sell",
+                    target_notional=100.0,
+                    quantity=71.4,
+                    quantity_text="71.4",
+                    reference_price=1.3992,
+                    reference_price_source="best_bid",
+                    worst_acceptable_price=1.3978,
+                    worst_price_text="1.3978",
+                    endpoint_path_hint="/exchange",
+                    auth_scheme="account address + API wallet private key",
+                    payload={"coin": "ZRO"},
+                    notes=[],
+                ),
+            ],
+        ),
+        note="operator confirmed",
+    )
+
+    class FirstLegNotFilledService:
+        async def submit_confirmed_preview(
+            self,
+            *,
+            paper_trade: PaperTradeEntry,
+            confirmation: PreviewConfirmationEntry,
+            executed_at: datetime | None = None,
+        ) -> ExecutionJournalEntry:
+            return ExecutionJournalEntry(
+                executed_at=executed_at or datetime.now(UTC),
+                adapter="paradex_live",
+                mode="live",
+                status="submitted",
+                paper_trade_id=paper_trade.entry_id,
+                preview_hash=confirmation.preview_hash,
+                confirmation_entry_id=confirmation.entry_id,
+                paper_trade=paper_trade,
+                legs=[
+                    ExecutionLegResult(
+                        venue="paradex",
+                        symbol="ZRO-USD-PERP",
+                        fee_profile="pro",
+                        side="buy",
+                        target_notional=100.0,
+                        status="submitted",
+                        simulated=False,
+                        external_reference="zro-paradex-order",
+                        response_payload={
+                            "observed_order_state": {
+                                "derived_state": first_leg_state,
+                                "size": "71.2",
+                                "remaining_size": remaining_size,
+                                "avg_fill_price": avg_fill_price,
+                            },
+                            "attempt_history": [
+                                {
+                                    "observed_order_state": {
+                                        "derived_state": first_leg_state,
+                                        "size": "71.2",
+                                        "remaining_size": remaining_size,
+                                        "avg_fill_price": avg_fill_price,
+                                    }
+                                }
+                            ],
+                        },
+                    )
+                ],
+            )
+
+    class SecondLegShouldNotRunService:
+        async def submit_confirmed_preview(
+            self,
+            *,
+            paper_trade: PaperTradeEntry,
+            confirmation: PreviewConfirmationEntry,
+            executed_at: datetime | None = None,
+        ) -> ExecutionJournalEntry:
+            raise AssertionError("second venue must not be submitted without a full first fill")
+
+    async def run() -> None:
+        service = PairedLiveExecutionCoordinator(
+            services={
+                "paradex": FirstLegNotFilledService(),
+                "hyperliquid": SecondLegShouldNotRunService(),
+            }
+        )
+        entry = await service.submit_confirmed_preview(
+            paper_trade=paper_trade,
+            confirmation=confirmation,
+        )
+        assert entry.status == expected_status
+        assert entry.adapter == "paired_live:paradex_then_hyperliquid"
+        assert [leg.venue for leg in entry.legs] == ["paradex"]
+        response_payload = entry.legs[0].response_payload
+        assert isinstance(response_payload, dict)
+        observed_order_state = response_payload["observed_order_state"]
+        assert isinstance(observed_order_state, dict)
+        assert observed_order_state["derived_state"] == first_leg_state
+
+    asyncio.run(run())
+
+
 def test_paired_live_execution_coordinator_marks_partial_when_second_leg_fails() -> None:
     paper_trade = PaperTradeEntry(
         entry_id=12,
@@ -10240,6 +10417,57 @@ def test_hyperliquid_order_state_observer_classifies_filled_order(
         assert state.derived_state == "filled"
         assert state.order_status == "filled"
         assert state.avg_fill_price == "0.0923"
+        assert state.observation_source == "rest_poll"
+
+    asyncio.run(run())
+
+
+def test_hyperliquid_order_state_observer_classifies_nested_rest_order(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class StubInfo:
+        def query_order_by_oid(self, address: str, oid: int) -> dict[str, object]:
+            assert address == "0xhyper"
+            assert oid == 407816282189
+            return {
+                "status": "order",
+                "order": {
+                    "status": "filled",
+                    "statusTimestamp": 1770000000000,
+                    "order": {
+                        "coin": "ZRO",
+                        "side": "B",
+                        "limitPx": "1.4007",
+                        "origSz": "71.4",
+                        "sz": "0.0",
+                        "cloid": "0xabc",
+                    },
+                },
+            }
+
+    monkeypatch.setattr(
+        "carryme_runtime.execution_order_state.build_hyperliquid_info",
+        lambda: StubInfo(),
+    )
+
+    async def run() -> None:
+        observer = HyperliquidOrderStateObserver(
+            account_address="0xhyper",
+            websocket_timeout_seconds=0,
+        )
+        state = await observer.observe(
+            {
+                "venue": "hyperliquid",
+                "external_reference": "407816282189",
+                "request_payload": {},
+            }
+        )
+        assert state.supported is True
+        assert state.derived_state == "filled"
+        assert state.order_status == "filled"
+        assert state.remaining_size == "0.0"
+        assert state.size == "71.4"
+        assert state.client_id == "0xabc"
         assert state.observation_source == "rest_poll"
 
     asyncio.run(run())
@@ -14392,6 +14620,88 @@ def test_execution_accounting_service_summarizes_filled_attempt_history(tmp_path
     assert route_summaries[0].total_estimated_fee_paid == pytest.approx(
         summary.total_estimated_fee_paid
     )
+
+
+def test_execution_accounting_service_summarizes_hyperliquid_submission_fill(
+    tmp_path: Path,
+) -> None:
+    store = ExecutionJournalStore(tmp_path / "history.sqlite3")
+    paper_trade = PaperTradeEntry(
+        entry_id=12,
+        created_at=datetime(2026, 5, 2, 20, 0, tzinfo=UTC),
+        intent=FundingPairTradeIntent(
+            label="zro_paradex_hyperliquid",
+            canonical_symbol="ZRO-USD-PERP",
+            source_recorded_at=datetime(2026, 5, 2, 19, 58, tzinfo=UTC),
+            one_day_net_edge_after_entry=0.00055,
+            break_even_days_entry=0.45,
+            capacity_limit_notional=250.0,
+            target_notional=100.0,
+            capacity_fraction=0.25,
+            max_target_notional=100.0,
+            long_leg=TradeLegIntent(
+                venue="paradex",
+                symbol="ZRO-USD-PERP",
+                fee_profile="pro",
+                side="buy",
+                target_notional=100.0,
+            ),
+            short_leg=TradeLegIntent(
+                venue="hyperliquid",
+                symbol="ZRO",
+                fee_profile="tier0",
+                side="sell",
+                target_notional=100.0,
+            ),
+        ),
+    )
+    entry = ExecutionJournalEntry(
+        executed_at=datetime(2026, 5, 2, 20, 1, tzinfo=UTC),
+        adapter="hyperliquid_live",
+        mode="live",
+        status="submitted",
+        paper_trade_id=12,
+        paper_trade=paper_trade,
+        legs=[
+            ExecutionLegResult(
+                venue="hyperliquid",
+                symbol="ZRO",
+                fee_profile="tier0",
+                side="sell",
+                target_notional=100.0,
+                status="submitted",
+                simulated=False,
+                auth_usage="api_wallet",
+                response_payload={
+                    "status": "ok",
+                    "response": {
+                        "type": "order",
+                        "data": {
+                            "statuses": [
+                                {
+                                    "filled": {
+                                        "totalSz": "71.4",
+                                        "avgPx": "1.3992",
+                                        "oid": 407816217258,
+                                    }
+                                }
+                            ]
+                        },
+                    },
+                },
+            )
+        ],
+    )
+
+    service = ExecutionAccountingService(journal_store=store)
+    summary = service.summarize_entry(entry)
+
+    assert summary.filled_leg_count == 1
+    assert summary.legs[0].derived_fill_state == "filled"
+    assert summary.legs[0].filled_size == pytest.approx(71.4)
+    assert summary.legs[0].avg_fill_price == pytest.approx(1.3992)
+    assert summary.total_filled_notional == pytest.approx(71.4 * 1.3992)
+    assert summary.total_estimated_fee_paid == pytest.approx((71.4 * 1.3992) * 0.00045)
 
 
 def test_execution_accounting_service_infers_held_hedge_fill_from_observation(

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -9116,7 +9116,7 @@ def test_paired_live_execution_coordinator_auto_prefers_paradex_first() -> None:
 @pytest.mark.parametrize(
     ("first_leg_state", "expected_status"),
     [
-        ("unfilled", "rejected"),
+        ("unfilled", "partial"),
         ("partial_fill", "partial"),
         ("open", "partial"),
         ("unknown", "partial"),
@@ -9316,6 +9316,42 @@ def test_observed_fill_state_logs_unexpected_derived_state(
         "unexpected observed order derived_state='filled_final'" in record.message
         for record in caplog.records
     )
+
+
+def test_observed_fill_state_logs_malformed_payload_shape(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    caplog.set_level(logging.WARNING, logger="carryme_runtime.paired_live_execution")
+
+    state = _observed_fill_state(["not", "a", "dict"])
+
+    assert state == "unknown"
+    assert any(
+        "malformed observed order state payload type=list" in record.message
+        for record in caplog.records
+    )
+
+
+def test_leg_observed_fill_state_logs_malformed_attempt_history(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    caplog.set_level(logging.WARNING, logger="carryme_runtime.paired_live_execution")
+    leg = ExecutionLegResult(
+        venue="paradex",
+        symbol="ZRO-USD-PERP",
+        fee_profile="pro",
+        side="buy",
+        target_notional=100.0,
+        status="submitted",
+        simulated=False,
+        external_reference="zro-paradex-order",
+        response_payload={"attempt_history": {"bad": "shape"}},
+    )
+
+    state = PairedLiveExecutionCoordinator._leg_observed_fill_state(leg)
+
+    assert state == "unknown"
+    assert any("malformed attempt_history" in record.message for record in caplog.records)
 
 
 def test_paired_live_execution_coordinator_marks_partial_when_second_leg_fails() -> None:

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -8918,8 +8918,9 @@ def test_paired_live_execution_coordinator_submits_both_legs() -> None:
             confirmation: PreviewConfirmationEntry,
             executed_at: datetime | None = None,
         ) -> ExecutionJournalEntry:
+            assert executed_at is not None
             return ExecutionJournalEntry(
-                executed_at=executed_at or datetime.now(UTC),
+                executed_at=executed_at,
                 adapter=f"{self.venue}_live",
                 mode="live",
                 status="submitted",
@@ -9064,8 +9065,9 @@ def test_paired_live_execution_coordinator_auto_prefers_paradex_first() -> None:
             executed_at: datetime | None = None,
         ) -> ExecutionJournalEntry:
             seen_venues.append(self.venue)
+            assert executed_at is not None
             return ExecutionJournalEntry(
-                executed_at=executed_at or datetime.now(UTC),
+                executed_at=executed_at,
                 adapter=f"{self.venue}_live",
                 mode="live",
                 status="submitted",
@@ -9118,6 +9120,7 @@ def test_paired_live_execution_coordinator_auto_prefers_paradex_first() -> None:
         ("partial_fill", "partial"),
         ("open", "partial"),
         ("unknown", "partial"),
+        ("missing_observation", "partial"),
     ],
 )
 def test_paired_live_execution_coordinator_stops_when_first_leg_not_fully_filled(
@@ -9216,8 +9219,33 @@ def test_paired_live_execution_coordinator_stops_when_first_leg_not_fully_filled
             confirmation: PreviewConfirmationEntry,
             executed_at: datetime | None = None,
         ) -> ExecutionJournalEntry:
+            if first_leg_state == "missing_observation":
+                response_payload: dict[str, Any] = {
+                    "id": "zro-paradex-order",
+                    "status": "submitted",
+                }
+            else:
+                response_payload = {
+                    "observed_order_state": {
+                        "derived_state": first_leg_state,
+                        "size": "71.2",
+                        "remaining_size": remaining_size,
+                        "avg_fill_price": avg_fill_price,
+                    },
+                    "attempt_history": [
+                        {
+                            "observed_order_state": {
+                                "derived_state": first_leg_state,
+                                "size": "71.2",
+                                "remaining_size": remaining_size,
+                                "avg_fill_price": avg_fill_price,
+                            }
+                        }
+                    ],
+                }
+            assert executed_at is not None
             return ExecutionJournalEntry(
-                executed_at=executed_at or datetime.now(UTC),
+                executed_at=executed_at,
                 adapter="paradex_live",
                 mode="live",
                 status="submitted",
@@ -9235,24 +9263,7 @@ def test_paired_live_execution_coordinator_stops_when_first_leg_not_fully_filled
                         status="submitted",
                         simulated=False,
                         external_reference="zro-paradex-order",
-                        response_payload={
-                            "observed_order_state": {
-                                "derived_state": first_leg_state,
-                                "size": "71.2",
-                                "remaining_size": remaining_size,
-                                "avg_fill_price": avg_fill_price,
-                            },
-                            "attempt_history": [
-                                {
-                                    "observed_order_state": {
-                                        "derived_state": first_leg_state,
-                                        "size": "71.2",
-                                        "remaining_size": remaining_size,
-                                        "avg_fill_price": avg_fill_price,
-                                    }
-                                }
-                            ],
-                        },
+                        response_payload=response_payload,
                     )
                 ],
             )
@@ -9283,9 +9294,12 @@ def test_paired_live_execution_coordinator_stops_when_first_leg_not_fully_filled
         assert [leg.venue for leg in entry.legs] == ["paradex"]
         response_payload = entry.legs[0].response_payload
         assert isinstance(response_payload, dict)
-        observed_order_state = response_payload["observed_order_state"]
-        assert isinstance(observed_order_state, dict)
-        assert observed_order_state["derived_state"] == first_leg_state
+        if first_leg_state == "missing_observation":
+            assert "observed_order_state" not in response_payload
+        else:
+            observed_order_state = response_payload["observed_order_state"]
+            assert isinstance(observed_order_state, dict)
+            assert observed_order_state["derived_state"] == first_leg_state
 
     asyncio.run(run())
 
@@ -9395,8 +9409,9 @@ def test_paired_live_execution_coordinator_marks_partial_when_second_leg_fails()
             confirmation: PreviewConfirmationEntry,
             executed_at: datetime | None = None,
         ) -> ExecutionJournalEntry:
+            assert executed_at is not None
             return ExecutionJournalEntry(
-                executed_at=executed_at or datetime.now(UTC),
+                executed_at=executed_at,
                 adapter="extended_live",
                 mode="live",
                 status="submitted",
@@ -9549,8 +9564,9 @@ def test_paired_live_execution_coordinator_supports_hyperliquid_leg() -> None:
             )
             fee_profile = "default" if self.venue == "extended" else "tier0"
             side: Literal["buy", "sell"] = "sell" if self.venue == "extended" else "buy"
+            assert executed_at is not None
             return ExecutionJournalEntry(
-                executed_at=executed_at or datetime.now(UTC),
+                executed_at=executed_at,
                 adapter=f"{self.venue}_live",
                 mode="live",
                 status="submitted",

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -8939,6 +8939,9 @@ def test_paired_live_execution_coordinator_submits_both_legs() -> None:
                         status="submitted",
                         simulated=False,
                         external_reference=f"{self.venue}-1",
+                        response_payload={
+                            "observed_order_state": {"derived_state": "filled"}
+                        },
                     )
                 ],
             )
@@ -9082,6 +9085,9 @@ def test_paired_live_execution_coordinator_auto_prefers_paradex_first() -> None:
                         status="submitted",
                         simulated=False,
                         external_reference=f"{self.venue}-1",
+                        response_payload={
+                            "observed_order_state": {"derived_state": "filled"}
+                        },
                     )
                 ],
             )
@@ -9108,6 +9114,8 @@ def test_paired_live_execution_coordinator_auto_prefers_paradex_first() -> None:
     [
         ("unfilled", "rejected"),
         ("partial_fill", "partial"),
+        ("open", "rejected"),
+        ("unknown", "rejected"),
     ],
 )
 def test_paired_live_execution_coordinator_stops_when_first_leg_not_fully_filled(
@@ -9144,8 +9152,8 @@ def test_paired_live_execution_coordinator_stops_when_first_leg_not_fully_filled
             ),
         ),
     )
-    remaining_size = "71.2" if first_leg_state == "unfilled" else "35.6"
-    avg_fill_price = "" if first_leg_state == "unfilled" else "1.4007"
+    remaining_size = "71.2" if first_leg_state in {"unfilled", "open", "unknown"} else "35.6"
+    avg_fill_price = "" if first_leg_state in {"unfilled", "open", "unknown"} else "1.4007"
     confirmation = PreviewConfirmationEntry(
         entry_id=12,
         confirmed_at=datetime(2026, 5, 2, 20, 1, tzinfo=UTC),
@@ -9390,6 +9398,9 @@ def test_paired_live_execution_coordinator_marks_partial_when_second_leg_fails()
                         status="submitted",
                         simulated=False,
                         external_reference="extended-1",
+                        response_payload={
+                            "observed_order_state": {"derived_state": "filled"}
+                        },
                     )
                 ],
             )
@@ -9541,6 +9552,9 @@ def test_paired_live_execution_coordinator_supports_hyperliquid_leg() -> None:
                         status="submitted",
                         simulated=False,
                         external_reference=f"{self.venue}-1",
+                        response_payload={
+                            "observed_order_state": {"derived_state": "filled"}
+                        },
                     )
                 ],
             )

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -1,5 +1,6 @@
 import asyncio
 import json
+import logging
 import time
 from datetime import UTC, datetime
 from pathlib import Path
@@ -111,6 +112,7 @@ from carryme_runtime.account_preflight import (
     _row_represents_open_position,
 )
 from carryme_runtime.execution_quality import ExecutionQualityService
+from carryme_runtime.paired_live_execution import _observed_fill_state
 from carryme_runtime.route_approvals import (
     scan_exact_canary_candidate_for_approval,
     scan_live_route_candidate_for_approval,
@@ -9114,8 +9116,8 @@ def test_paired_live_execution_coordinator_auto_prefers_paradex_first() -> None:
     [
         ("unfilled", "rejected"),
         ("partial_fill", "partial"),
-        ("open", "rejected"),
-        ("unknown", "rejected"),
+        ("open", "partial"),
+        ("unknown", "partial"),
     ],
 )
 def test_paired_live_execution_coordinator_stops_when_first_leg_not_fully_filled(
@@ -9286,6 +9288,20 @@ def test_paired_live_execution_coordinator_stops_when_first_leg_not_fully_filled
         assert observed_order_state["derived_state"] == first_leg_state
 
     asyncio.run(run())
+
+
+def test_observed_fill_state_logs_unexpected_derived_state(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    caplog.set_level(logging.WARNING, logger="carryme_runtime.paired_live_execution")
+
+    state = _observed_fill_state({"derived_state": "filled_final", "raw": {"status": "done"}})
+
+    assert state == "unknown"
+    assert any(
+        "unexpected observed order derived_state='filled_final'" in record.message
+        for record in caplog.records
+    )
 
 
 def test_paired_live_execution_coordinator_marks_partial_when_second_leg_fails() -> None:


### PR DESCRIPTION
## Summary
- stop paired live execution before submitting leg two when leg one is explicitly observed as unfilled or partial
- parse nested Hyperliquid REST order payloads so filled orders are classified as filled instead of unknown
- include Hyperliquid direct submission fills in execution accounting

## Root Cause
ZRO opened a one-sided Hyperliquid leg because the paired coordinator only checked the first venue journal status. Paradex returned `status="submitted"` even though its embedded order observation was `unfilled`, so the coordinator still submitted the Hyperliquid leg.

## Production Impact
This fails closed for explicit first-leg no-fill/partial-fill states and prevents opening the easier hedge leg when the harder first leg did not fully fill. Unknown first-leg observations keep existing behavior so this PR does not block venues that cannot yet provide terminal order observations.

## Validation
- `uv run pytest tests/test_runtime.py -q -k 'stops_when_first_leg_not_fully_filled or classifies_nested_rest_order or summarizes_hyperliquid_submission_fill'`
- `uv run pytest tests/test_runtime.py -q -k 'paired_live_execution_coordinator or hyperliquid_order_state_observer or execution_accounting_service'`
- `uv run ruff check .`
- `uv run mypy src apps packages tests`
- `uv run pytest -q`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Paired execution coordinator now stops when the first leg is not fully filled, avoiding unnecessary second-leg submissions
  * Hyperliquid order-state extraction handles nested payload/status cases and classifies nested REST “order” payloads as filled when appropriate

* **New Features**
  * Derive fill events from Hyperliquid submission responses (filled size, notional, avg price)
  * Unexpected observed-derived states map to "unknown" and emit a warning

* **Tests**
  * Updated and added tests for paired execution, nested Hyperliquid order-state, and submission-fill accounting
<!-- end of auto-generated comment: release notes by coderabbit.ai -->