### PR TITLE
feat: allocate stable launch capital across routes

### DIFF
--- a/apps/worker/src/carryme_worker/config.py
+++ b/apps/worker/src/carryme_worker/config.py
@@ -406,6 +406,20 @@ class WorkerSettings(BaseSettings):
         return self
 
     @model_validator(mode="after")
+    def validate_stable_launch_multi_route_active_cap(self) -> "WorkerSettings":
+        """Require an explicit active-execution cap before enabling multi-route launch."""
+
+        if (
+            self.stable_canary_launch_max_routes_per_cycle > 1
+            and self.stable_canary_launch_max_active_live_executions <= 0
+        ):
+            raise ValueError(
+                "stable_canary_launch_max_active_live_executions must be positive when "
+                "stable_canary_launch_max_routes_per_cycle is greater than 1"
+            )
+        return self
+
+    @model_validator(mode="after")
     def validate_stable_launch_reservation_retention(self) -> "WorkerSettings":
         """Keep reservation cleanup from deleting leases before they are stale."""
 

--- a/apps/worker/src/carryme_worker/config.py
+++ b/apps/worker/src/carryme_worker/config.py
@@ -44,6 +44,7 @@ class WorkerSettings(BaseSettings):
         gt=0,
         le=MAX_RECENT_LABEL_LIMIT,
     )
