### PR TITLE
fix: retry API startup prewarm

### DIFF
--- a/apps/api/src/carryme_api/app.py
+++ b/apps/api/src/carryme_api/app.py
@@ -816,6 +816,36 @@ def _should_prewarm_execution_journal(settings: ApiSettings) -> bool:
     )
 
 
+async def _prewarm_execution_journal_with_retries(settings: ApiSettings) -> None:
+    """Prewarm the execution journal while tolerating brief Postgres restarts."""
+
+    if not _should_prewarm_execution_journal(settings):
+        return
+
+    max_attempts = settings.startup_prewarm_max_attempts
+    for attempt in range(1, max_attempts + 1):
+        try:
+            _execution_journal_store_for_path(settings.database_path).initialize()
+            return
+        except Exception:
+            if attempt >= max_attempts:
+                logger.exception(
+                    "API startup execution journal prewarm failed after %d attempts",
+                    max_attempts,
+                )
+                raise
+            logger.warning(
+                "API startup execution journal prewarm failed on attempt %d/%d; "
+                "retrying in %.1fs",
+                attempt,
+                max_attempts,
+                settings.startup_prewarm_retry_delay_seconds,
+                exc_info=True,
+            )
+            if settings.startup_prewarm_retry_delay_seconds > 0:
+                await asyncio.sleep(settings.startup_prewarm_retry_delay_seconds)
+
+
 def _operator_auth_error(status_code: int, detail: str) -> JSONResponse:
     headers = {"WWW-Authenticate": "Bearer"} if status_code == 401 else None
     return JSONResponse(status_code=status_code, content={"detail": detail}, headers=headers)
@@ -5085,8 +5115,7 @@ def create_app() -> FastAPI:
         """Warm the shared execution journal store before serving live requests."""
 
         settings = await _resolve_api_settings_for_app(app)
-        if _should_prewarm_execution_journal(settings):
-            _execution_journal_store_for_path(settings.database_path).initialize()
+        await _prewarm_execution_journal_with_retries(settings)
         yield
 
     app = FastAPI(title="carryme", version=APP_VERSION, lifespan=lifespan)

--- a/apps/api/src/carryme_api/app.py
+++ b/apps/api/src/carryme_api/app.py
@@ -825,22 +825,35 @@ async def _prewarm_execution_journal_with_retries(settings: ApiSettings) -> None
     max_attempts = settings.startup_prewarm_max_attempts
     for attempt in range(1, max_attempts + 1):
         try:
-            _execution_journal_store_for_path(settings.database_path).initialize()
+            await asyncio.wait_for(
+                asyncio.to_thread(
+                    _execution_journal_store_for_path(settings.database_path).initialize
+                ),
+                timeout=settings.startup_prewarm_attempt_timeout_seconds,
+            )
             return
-        except Exception:
+        except Exception as exc:
             if attempt >= max_attempts:
-                logger.exception(
-                    "API startup execution journal prewarm failed after %d attempts",
+                logger.error(
+                    "API startup execution journal prewarm failed after %d attempts "
+                    "for database=%s error_type=%s",
                     max_attempts,
+                    settings.database_target,
+                    type(exc).__name__,
                 )
-                raise
+                raise RuntimeError(
+                    "API startup execution journal prewarm failed after "
+                    f"{max_attempts} attempts for database={settings.database_target} "
+                    f"error_type={type(exc).__name__}"
+                ) from None
             logger.warning(
                 "API startup execution journal prewarm failed on attempt %d/%d; "
-                "retrying in %.1fs",
+                "retrying in %.1fs for database=%s error_type=%s",
                 attempt,
                 max_attempts,
                 settings.startup_prewarm_retry_delay_seconds,
-                exc_info=True,
+                settings.database_target,
+                type(exc).__name__,
             )
             if settings.startup_prewarm_retry_delay_seconds > 0:
                 await asyncio.sleep(settings.startup_prewarm_retry_delay_seconds)

--- a/apps/api/src/carryme_api/config.py
+++ b/apps/api/src/carryme_api/config.py
@@ -41,6 +41,8 @@ class ApiSettings(BaseSettings):
     hyperliquid_vault_address: str | None = None
     hyperliquid_api_wallet_private_key: str | None = None
     launch_ready_canary_max_snapshot_age_seconds: int = Field(default=300, gt=0)
+    startup_prewarm_max_attempts: int = Field(default=3, ge=1)
+    startup_prewarm_retry_delay_seconds: float = Field(default=2.0, ge=0)
     stable_launch_ready_min_edge_retention_ratio: float = Field(
         default=0.7,
         ge=0,

--- a/apps/api/src/carryme_api/config.py
+++ b/apps/api/src/carryme_api/config.py
@@ -42,6 +42,7 @@ class ApiSettings(BaseSettings):
     hyperliquid_api_wallet_private_key: str | None = None
     launch_ready_canary_max_snapshot_age_seconds: int = Field(default=300, gt=0)
     startup_prewarm_max_attempts: int = Field(default=3, ge=1)
+    startup_prewarm_attempt_timeout_seconds: float = Field(default=5.0, gt=0)
     startup_prewarm_retry_delay_seconds: float = Field(default=2.0, ge=0)
     stable_launch_ready_min_edge_retention_ratio: float = Field(
         default=0.7,

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,4 +1,5 @@
 import asyncio
+import logging
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any, cast
@@ -378,6 +379,49 @@ def test_app_startup_retries_execution_store_prewarm_transient_failure(
     assert attempts == [1, 2, 3]
 
 
+def test_app_startup_retries_execution_store_prewarm_timeout(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    seen_timeouts: list[float | None] = []
+
+    async def override_settings() -> ApiSettings:
+        return ApiSettings(
+            database_path=str(tmp_path / "timeout.sqlite3"),
+            startup_prewarm_max_attempts=2,
+            startup_prewarm_attempt_timeout_seconds=1.25,
+            startup_prewarm_retry_delay_seconds=0,
+        )
+
+    class HealthyExecutionStore:
+        def initialize(self) -> None:
+            return None
+
+    real_wait_for = app_module.asyncio.wait_for
+
+    async def timeout_once(awaitable: Any, timeout: float | None = None) -> Any:
+        seen_timeouts.append(timeout)
+        if len(seen_timeouts) == 1:
+            awaitable.close()
+            raise TimeoutError("prewarm attempt timed out")
+        return await real_wait_for(awaitable, timeout=timeout)
+
+    monkeypatch.setattr(
+        app_module,
+        "_execution_journal_store_for_path",
+        lambda database_path: HealthyExecutionStore(),
+    )
+    monkeypatch.setattr(app_module.asyncio, "wait_for", timeout_once)
+    app.dependency_overrides[get_api_settings] = override_settings
+    try:
+        with TestClient(app):
+            pass
+    finally:
+        app.dependency_overrides.clear()
+
+    assert seen_timeouts == [1.25, 1.25]
+
+
 def test_app_startup_fails_closed_when_execution_store_prewarm_fails(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -386,6 +430,7 @@ def test_app_startup_fails_closed_when_execution_store_prewarm_fails(
         return ApiSettings(
             database_path=str(tmp_path / "blocked.sqlite3"),
             startup_prewarm_max_attempts=2,
+            startup_prewarm_attempt_timeout_seconds=1,
             startup_prewarm_retry_delay_seconds=0,
         )
 
@@ -404,12 +449,55 @@ def test_app_startup_fails_closed_when_execution_store_prewarm_fails(
     )
     app.dependency_overrides[get_api_settings] = override_settings
     try:
-        with pytest.raises(RuntimeError, match="prewarm failed"), TestClient(app):
+        with pytest.raises(
+            RuntimeError,
+            match="API startup execution journal prewarm failed after 2 attempts",
+        ), TestClient(app):
             pass
     finally:
         app.dependency_overrides.clear()
 
     assert attempts == 2
+
+
+def test_app_startup_prewarm_retry_logs_redacted_database_target(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    async def override_settings() -> ApiSettings:
+        return ApiSettings(
+            database_path=(
+                "postgresql+psycopg://carryme:super-secret"
+                "@db.internal.example:5432/carryme"
+            ),
+            startup_prewarm_max_attempts=1,
+            startup_prewarm_attempt_timeout_seconds=1,
+            startup_prewarm_retry_delay_seconds=0,
+        )
+
+    class FailingExecutionStore:
+        def initialize(self) -> None:
+            raise RuntimeError("raw dsn contains super-secret")
+
+    monkeypatch.setattr(
+        app_module,
+        "_execution_journal_store_for_path",
+        lambda database_path: FailingExecutionStore(),
+    )
+    app.dependency_overrides[get_api_settings] = override_settings
+    caplog.set_level(logging.WARNING, logger=app_module.logger.name)
+    try:
+        with pytest.raises(
+            RuntimeError,
+            match="API startup execution journal prewarm failed after 1 attempts",
+        ), TestClient(app):
+            pass
+    finally:
+        app.dependency_overrides.clear()
+
+    assert "super-secret" not in caplog.text
+    assert "raw dsn" not in caplog.text
+    assert "error_type=RuntimeError" in caplog.text
 
 
 def test_operator_auth_does_not_gate_get_requests(tmp_path: Path) -> None:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -344,15 +344,57 @@ def test_app_startup_skips_prewarm_for_equivalent_default_development_database(
     assert seen == {}
 
 
+def test_app_startup_retries_execution_store_prewarm_transient_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    attempts: list[int] = []
+
+    async def override_settings() -> ApiSettings:
+        return ApiSettings(
+            database_path=str(tmp_path / "recovering.sqlite3"),
+            startup_prewarm_max_attempts=3,
+            startup_prewarm_retry_delay_seconds=0,
+        )
+
+    class TransientExecutionStore:
+        def initialize(self) -> None:
+            attempts.append(len(attempts) + 1)
+            if len(attempts) < 3:
+                raise RuntimeError("database system is in recovery mode")
+
+    monkeypatch.setattr(
+        app_module,
+        "_execution_journal_store_for_path",
+        lambda database_path: TransientExecutionStore(),
+    )
+    app.dependency_overrides[get_api_settings] = override_settings
+    try:
+        with TestClient(app):
+            pass
+    finally:
+        app.dependency_overrides.clear()
+
+    assert attempts == [1, 2, 3]
+
+
 def test_app_startup_fails_closed_when_execution_store_prewarm_fails(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     async def override_settings() -> ApiSettings:
-        return ApiSettings(database_path=str(tmp_path / "blocked.sqlite3"))
+        return ApiSettings(
+            database_path=str(tmp_path / "blocked.sqlite3"),
+            startup_prewarm_max_attempts=2,
+            startup_prewarm_retry_delay_seconds=0,
+        )
+
+    attempts = 0
 
     class FailingExecutionStore:
         def initialize(self) -> None:
+            nonlocal attempts
+            attempts += 1
             raise RuntimeError("prewarm failed")
 
     monkeypatch.setattr(
@@ -366,6 +408,8 @@ def test_app_startup_fails_closed_when_execution_store_prewarm_fails(
             pass
     finally:
         app.dependency_overrides.clear()
+
+    assert attempts == 2
 
 
 def test_operator_auth_does_not_gate_get_requests(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- retry API execution-journal prewarm during startup so transient Postgres recovery does not fail the whole Render deploy
- keep fail-closed behavior after the configured retry budget
- add startup retry coverage without real sleeps

## Validation
- uv run ruff check .
- uv run mypy src apps packages tests
- uv run pytest -q tests/test_api.py -k 'startup'
- uv run pytest -q

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added configurable retry mechanism for startup initialization with adjustable maximum attempts and delay between retries.

* **Improvements**
  * Enhanced startup resilience through automatic retry logic for transient failures during initialization.

* **Tests**
  * Added test coverage for retry behavior and transient failure recovery during startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->