+    stable_canary_launch_max_routes_per_cycle: int = Field(default=1, gt=0)
     stable_canary_launch_max_total_live_notional: float | None = Field(
         default=None,
         ge=0,

--- a/apps/worker/src/carryme_worker/main.py
+++ b/apps/worker/src/carryme_worker/main.py
@@ -108,6 +108,9 @@ def build_automation_mode_payload(
         "stable_canary_launch_active_execution_limit": (
             settings.stable_canary_launch_active_execution_limit
         ),
+        "stable_canary_launch_max_routes_per_cycle": (
+            settings.stable_canary_launch_max_routes_per_cycle
+        ),
         "stable_canary_launch_max_total_live_notional": (
             settings.stable_canary_launch_max_total_live_notional
         ),
@@ -286,6 +289,18 @@ def build_stable_canary_launch_payload(
         "approved_snapshot_id": summary.approved_snapshot_id,
         "paper_trade_id": summary.paper_trade_id,
         "final_pair_state": summary.final_pair_state,
+        "launched_count": summary.launched_count,
+        "launched_routes": [
+            {
+                "label": route.label,
+                "launch_ready_snapshot_id": route.launch_ready_snapshot_id,
+                "approved_snapshot_id": route.approved_snapshot_id,
+                "paper_trade_id": route.paper_trade_id,
+                "final_pair_state": route.final_pair_state,
+                "selected_notional": route.selected_notional,
+            }
+            for route in summary.launched_routes
+        ],
         "detail": summary.detail,
         "database_path": summary.database_path,
     }

--- a/apps/worker/src/carryme_worker/poller.py
+++ b/apps/worker/src/carryme_worker/poller.py
@@ -379,6 +379,18 @@ class LaunchReadyCanaryCacheLoopSummary:
 
 
 @dataclass
+class StableCanaryLaunchedRoute:
+    """One route opened by a stable-canary launch cycle."""
+
+    label: str
+    launch_ready_snapshot_id: int | None
+    approved_snapshot_id: int | None
+    paper_trade_id: int
+    final_pair_state: str
+    selected_notional: float
+
+
+@dataclass
 class StableCanaryLaunchSummary:
     """Summary emitted after attempting to launch the latest stable canary."""
 
@@ -389,6 +401,8 @@ class StableCanaryLaunchSummary:
     approved_snapshot_id: int | None = None
     paper_trade_id: int | None = None
     final_pair_state: str | None = None
+    launched_count: int = 0
+    launched_routes: list[StableCanaryLaunchedRoute] = field(default_factory=list)
     detail: object | None = None
     lifecycle: CanaryLifecycleResult | None = field(default=None, repr=False)
 
@@ -531,13 +545,14 @@ def _summarize_active_live_notional_for_stable_launch(
     return total_active_notional, active_notional_by_venue
 
 
-def _build_stable_launch_risk_budget_reason(
+def _build_stable_launch_risk_budget_reason_from_exposure(
     *,
     settings: WorkerSettings,
-    active_executions: list[ExecutionJournalEntry],
+    total_active_notional: float,
+    active_notional_by_venue: dict[str, float],
     candidate: FundingUniverseCanaryCandidate,
 ) -> str | None:
-    """Return the deterministic reason a proposed unattended launch exceeds budget."""
+    """Return why adding a proposed route would exceed unattended live budgets."""
 
     max_total_live_notional = settings.stable_canary_launch_max_total_live_notional
     max_live_notional_per_venue = settings.stable_canary_launch_max_live_notional_per_venue
@@ -545,9 +560,6 @@ def _build_stable_launch_risk_budget_reason(
         return None
 
     proposed_notional = candidate.suggested_canary_notional
-    total_active_notional, active_notional_by_venue = (
-        _summarize_active_live_notional_for_stable_launch(active_executions)
-    )
     if max_total_live_notional is not None:
         proposed_total_notional = total_active_notional + proposed_notional
         if proposed_total_notional - max_total_live_notional > 1e-9:
@@ -572,6 +584,59 @@ def _build_stable_launch_risk_budget_reason(
             )
 
     return None
+
+
+def _build_stable_launch_risk_budget_reason(
+    *,
+    settings: WorkerSettings,
+    active_executions: list[ExecutionJournalEntry],
+    candidate: FundingUniverseCanaryCandidate,
+) -> str | None:
+    """Return the deterministic reason a proposed unattended launch exceeds budget."""
+
+    total_active_notional, active_notional_by_venue = (
+        _summarize_active_live_notional_for_stable_launch(active_executions)
+    )
+    return _build_stable_launch_risk_budget_reason_from_exposure(
+        settings=settings,
+        total_active_notional=total_active_notional,
+        active_notional_by_venue=active_notional_by_venue,
+        candidate=candidate,
+    )
+
+
+def _add_stable_launch_notional_exposure(
+    *,
+    total_active_notional: float,
+    active_notional_by_venue: dict[str, float],
+    candidate: FundingUniverseCanaryCandidate,
+) -> tuple[float, dict[str, float]]:
+    """Return active exposure after accounting for one newly launched route."""
+
+    selected_notional = candidate.suggested_canary_notional
+    updated_by_venue = dict(active_notional_by_venue)
+    opportunity = candidate.opportunity.opportunity
+    for venue in {opportunity.short_venue, opportunity.long_venue}:
+        updated_by_venue[venue] = updated_by_venue.get(venue, 0.0) + selected_notional
+    return total_active_notional + selected_notional, updated_by_venue
+
+
+def _max_stable_launch_routes_this_cycle(
+    *,
+    settings: WorkerSettings,
+    current_blocking_live_executions: int,
+) -> int:
+    """Return how many new routes this cycle may open under active-execution controls."""
+
+    if settings.stable_canary_launch_max_active_live_executions <= 0:
+        active_budget_remaining = 1
+    else:
+        active_budget_remaining = max(
+            1,
+            settings.stable_canary_launch_max_active_live_executions
+            - current_blocking_live_executions,
+        )
+    return min(settings.stable_canary_launch_max_routes_per_cycle, active_budget_remaining)
 
 
 def _build_stable_launch_hold_mode_blocker(settings: WorkerSettings) -> str | None:
@@ -2677,6 +2742,33 @@ def _build_stable_launch_candidate_skip_summary(
     )
 
 
+def _build_stable_launch_launched_summary(
+    *,
+    database_path: str,
+    launched_routes: list[StableCanaryLaunchedRoute],
+    detail: object | None = None,
+    lifecycle: CanaryLifecycleResult | None = None,
+) -> StableCanaryLaunchSummary:
+    """Return the cycle summary after one or more stable routes launched."""
+
+    if not launched_routes:
+        raise ValueError("launched_routes must not be empty")
+    primary = launched_routes[0]
+    return StableCanaryLaunchSummary(
+        status="launched",
+        database_path=database_path,
+        label=primary.label,
+        launch_ready_snapshot_id=primary.launch_ready_snapshot_id,
+        approved_snapshot_id=primary.approved_snapshot_id,
+        paper_trade_id=primary.paper_trade_id,
+        final_pair_state=primary.final_pair_state,
+        launched_count=len(launched_routes),
+        launched_routes=launched_routes,
+        detail=detail,
+        lifecycle=lifecycle,
+    )
+
+
 async def scan_approved_canary_once(
     settings: WorkerSettings,
     *,
@@ -3378,6 +3470,13 @@ async def launch_latest_stable_canary_once(
                 "stable_canary_launch_active_execution_limit; increase limit"
             ),
         )
+    active_budget_total_notional, active_budget_notional_by_venue = (
+        _summarize_active_live_notional_for_stable_launch(active_executions_for_budget)
+    )
+    launch_route_limit = _max_stable_launch_routes_this_cycle(
+        settings=settings,
+        current_blocking_live_executions=len(blocking_live_executions),
+    )
 
     # Some production pre-checks intentionally touch live execution and balance
     # history. Use a fresh timestamp for market-snapshot freshness so a slow
@@ -3400,8 +3499,51 @@ async def launch_latest_stable_canary_once(
         )
 
     skipped_candidates: list[_StableCanaryCandidateSkip] = []
+    launched_routes: list[StableCanaryLaunchedRoute] = []
+    last_lifecycle: CanaryLifecycleResult | None = None
 
     for candidate_stability in stable_candidates:
+        if launched_routes:
+            if len(launched_routes) >= launch_route_limit:
+                return _build_stable_launch_launched_summary(
+                    database_path=settings.database_target,
+                    launched_routes=launched_routes,
+                    detail=(
+                        "Stable launch reached max routes per cycle: "
+                        f"{launch_route_limit}"
+                    ),
+                    lifecycle=last_lifecycle,
+                )
+            global_cooldown_reason = _build_stable_launch_cooldown_reason(
+                settings=settings,
+                launch_store=stable_launch_store,
+                now=snapshot_selection_timestamp,
+            )
+            if global_cooldown_reason is not None:
+                return _build_stable_launch_launched_summary(
+                    database_path=settings.database_target,
+                    launched_routes=launched_routes,
+                    detail=(
+                        "Stable launch stopped after launched routes because "
+                        f"{global_cooldown_reason}"
+                    ),
+                    lifecycle=last_lifecycle,
+                )
+            global_rate_cap_reason = _build_stable_launch_rate_cap_reason(
+                settings=settings,
+                launch_store=stable_launch_store,
+                now=snapshot_selection_timestamp,
+            )
+            if global_rate_cap_reason is not None:
+                return _build_stable_launch_launched_summary(
+                    database_path=settings.database_target,
+                    launched_routes=launched_routes,
+                    detail=(
+                        "Stable launch stopped after launched routes because "
+                        f"{global_rate_cap_reason}"
+                    ),
+                    lifecycle=last_lifecycle,
+                )
         candidate_snapshot = candidate_stability.snapshot
         if settings.stable_canary_launch_consecutive_loss_scope == "label":
             loss_circuit_breaker_reason = _build_stable_launch_loss_circuit_breaker_reason(
@@ -3734,9 +3876,10 @@ async def launch_latest_stable_canary_once(
                     )
                     continue
 
-        risk_budget_reason = _build_stable_launch_risk_budget_reason(
+        risk_budget_reason = _build_stable_launch_risk_budget_reason_from_exposure(
             settings=settings,
-            active_executions=active_executions_for_budget,
+            total_active_notional=active_budget_total_notional,
+            active_notional_by_venue=active_budget_notional_by_venue,
             candidate=candidate_selected,
         )
         if risk_budget_reason is not None:
@@ -3941,6 +4084,16 @@ async def launch_latest_stable_canary_once(
                         detail=exc.detail,
                     )
                 )
+                if launched_routes:
+                    return _build_stable_launch_launched_summary(
+                        database_path=settings.database_target,
+                        launched_routes=launched_routes,
+                        detail=(
+                            "Stable launch stopped after launched routes because "
+                            f"{exc.detail}"
+                        ),
+                        lifecycle=last_lifecycle,
+                    )
                 if exc.status_code == 404:
                     continue
                 return _build_stable_launch_candidate_skip_summary(
@@ -3966,18 +4119,42 @@ async def launch_latest_stable_canary_once(
                 final_pair_state=lifecycle.final_pair_status.derived_state,
             )
         )
-        return StableCanaryLaunchSummary(
-            status="launched",
-            database_path=settings.database_target,
-            label=candidate_snapshot.label,
-            launch_ready_snapshot_id=candidate_snapshot.launch_ready_snapshot_id,
-            approved_snapshot_id=launch_approved_snapshot_id,
-            paper_trade_id=paper_trade_id,
-            final_pair_state=lifecycle.final_pair_status.derived_state,
-            detail=None,
-            lifecycle=lifecycle,
+        launched_routes.append(
+            StableCanaryLaunchedRoute(
+                label=candidate_snapshot.label,
+                launch_ready_snapshot_id=candidate_snapshot.launch_ready_snapshot_id,
+                approved_snapshot_id=launch_approved_snapshot_id,
+                paper_trade_id=paper_trade_id,
+                final_pair_state=lifecycle.final_pair_status.derived_state,
+                selected_notional=candidate_selected.suggested_canary_notional,
+            )
         )
+        last_lifecycle = lifecycle
+        active_budget_total_notional, active_budget_notional_by_venue = (
+            _add_stable_launch_notional_exposure(
+                total_active_notional=active_budget_total_notional,
+                active_notional_by_venue=active_budget_notional_by_venue,
+                candidate=candidate_selected,
+            )
+        )
+        if len(launched_routes) >= launch_route_limit:
+            return _build_stable_launch_launched_summary(
+                database_path=settings.database_target,
+                launched_routes=launched_routes,
+                detail=None if len(launched_routes) == 1 else (
+                    "Stable launch reached max routes per cycle: "
+                    f"{launch_route_limit}"
+                ),
+                lifecycle=last_lifecycle,
+            )
 
+    if launched_routes:
+        return _build_stable_launch_launched_summary(
+            database_path=settings.database_target,
+            launched_routes=launched_routes,
+            detail=None,
+            lifecycle=last_lifecycle,
+        )
     return _build_stable_launch_candidate_skip_summary(
         database_path=settings.database_target,
         skipped_candidates=skipped_candidates,
@@ -4017,13 +4194,13 @@ async def run_supervised_stable_canary_launch_loop(
             successful_cycles += 1
             consecutive_failures = 0
             if summary.status == "launched":
-                launched += 1
+                launched += max(1, summary.launched_count)
             else:
                 skipped += 1
             loop_logger.info(
                 "completed supervised stable canary launch cycle %s with status=%s "
                 "label=%s launch_ready_snapshot_id=%s approved_snapshot_id=%s "
-                "paper_trade_id=%s final_pair_state=%s detail=%s",
+                "paper_trade_id=%s final_pair_state=%s launched_count=%s detail=%s",
                 attempts,
                 summary.status,
                 summary.label,
@@ -4031,6 +4208,7 @@ async def run_supervised_stable_canary_launch_loop(
                 summary.approved_snapshot_id,
                 summary.paper_trade_id,
                 summary.final_pair_state,
+                summary.launched_count,
                 summary.detail,
             )
             if max_iterations is not None and attempts >= max_iterations:

--- a/apps/worker/src/carryme_worker/poller.py
+++ b/apps/worker/src/carryme_worker/poller.py
@@ -629,10 +629,10 @@ def _max_stable_launch_routes_this_cycle(
     """Return how many new routes this cycle may open under active-execution controls."""
 
     if settings.stable_canary_launch_max_active_live_executions <= 0:
-        active_budget_remaining = 1
+        active_budget_remaining = 1 if current_blocking_live_executions == 0 else 0
     else:
         active_budget_remaining = max(
-            1,
+            0,
             settings.stable_canary_launch_max_active_live_executions
             - current_blocking_live_executions,
         )
@@ -3477,6 +3477,17 @@ async def launch_latest_stable_canary_once(
         settings=settings,
         current_blocking_live_executions=len(blocking_live_executions),
     )
+    if launch_route_limit <= 0:
+        return StableCanaryLaunchSummary(
+            status="skipped",
+            database_path=settings.database_target,
+            detail=_build_blocking_live_execution_detail(
+                blocking=blocking_live_executions,
+                max_active_live_executions=(
+                    settings.stable_canary_launch_max_active_live_executions
+                ),
+            ),
+        )
 
     # Some production pre-checks intentionally touch live execution and balance
     # history. Use a fresh timestamp for market-snapshot freshness so a slow
@@ -3503,6 +3514,7 @@ async def launch_latest_stable_canary_once(
     last_lifecycle: CanaryLifecycleResult | None = None
 
     for candidate_stability in stable_candidates:
+        route_selection_timestamp = now or _utc_now()
         if launched_routes:
             if len(launched_routes) >= launch_route_limit:
                 return _build_stable_launch_launched_summary(
@@ -3517,7 +3529,7 @@ async def launch_latest_stable_canary_once(
             global_cooldown_reason = _build_stable_launch_cooldown_reason(
                 settings=settings,
                 launch_store=stable_launch_store,
-                now=snapshot_selection_timestamp,
+                now=route_selection_timestamp,
             )
             if global_cooldown_reason is not None:
                 return _build_stable_launch_launched_summary(
@@ -3532,7 +3544,7 @@ async def launch_latest_stable_canary_once(
             global_rate_cap_reason = _build_stable_launch_rate_cap_reason(
                 settings=settings,
                 launch_store=stable_launch_store,
-                now=snapshot_selection_timestamp,
+                now=route_selection_timestamp,
             )
             if global_rate_cap_reason is not None:
                 return _build_stable_launch_launched_summary(
@@ -3574,7 +3586,7 @@ async def launch_latest_stable_canary_once(
                     approval_service=route_approval_service,
                     label=candidate_stability.snapshot.label,
                     max_snapshot_age_seconds=settings.launch_ready_canary_max_snapshot_age_seconds,
-                    now=snapshot_selection_timestamp,
+                    now=route_selection_timestamp,
                 )
             )
         except HTTPException as exc:
@@ -3591,6 +3603,16 @@ async def launch_latest_stable_canary_once(
                         detail=exc.detail,
                     )
                 )
+                if launched_routes:
+                    return _build_stable_launch_launched_summary(
+                        database_path=settings.database_target,
+                        launched_routes=launched_routes,
+                        detail=(
+                            "Stable launch stopped after launched routes because "
+                            f"{exc.detail}"
+                        ),
+                        lifecycle=last_lifecycle,
+                    )
                 continue
             raise
 
@@ -3623,7 +3645,7 @@ async def launch_latest_stable_canary_once(
         label_cooldown_reason = _build_stable_launch_cooldown_reason(
             settings=settings,
             launch_store=stable_launch_store,
-            now=snapshot_selection_timestamp,
+            now=route_selection_timestamp,
             label=candidate_snapshot.label,
         )
         if label_cooldown_reason is not None:
@@ -3640,7 +3662,7 @@ async def launch_latest_stable_canary_once(
         label_rate_cap_reason = _build_stable_launch_rate_cap_reason(
             settings=settings,
             launch_store=stable_launch_store,
-            now=snapshot_selection_timestamp,
+            now=route_selection_timestamp,
             label=candidate_snapshot.label,
         )
         if label_rate_cap_reason is not None:
@@ -3970,10 +3992,11 @@ async def launch_latest_stable_canary_once(
         candidate_reservation_owner_id: str | None = None
         if candidate_snapshot.launch_ready_snapshot_id is not None:
             candidate_reservation_owner_id = uuid.uuid4().hex
+            route_reservation_timestamp = now or _utc_now()
             reserved = stable_launch_store.reserve_snapshot_launch(
                 launch_ready_snapshot_id=candidate_snapshot.launch_ready_snapshot_id,
                 label=candidate_snapshot.label,
-                reserved_at=timestamp,
+                reserved_at=route_reservation_timestamp,
                 max_age_seconds=settings.stable_canary_launch_reservation_ttl_seconds,
                 retention_seconds=(
                     settings.stable_canary_launch_reservation_retention_seconds
@@ -4003,7 +4026,7 @@ async def launch_latest_stable_canary_once(
             renewed = stable_launch_store.renew_snapshot_launch_reservation(
                 launch_ready_snapshot_id=launch_ready_snapshot_id,
                 owner_id=owner_id,
-                reserved_at=datetime.now(UTC),
+                reserved_at=now or _utc_now(),
                 max_age_seconds=settings.stable_canary_launch_reservation_ttl_seconds,
             )
             if not renewed:
@@ -4108,9 +4131,10 @@ async def launch_latest_stable_canary_once(
                 "stable canary lifecycle returned launched paper trade without entry_id"
             )
 
+        route_launched_at = now or _utc_now()
         stable_launch_store.append(
             StableCanaryLaunchRecord(
-                launched_at=timestamp,
+                launched_at=route_launched_at,
                 status="launched",
                 label=candidate_snapshot.label,
                 launch_ready_snapshot_id=candidate_snapshot.launch_ready_snapshot_id or 0,

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -439,6 +439,17 @@ def test_stable_launch_route_limit_fails_closed_at_active_cap(tmp_path: Path) ->
     )
 
 
+def test_worker_rejects_multi_route_stable_launch_without_active_cap(tmp_path: Path) -> None:
+    with pytest.raises(
+        ValidationError,
+        match="stable_canary_launch_max_active_live_executions must be positive",
+    ):
+        WorkerSettings(
+            database_path=str(tmp_path / "history.sqlite3"),
+            stable_canary_launch_max_routes_per_cycle=2,
+        )
+
+
 def test_worker_env_can_disable_stable_launch_immediate_close(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -635,7 +646,7 @@ def test_worker_automation_mode_payload_is_redacted_and_shows_hold_controls() ->
         environment="production",
         database_path="postgresql+psycopg://user:secret@db.example.com/carryme",
         stable_canary_launch_close_position=False,
-        stable_canary_launch_max_active_live_executions=0,
+        stable_canary_launch_max_active_live_executions=2,
         stable_canary_launch_max_routes_per_cycle=2,
         stable_canary_launch_max_total_live_notional=25.0,
         stable_canary_launch_max_live_notional_per_venue=20.0,
@@ -656,7 +667,7 @@ def test_worker_automation_mode_payload_is_redacted_and_shows_hold_controls() ->
     assert "secret" not in json.dumps(payload)
     assert payload["stable_canary_launch_close_position"] is False
     assert payload["stable_canary_launch_hold_mode"] is True
-    assert payload["stable_canary_launch_max_active_live_executions"] == 0
+    assert payload["stable_canary_launch_max_active_live_executions"] == 2
     assert payload["stable_canary_launch_max_routes_per_cycle"] == 2
     assert payload["stable_canary_launch_max_total_live_notional"] == 25.0
     assert payload["stable_canary_launch_max_live_notional_per_venue"] == 20.0

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -133,6 +133,7 @@ from carryme_worker.poller import (
     _build_stable_launch_loss_circuit_breaker_reason,
     _execution_requires_continued_monitoring,
     _list_ranked_stable_launch_ready_stabilities,
+    _max_stable_launch_routes_this_cycle,
     _maybe_auto_cleanup_partial_fill_execution,
     _maybe_auto_close_open_hedged_execution,
     _probe_candidate_system_state,
@@ -413,6 +414,29 @@ def test_worker_defaults(monkeypatch: pytest.MonkeyPatch) -> None:
     assert settings.database_path == "data/carryme.sqlite3"
     assert Path(settings.watchlist_path).is_file()
     assert settings.watchlist_path.endswith("config/watchlists/default.json")
+
+
+def test_stable_launch_route_limit_fails_closed_at_active_cap(tmp_path: Path) -> None:
+    settings = WorkerSettings(
+        database_path=str(tmp_path / "history.sqlite3"),
+        stable_canary_launch_max_active_live_executions=2,
+        stable_canary_launch_max_routes_per_cycle=3,
+    )
+
+    assert (
+        _max_stable_launch_routes_this_cycle(
+            settings=settings,
+            current_blocking_live_executions=2,
+        )
+        == 0
+    )
+    assert (
+        _max_stable_launch_routes_this_cycle(
+            settings=settings,
+            current_blocking_live_executions=1,
+        )
+        == 1
+    )
 
 
 def test_worker_env_can_disable_stable_launch_immediate_close(
@@ -5409,6 +5433,9 @@ def test_launch_latest_stable_canary_once_refreshes_snapshot_time_after_precheck
         [
             datetime(2026, 4, 4, 10, 0, 50, tzinfo=UTC),
             datetime(2026, 4, 4, 10, 1, 45, tzinfo=UTC),
+            datetime(2026, 4, 4, 10, 1, 45, tzinfo=UTC),
+            datetime(2026, 4, 4, 10, 1, 46, tzinfo=UTC),
+            datetime(2026, 4, 4, 10, 1, 47, tzinfo=UTC),
         ]
     )
 
@@ -6172,6 +6199,291 @@ def test_launch_latest_stable_canary_once_spends_budget_across_cycle_routes(
     assert captured_labels == ["zro_extended_paradex", "strk_extended_paradex"]
     assert [route.label for route in summary.launched_routes] == captured_labels
     assert len(launch_store.list_recent(limit=10)) == 2
+
+
+def test_launch_latest_stable_canary_once_refreshes_snapshot_time_per_route(
+    tmp_path: Path,
+) -> None:
+    settings = WorkerSettings(
+        database_path=str(tmp_path / "history.sqlite3"),
+        launch_ready_canary_max_snapshot_age_seconds=60,
+        stable_canary_launch_max_routes_per_cycle=2,
+        stable_canary_launch_max_active_live_executions=2,
+    )
+    approved_store = ApprovedCanaryStore(settings.database_path)
+    launch_ready_store = LaunchReadyCanaryStore(settings.database_path)
+    launch_store = StableCanaryLaunchStore(settings.database_path)
+    route_approval_store = RouteApprovalStore(settings.database_path)
+    approval_by_label: dict[str, RouteApprovalEntry] = {}
+    latest_snapshot_by_label: dict[str, LaunchReadyCanarySnapshot] = {}
+    for index, label in enumerate(["zro_extended_paradex", "strk_extended_paradex"], start=1):
+        approval, _, snapshot, _ = _build_stable_launch_test_snapshot(
+            label=label,
+            canonical_symbol=f"{label.split('_', maxsplit=1)[0].upper()}-USD-PERP",
+            short_symbol=f"{label.split('_', maxsplit=1)[0].upper()}-USD",
+            long_symbol=f"{label.split('_', maxsplit=1)[0].upper()}-USD-PERP",
+            launch_ready_snapshot_id=index * 10 + 1,
+            approved_snapshot_id=index * 10,
+            estimated_one_day_pnl_after_round_trip=float(3 - index),
+        )
+        approved_snapshot = approved_store.append(snapshot.approved_snapshot)
+        route_approval_store.upsert(approval)
+        approval_by_label[label] = approval
+        latest_snapshot_by_label[label] = _append_stable_launch_ready_pair(
+            launch_ready_store,
+            snapshot,
+            approved_snapshot,
+            datetime(2026, 4, 4, 9, 59, index, tzinfo=UTC),
+            datetime(2026, 4, 4, 10, 0, index, tzinfo=UTC),
+        )
+
+    captured_labels: list[str] = []
+
+    class StubLifecycleResult:
+        def __init__(self, label: str, paper_trade_id: int) -> None:
+            self.paper_trade = PaperTradeEntry(
+                entry_id=paper_trade_id,
+                created_at=datetime(2026, 4, 4, 10, 0, 30, tzinfo=UTC),
+                intent=_build_auto_close_paper_trade(
+                    entry_id=paper_trade_id,
+                    created_at=datetime(2026, 4, 4, 10, 0, 30, tzinfo=UTC),
+                    label=label,
+                ).intent,
+                note="worker launch",
+            )
+            self.final_pair_status = ExecutionPairStatus(
+                execution_entry_id=paper_trade_id + 100,
+                paper_trade_id=paper_trade_id,
+                preview_hash=f"preview-{paper_trade_id}",
+                derived_state="hedged",
+                recommended_action="monitor_open_hedge",
+                order_state=ExecutionOrderState(
+                    execution_entry_id=paper_trade_id + 100,
+                    paper_trade_id=paper_trade_id,
+                    preview_hash=f"preview-{paper_trade_id}",
+                    legs=[],
+                    notes=[],
+                ),
+                reconciliation=ExecutionReconciliation(
+                    execution_entry_id=paper_trade_id + 100,
+                    paper_trade_id=paper_trade_id,
+                    preview_hash=f"preview-{paper_trade_id}",
+                    status="accepted",
+                    recommended_action="monitor_open_hedge",
+                    matched_all_leg_symbols=True,
+                    venues=[],
+                    notes=[],
+                ),
+                notes=[],
+            )
+
+    async def run_stub_lifecycle(**kwargs: object) -> StubLifecycleResult:
+        approval = cast(RouteApprovalEntry, kwargs["approval"])
+        captured_labels.append(approval.label)
+        return StubLifecycleResult(approval.label, 300 + len(captured_labels))
+
+    clock = iter(
+        [
+            datetime(2026, 4, 4, 10, 0, 30, tzinfo=UTC),
+            datetime(2026, 4, 4, 10, 0, 30, tzinfo=UTC),
+            datetime(2026, 4, 4, 10, 0, 30, tzinfo=UTC),
+            datetime(2026, 4, 4, 10, 0, 31, tzinfo=UTC),
+            datetime(2026, 4, 4, 10, 0, 32, tzinfo=UTC),
+            datetime(2026, 4, 4, 10, 2, 5, tzinfo=UTC),
+        ]
+    )
+    selection_times: list[datetime] = []
+
+    def fake_select_latest_launch_ready_canary_snapshot(
+        **kwargs: object,
+    ) -> tuple[LaunchReadyCanarySnapshot, FundingUniverseCanaryCandidate, RouteApprovalEntry]:
+        label = cast(str, kwargs["label"])
+        selected_at = cast(datetime, kwargs["now"])
+        selection_times.append(selected_at)
+        if len(selection_times) == 2 and selected_at > datetime(
+            2026, 4, 4, 10, 1, 5, tzinfo=UTC
+        ):
+            raise HTTPException(
+                status_code=409,
+                detail="Launch-ready canary snapshot is stale in test",
+            )
+        snapshot = latest_snapshot_by_label[label]
+        return snapshot, snapshot.approved_snapshot.candidate, approval_by_label[label]
+
+    with pytest.MonkeyPatch.context() as monkeypatch:
+        monkeypatch.setattr("carryme_worker.poller._utc_now", lambda: next(clock))
+        monkeypatch.setattr(
+            "carryme_worker.poller._select_latest_launch_ready_canary_snapshot",
+            fake_select_latest_launch_ready_canary_snapshot,
+        )
+        monkeypatch.setattr(
+            "carryme_worker.poller._run_guarded_canary_lifecycle",
+            run_stub_lifecycle,
+        )
+        summary = asyncio.run(
+            launch_latest_stable_canary_once(
+                settings,
+                api_settings=ApiSettings(
+                    database_path=settings.database_path,
+                    watchlist_path=settings.watchlist_path,
+                    environment=settings.environment,
+                    extended_live_enabled=True,
+                    extended_api_key="extended-key",
+                    extended_stark_private_key="extended-secret",
+                    paradex_live_enabled=True,
+                    paradex_account_address="0x123",
+                    paradex_private_key="0x456",
+                ),
+                launch_store=launch_store,
+                approved_store=approved_store,
+            )
+        )
+
+    assert summary.status == "launched"
+    assert summary.launched_count == 1
+    assert captured_labels == ["zro_extended_paradex"]
+    assert selection_times == [
+        datetime(2026, 4, 4, 10, 0, 30, tzinfo=UTC),
+        datetime(2026, 4, 4, 10, 2, 5, tzinfo=UTC),
+    ]
+    assert "Stable launch stopped after launched routes" in cast(str, summary.detail)
+
+
+def test_launch_latest_stable_canary_once_uses_fresh_per_route_timestamps(
+    tmp_path: Path,
+) -> None:
+    settings = WorkerSettings(
+        database_path=str(tmp_path / "history.sqlite3"),
+        stable_canary_launch_max_routes_per_cycle=2,
+        stable_canary_launch_max_active_live_executions=2,
+    )
+    approved_store = ApprovedCanaryStore(settings.database_path)
+    launch_ready_store = LaunchReadyCanaryStore(settings.database_path)
+    launch_store = StableCanaryLaunchStore(settings.database_path)
+    route_approval_store = RouteApprovalStore(settings.database_path)
+    for index, label in enumerate(["zro_extended_paradex", "strk_extended_paradex"], start=1):
+        approval, _, snapshot, _ = _build_stable_launch_test_snapshot(
+            label=label,
+            canonical_symbol=f"{label.split('_', maxsplit=1)[0].upper()}-USD-PERP",
+            short_symbol=f"{label.split('_', maxsplit=1)[0].upper()}-USD",
+            long_symbol=f"{label.split('_', maxsplit=1)[0].upper()}-USD-PERP",
+            launch_ready_snapshot_id=index * 10 + 1,
+            approved_snapshot_id=index * 10,
+            estimated_one_day_pnl_after_round_trip=float(3 - index),
+        )
+        approved_snapshot = approved_store.append(snapshot.approved_snapshot)
+        route_approval_store.upsert(approval)
+        _append_stable_launch_ready_pair(
+            launch_ready_store,
+            snapshot,
+            approved_snapshot,
+            datetime(2026, 4, 4, 10, 0, index, tzinfo=UTC),
+            datetime(2026, 4, 4, 10, 1, index, tzinfo=UTC),
+        )
+
+    class StubLifecycleResult:
+        def __init__(self, label: str, paper_trade_id: int) -> None:
+            self.paper_trade = PaperTradeEntry(
+                entry_id=paper_trade_id,
+                created_at=datetime(2026, 4, 4, 10, 2, tzinfo=UTC),
+                intent=_build_auto_close_paper_trade(
+                    entry_id=paper_trade_id,
+                    created_at=datetime(2026, 4, 4, 10, 2, tzinfo=UTC),
+                    label=label,
+                ).intent,
+                note="worker launch",
+            )
+            self.final_pair_status = ExecutionPairStatus(
+                execution_entry_id=paper_trade_id + 100,
+                paper_trade_id=paper_trade_id,
+                preview_hash=f"preview-{paper_trade_id}",
+                derived_state="hedged",
+                recommended_action="monitor_open_hedge",
+                order_state=ExecutionOrderState(
+                    execution_entry_id=paper_trade_id + 100,
+                    paper_trade_id=paper_trade_id,
+                    preview_hash=f"preview-{paper_trade_id}",
+                    legs=[],
+                    notes=[],
+                ),
+                reconciliation=ExecutionReconciliation(
+                    execution_entry_id=paper_trade_id + 100,
+                    paper_trade_id=paper_trade_id,
+                    preview_hash=f"preview-{paper_trade_id}",
+                    status="accepted",
+                    recommended_action="monitor_open_hedge",
+                    matched_all_leg_symbols=True,
+                    venues=[],
+                    notes=[],
+                ),
+                notes=[],
+            )
+
+    launched_labels: list[str] = []
+
+    async def run_stub_lifecycle(**kwargs: object) -> StubLifecycleResult:
+        approval = cast(RouteApprovalEntry, kwargs["approval"])
+        launched_labels.append(approval.label)
+        return StubLifecycleResult(approval.label, 400 + len(launched_labels))
+
+    clock = iter(
+        [
+            datetime(2026, 4, 4, 10, 2, 0, tzinfo=UTC),
+            datetime(2026, 4, 4, 10, 2, 0, tzinfo=UTC),
+            datetime(2026, 4, 4, 10, 2, 0, tzinfo=UTC),
+            datetime(2026, 4, 4, 10, 2, 1, tzinfo=UTC),
+            datetime(2026, 4, 4, 10, 2, 2, tzinfo=UTC),
+            datetime(2026, 4, 4, 10, 2, 3, tzinfo=UTC),
+            datetime(2026, 4, 4, 10, 2, 4, tzinfo=UTC),
+            datetime(2026, 4, 4, 10, 2, 5, tzinfo=UTC),
+        ]
+    )
+
+    with pytest.MonkeyPatch.context() as monkeypatch:
+        monkeypatch.setattr("carryme_worker.poller._utc_now", lambda: next(clock))
+        monkeypatch.setattr(
+            "carryme_worker.poller._run_guarded_canary_lifecycle",
+            run_stub_lifecycle,
+        )
+        summary = asyncio.run(
+            launch_latest_stable_canary_once(
+                settings,
+                api_settings=ApiSettings(
+                    database_path=settings.database_path,
+                    watchlist_path=settings.watchlist_path,
+                    environment=settings.environment,
+                    extended_live_enabled=True,
+                    extended_api_key="extended-key",
+                    extended_stark_private_key="extended-secret",
+                    paradex_live_enabled=True,
+                    paradex_account_address="0x123",
+                    paradex_private_key="0x456",
+                ),
+                launch_store=launch_store,
+                approved_store=approved_store,
+            )
+        )
+
+    assert summary.status == "launched"
+    assert summary.launched_count == 2
+    assert launched_labels == ["zro_extended_paradex", "strk_extended_paradex"]
+    launch_records = launch_store.list_recent(limit=10)
+    assert {record.launched_at for record in launch_records} == {
+        datetime(2026, 4, 4, 10, 2, 2, tzinfo=UTC),
+        datetime(2026, 4, 4, 10, 2, 5, tzinfo=UTC),
+    }
+    with launch_store.database.begin() as connection:
+        reservation_rows = connection.execute(
+            """
+            SELECT reserved_at
+            FROM stable_canary_launch_reservations
+            ORDER BY reserved_at
+            """
+        ).fetchall()
+    assert [row[0] for row in reservation_rows] == [
+        "2026-04-04T10:02:01+00:00",
+        "2026-04-04T10:02:04+00:00",
+    ]
 
 
 def test_launch_latest_stable_canary_once_falls_through_reserved_snapshot(
@@ -7099,7 +7411,7 @@ def test_launch_latest_stable_canary_once_allows_launch_when_latest_outcome_is_c
     settings = WorkerSettings(
         database_path=str(tmp_path / "history.sqlite3"),
         stable_canary_launch_block_adverse_latest_outcome=True,
-        stable_canary_launch_max_active_live_executions=1,
+        stable_canary_launch_max_active_live_executions=2,
     )
     approval, candidate, snapshot, stability = _build_stable_launch_test_snapshot(
         label="arb_extended_paradex",
@@ -7798,7 +8110,7 @@ def test_launch_latest_stable_canary_once_allows_launch_at_exact_maturity_thresh
         database_path=str(tmp_path / "history.sqlite3"),
         stable_canary_launch_min_execution_quality_score=0.55,
         stable_canary_launch_min_execution_samples=2,
-        stable_canary_launch_max_active_live_executions=1,
+        stable_canary_launch_max_active_live_executions=2,
     )
     approval, candidate, snapshot, stability = _build_stable_launch_test_snapshot(
         label="arb_extended_paradex",
@@ -8433,7 +8745,7 @@ def test_launch_latest_stable_canary_once_skips_when_total_live_notional_budget_
 ) -> None:
     settings = WorkerSettings(
         database_path=str(tmp_path / "history.sqlite3"),
-        stable_canary_launch_max_active_live_executions=1,
+        stable_canary_launch_max_active_live_executions=2,
         stable_canary_launch_max_total_live_notional=40.0,
     )
     execution_store = ExecutionJournalStore(settings.database_path)
@@ -9061,7 +9373,7 @@ def test_launch_latest_stable_canary_once_skips_when_venue_live_notional_budget_
 ) -> None:
     settings = WorkerSettings(
         database_path=str(tmp_path / "history.sqlite3"),
-        stable_canary_launch_max_active_live_executions=1,
+        stable_canary_launch_max_active_live_executions=2,
         stable_canary_launch_max_live_notional_per_venue=30.0,
     )
     execution_store = ExecutionJournalStore(settings.database_path)

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -118,6 +118,7 @@ from carryme_worker.poller import (
     PollLoopSummary,
     ProductionSupervisorCycleSummary,
     ProductionSupervisorLoopSummary,
+    StableCanaryLaunchedRoute,
     StableCanaryLaunchLoopSummary,
     StableCanaryLaunchSummary,
     SystemStateObservationLoopSummary,
@@ -249,6 +250,10 @@ def _clear_worker_env(monkeypatch: pytest.MonkeyPatch) -> None:
         raising=False,
     )
     monkeypatch.delenv(
+        "CARRYME_WORKER_STABLE_CANARY_LAUNCH_MAX_ROUTES_PER_CYCLE",
+        raising=False,
+    )
+    monkeypatch.delenv(
         "CARRYME_WORKER_STABLE_CANARY_LAUNCH_MAX_TOTAL_LIVE_NOTIONAL",
         raising=False,
     )
@@ -344,6 +349,7 @@ def test_worker_defaults(monkeypatch: pytest.MonkeyPatch) -> None:
     assert settings.stable_canary_launch_max_active_live_executions == 0
     assert settings.stable_canary_launch_active_execution_limit == 20
     assert settings.stable_canary_launch_candidate_scan_limit == 100
+    assert settings.stable_canary_launch_max_routes_per_cycle == 1
     assert settings.stable_canary_launch_max_total_live_notional is None
     assert settings.stable_canary_launch_max_live_notional_per_venue is None
     assert settings.stable_canary_launch_recent_closed_trade_limit == 10
@@ -606,6 +612,7 @@ def test_worker_automation_mode_payload_is_redacted_and_shows_hold_controls() ->
         database_path="postgresql+psycopg://user:secret@db.example.com/carryme",
         stable_canary_launch_close_position=False,
         stable_canary_launch_max_active_live_executions=0,
+        stable_canary_launch_max_routes_per_cycle=2,
         stable_canary_launch_max_total_live_notional=25.0,
         stable_canary_launch_max_live_notional_per_venue=20.0,
         execution_auto_pair_close_enabled=True,
@@ -626,6 +633,7 @@ def test_worker_automation_mode_payload_is_redacted_and_shows_hold_controls() ->
     assert payload["stable_canary_launch_close_position"] is False
     assert payload["stable_canary_launch_hold_mode"] is True
     assert payload["stable_canary_launch_max_active_live_executions"] == 0
+    assert payload["stable_canary_launch_max_routes_per_cycle"] == 2
     assert payload["stable_canary_launch_max_total_live_notional"] == 25.0
     assert payload["stable_canary_launch_max_live_notional_per_venue"] == 20.0
     assert payload["execution_auto_pair_close_enabled"] is True
@@ -919,6 +927,17 @@ def test_worker_stable_canary_launch_payload() -> None:
             approved_snapshot_id=5,
             paper_trade_id=11,
             final_pair_state="closed",
+            launched_count=1,
+            launched_routes=[
+                StableCanaryLaunchedRoute(
+                    label="arb_extended_paradex",
+                    launch_ready_snapshot_id=7,
+                    approved_snapshot_id=5,
+                    paper_trade_id=11,
+                    final_pair_state="closed",
+                    selected_notional=20.0,
+                )
+            ],
             detail=None,
             database_path="tmp/history.sqlite3",
         )
@@ -931,6 +950,17 @@ def test_worker_stable_canary_launch_payload() -> None:
         "approved_snapshot_id": 5,
         "paper_trade_id": 11,
         "final_pair_state": "closed",
+        "launched_count": 1,
+        "launched_routes": [
+            {
+                "label": "arb_extended_paradex",
+                "launch_ready_snapshot_id": 7,
+                "approved_snapshot_id": 5,
+                "paper_trade_id": 11,
+                "final_pair_state": "closed",
+                "selected_notional": 20.0,
+            }
+        ],
         "detail": None,
         "database_path": "tmp/history.sqlite3",
     }
@@ -5845,6 +5875,303 @@ def test_launch_latest_stable_canary_once_falls_through_label_cooldown(
     assert summary.label == "arb_extended_paradex"
     assert summary.launch_ready_snapshot_id == latest_fallback.launch_ready_snapshot_id
     assert captured_labels == ["arb_extended_paradex"]
+
+
+def test_launch_latest_stable_canary_once_launches_multiple_routes_per_cycle(
+    tmp_path: Path,
+) -> None:
+    settings = WorkerSettings(
+        database_path=str(tmp_path / "history.sqlite3"),
+        stable_canary_launch_max_routes_per_cycle=3,
+        stable_canary_launch_max_active_live_executions=3,
+        stable_canary_launch_max_total_live_notional=60.0,
+        stable_canary_launch_max_live_notional_per_venue=60.0,
+    )
+    approved_store = ApprovedCanaryStore(settings.database_path)
+    launch_ready_store = LaunchReadyCanaryStore(settings.database_path)
+    launch_store = StableCanaryLaunchStore(settings.database_path)
+    route_approval_store = RouteApprovalStore(settings.database_path)
+    latest_snapshots: dict[str, LaunchReadyCanarySnapshot] = {}
+    route_specs = [
+        ("zro_extended_paradex", "ZRO-USD-PERP", "ZRO-USD", "ZRO-USD-PERP", 4.0),
+        ("strk_extended_paradex", "STRK-USD-PERP", "STRK-USD", "STRK-USD-PERP", 3.0),
+        ("op_extended_paradex", "OP-USD-PERP", "OP-USD", "OP-USD-PERP", 2.0),
+    ]
+    for index, (label, canonical_symbol, short_symbol, long_symbol, pnl) in enumerate(
+        route_specs,
+        start=1,
+    ):
+        approval, _, snapshot, _ = _build_stable_launch_test_snapshot(
+            label=label,
+            canonical_symbol=canonical_symbol,
+            short_symbol=short_symbol,
+            long_symbol=long_symbol,
+            launch_ready_snapshot_id=index * 10 + 1,
+            approved_snapshot_id=index * 10,
+            suggested_canary_notional=20.0,
+            estimated_one_day_pnl_after_round_trip=pnl,
+        )
+        approved_snapshot = approved_store.append(snapshot.approved_snapshot)
+        route_approval_store.upsert(approval)
+        latest_snapshots[label] = _append_stable_launch_ready_pair(
+            launch_ready_store,
+            snapshot,
+            approved_snapshot,
+            datetime(2026, 4, 4, 10, 0, index, tzinfo=UTC),
+            datetime(2026, 4, 4, 10, 1, index, tzinfo=UTC),
+        )
+
+    captured_labels: list[str] = []
+    captured_notional: list[float] = []
+
+    class StubLifecycleResult:
+        def __init__(
+            self,
+            *,
+            candidate: FundingUniverseCanaryCandidate,
+            label: str,
+            paper_trade_id: int,
+        ) -> None:
+            opportunity = candidate.opportunity.opportunity
+            notional = candidate.suggested_canary_notional
+            capacity_limit = (
+                opportunity.capacity.max_entry_notional
+                if opportunity.capacity is not None
+                and opportunity.capacity.max_entry_notional is not None
+                else notional
+            )
+            self.paper_trade = PaperTradeEntry(
+                entry_id=paper_trade_id,
+                created_at=datetime(2026, 4, 4, 10, 2, tzinfo=UTC),
+                intent=FundingPairTradeIntent(
+                    label=label,
+                    canonical_symbol=opportunity.canonical_symbol,
+                    source_recorded_at=datetime(2026, 4, 4, 10, 1, tzinfo=UTC),
+                    one_day_net_edge_after_entry=opportunity.one_day_net_edge_after_entry,
+                    break_even_days_entry=opportunity.break_even_days_entry,
+                    capacity_limit_notional=capacity_limit,
+                    target_notional=notional,
+                    capacity_fraction=notional / capacity_limit,
+                    max_target_notional=notional,
+                    long_leg=TradeLegIntent(
+                        venue=opportunity.long_venue,
+                        symbol=candidate.opportunity.venue_markets[
+                            opportunity.long_venue
+                        ].symbol,
+                        fee_profile=opportunity.long_fee_profile,
+                        side="buy",
+                        target_notional=notional,
+                    ),
+                    short_leg=TradeLegIntent(
+                        venue=opportunity.short_venue,
+                        symbol=candidate.opportunity.venue_markets[
+                            opportunity.short_venue
+                        ].symbol,
+                        fee_profile=opportunity.short_fee_profile,
+                        side="sell",
+                        target_notional=notional,
+                    ),
+                ),
+                note="worker launch",
+            )
+            self.final_pair_status = ExecutionPairStatus(
+                execution_entry_id=paper_trade_id + 100,
+                paper_trade_id=paper_trade_id,
+                preview_hash=f"preview-{paper_trade_id}",
+                derived_state="hedged",
+                recommended_action="monitor_open_hedge",
+                order_state=ExecutionOrderState(
+                    execution_entry_id=paper_trade_id + 100,
+                    paper_trade_id=paper_trade_id,
+                    preview_hash=f"preview-{paper_trade_id}",
+                    legs=[],
+                    notes=[],
+                ),
+                reconciliation=ExecutionReconciliation(
+                    execution_entry_id=paper_trade_id + 100,
+                    paper_trade_id=paper_trade_id,
+                    preview_hash=f"preview-{paper_trade_id}",
+                    status="accepted",
+                    recommended_action="monitor_open_hedge",
+                    matched_all_leg_symbols=True,
+                    venues=[],
+                    notes=[],
+                ),
+                notes=[],
+            )
+
+    async def run_stub_lifecycle(**kwargs: object) -> StubLifecycleResult:
+        approval = cast(RouteApprovalEntry, kwargs["approval"])
+        candidate = cast(FundingUniverseCanaryCandidate, kwargs["candidate"])
+        captured_labels.append(approval.label)
+        captured_notional.append(candidate.suggested_canary_notional)
+        return StubLifecycleResult(
+            candidate=candidate,
+            label=approval.label,
+            paper_trade_id=100 + len(captured_labels),
+        )
+
+    api_settings = ApiSettings(
+        database_path=settings.database_path,
+        watchlist_path=settings.watchlist_path,
+        environment=settings.environment,
+        extended_live_enabled=True,
+        extended_api_key="extended-key",
+        extended_stark_private_key="extended-secret",
+        paradex_live_enabled=True,
+        paradex_account_address="0x123",
+        paradex_private_key="0x456",
+    )
+    with pytest.MonkeyPatch.context() as monkeypatch:
+        monkeypatch.setattr(
+            "carryme_worker.poller._run_guarded_canary_lifecycle",
+            run_stub_lifecycle,
+        )
+        summary = asyncio.run(
+            launch_latest_stable_canary_once(
+                settings,
+                api_settings=api_settings,
+                launch_store=launch_store,
+                approved_store=approved_store,
+                now=datetime(2026, 4, 4, 10, 2, tzinfo=UTC),
+            )
+        )
+
+    assert summary.status == "launched"
+    assert summary.launched_count == 3
+    assert captured_labels == [
+        "zro_extended_paradex",
+        "strk_extended_paradex",
+        "op_extended_paradex",
+    ]
+    assert captured_notional == [20.0, 20.0, 20.0]
+    assert [route.label for route in summary.launched_routes] == captured_labels
+    assert [route.selected_notional for route in summary.launched_routes] == [
+        20.0,
+        20.0,
+        20.0,
+    ]
+    assert summary.launch_ready_snapshot_id == (
+        latest_snapshots["zro_extended_paradex"].launch_ready_snapshot_id
+    )
+    launch_records = launch_store.list_recent(limit=10)
+    assert len(launch_records) == 3
+
+
+def test_launch_latest_stable_canary_once_spends_budget_across_cycle_routes(
+    tmp_path: Path,
+) -> None:
+    settings = WorkerSettings(
+        database_path=str(tmp_path / "history.sqlite3"),
+        stable_canary_launch_max_routes_per_cycle=3,
+        stable_canary_launch_max_active_live_executions=3,
+        stable_canary_launch_max_total_live_notional=45.0,
+        stable_canary_launch_max_live_notional_per_venue=100.0,
+    )
+    approved_store = ApprovedCanaryStore(settings.database_path)
+    launch_ready_store = LaunchReadyCanaryStore(settings.database_path)
+    launch_store = StableCanaryLaunchStore(settings.database_path)
+    route_approval_store = RouteApprovalStore(settings.database_path)
+    for index, label in enumerate(
+        ["zro_extended_paradex", "strk_extended_paradex", "op_extended_paradex"],
+        start=1,
+    ):
+        approval, _, snapshot, _ = _build_stable_launch_test_snapshot(
+            label=label,
+            canonical_symbol=f"{label.split('_', maxsplit=1)[0].upper()}-USD-PERP",
+            short_symbol=f"{label.split('_', maxsplit=1)[0].upper()}-USD",
+            long_symbol=f"{label.split('_', maxsplit=1)[0].upper()}-USD-PERP",
+            launch_ready_snapshot_id=index * 10 + 1,
+            approved_snapshot_id=index * 10,
+            suggested_canary_notional=20.0,
+            estimated_one_day_pnl_after_round_trip=float(5 - index),
+        )
+        approved_snapshot = approved_store.append(snapshot.approved_snapshot)
+        route_approval_store.upsert(approval)
+        _append_stable_launch_ready_pair(
+            launch_ready_store,
+            snapshot,
+            approved_snapshot,
+            datetime(2026, 4, 4, 10, 0, index, tzinfo=UTC),
+            datetime(2026, 4, 4, 10, 1, index, tzinfo=UTC),
+        )
+
+    captured_labels: list[str] = []
+
+    class StubLifecycleResult:
+        def __init__(self, label: str, paper_trade_id: int) -> None:
+            self.paper_trade = PaperTradeEntry(
+                entry_id=paper_trade_id,
+                created_at=datetime(2026, 4, 4, 10, 2, tzinfo=UTC),
+                intent=_build_auto_close_paper_trade(
+                    entry_id=paper_trade_id,
+                    created_at=datetime(2026, 4, 4, 10, 2, tzinfo=UTC),
+                    label=label,
+                ).intent,
+                note="worker launch",
+            )
+            self.final_pair_status = ExecutionPairStatus(
+                execution_entry_id=paper_trade_id + 100,
+                paper_trade_id=paper_trade_id,
+                preview_hash=f"preview-{paper_trade_id}",
+                derived_state="hedged",
+                recommended_action="monitor_open_hedge",
+                order_state=ExecutionOrderState(
+                    execution_entry_id=paper_trade_id + 100,
+                    paper_trade_id=paper_trade_id,
+                    preview_hash=f"preview-{paper_trade_id}",
+                    legs=[],
+                    notes=[],
+                ),
+                reconciliation=ExecutionReconciliation(
+                    execution_entry_id=paper_trade_id + 100,
+                    paper_trade_id=paper_trade_id,
+                    preview_hash=f"preview-{paper_trade_id}",
+                    status="accepted",
+                    recommended_action="monitor_open_hedge",
+                    matched_all_leg_symbols=True,
+                    venues=[],
+                    notes=[],
+                ),
+                notes=[],
+            )
+
+    async def run_stub_lifecycle(**kwargs: object) -> StubLifecycleResult:
+        approval = cast(RouteApprovalEntry, kwargs["approval"])
+        captured_labels.append(approval.label)
+        return StubLifecycleResult(approval.label, 200 + len(captured_labels))
+
+    api_settings = ApiSettings(
+        database_path=settings.database_path,
+        watchlist_path=settings.watchlist_path,
+        environment=settings.environment,
+        extended_live_enabled=True,
+        extended_api_key="extended-key",
+        extended_stark_private_key="extended-secret",
+        paradex_live_enabled=True,
+        paradex_account_address="0x123",
+        paradex_private_key="0x456",
+    )
+    with pytest.MonkeyPatch.context() as monkeypatch:
+        monkeypatch.setattr(
+            "carryme_worker.poller._run_guarded_canary_lifecycle",
+            run_stub_lifecycle,
+        )
+        summary = asyncio.run(
+            launch_latest_stable_canary_once(
+                settings,
+                api_settings=api_settings,
+                launch_store=launch_store,
+                approved_store=approved_store,
+                now=datetime(2026, 4, 4, 10, 2, tzinfo=UTC),
+            )
+        )
+
+    assert summary.status == "launched"
+    assert summary.launched_count == 2
+    assert captured_labels == ["zro_extended_paradex", "strk_extended_paradex"]
+    assert [route.label for route in summary.launched_routes] == captured_labels
+    assert len(launch_store.list_recent(limit=10)) == 2
 
 
 def test_launch_latest_stable_canary_once_falls_through_reserved_snapshot(


### PR DESCRIPTION
## Summary
- add `CARRYME_WORKER_STABLE_CANARY_LAUNCH_MAX_ROUTES_PER_CYCLE` so stable launch can open multiple ranked, route-approved stable canaries in one supervised cycle
- track per-cycle launched routes, selected notional, and launched count in worker summaries/log payloads
- spend total/per-venue live-notional budgets after each route so later routes in the same cycle cannot over-allocate capital
- preserve fail-closed defaults: default max routes per cycle remains 1, and existing approval, freshness, live credential, active execution, cooldown, rate-cap, hold-mode, and notional gates still apply

## Review Fixes
- active-execution cap equality now fails closed instead of allowing one extra route when the cap is already reached
- multi-route launch now fails fast at configuration time unless `stable_canary_launch_max_active_live_executions` is positive
- launch-ready snapshot freshness is rechecked with a fresh per-route timestamp inside multi-route cycles
- reservation renewal, reservation creation, and launch records use fresh per-route timestamps so leases and cooldown/rate-cap records are not backdated by cycle-start time

## Why
The stable-launch worker previously opened at most one route per cycle. That made capital deployment slow even when multiple approved, stable, monitorable opportunities were available. This lets operators explicitly enable controlled multi-route deployment without bypassing the existing safety budget gates.

## Validation
- `uv run pytest -q tests/test_worker.py::test_worker_defaults tests/test_worker.py::test_worker_automation_mode_payload_is_redacted_and_shows_hold_controls tests/test_worker.py::test_worker_stable_canary_launch_payload tests/test_worker.py::test_launch_latest_stable_canary_once_launches_multiple_routes_per_cycle tests/test_worker.py::test_launch_latest_stable_canary_once_spends_budget_across_cycle_routes tests/test_worker.py::test_launch_latest_stable_canary_once_returns_launched_summary tests/test_worker.py::test_run_supervised_stable_canary_launch_loop_honors_max_iterations`
- `uv run pytest -q tests/test_worker.py::test_worker_rejects_multi_route_stable_launch_without_active_cap tests/test_worker.py::test_stable_launch_route_limit_fails_closed_at_active_cap tests/test_worker.py::test_launch_latest_stable_canary_once_refreshes_snapshot_time_per_route tests/test_worker.py::test_launch_latest_stable_canary_once_uses_fresh_per_route_timestamps tests/test_worker.py::test_launch_latest_stable_canary_once_aborts_when_reservation_owner_is_lost`
- `uv run ruff check apps/worker/src/carryme_worker/config.py apps/worker/src/carryme_worker/main.py apps/worker/src/carryme_worker/poller.py tests/test_worker.py`
- `uv run mypy apps/worker/src/carryme_worker/config.py apps/worker/src/carryme_worker/main.py apps/worker/src/carryme_worker/poller.py tests/test_worker.py`
- `uv run pytest -q tests/test_worker.py`
- `uv run pytest -q tests/test_runtime.py::test_route_approval_service_builds_approved_canary_basket_plan tests/test_runtime.py::test_route_approval_service_caps_approved_canary_basket_by_target_notional tests/test_canary_cycle_api.py::test_execute_guarded_approved_canary_basket_uses_shared_cap_plan`
- `uv run ruff check .`
- `uv run mypy src apps packages tests`
- `uv run pytest -q`
