### PR TITLE
fix: retry stable launch quality reads

### DIFF
--- a/apps/worker/src/carryme_worker/config.py
+++ b/apps/worker/src/carryme_worker/config.py
@@ -93,6 +93,11 @@ class WorkerSettings(BaseSettings):
         default=None,
         ge=0,
     )
+    stable_canary_launch_execution_quality_max_attempts: int = Field(default=2, ge=1)
+    stable_canary_launch_execution_quality_retry_delay_seconds: float = Field(
+        default=0.25,
+        ge=0,
+    )
     stable_canary_launch_min_daily_volume: float | None = Field(
         default=None,
         ge=0,

--- a/apps/worker/src/carryme_worker/poller.py
+++ b/apps/worker/src/carryme_worker/poller.py
@@ -964,6 +964,50 @@ def _stable_launch_needs_current_execution_quality(settings: WorkerSettings) -> 
     )
 
 
+async def _build_current_execution_quality_index(
+    *,
+    settings: WorkerSettings,
+    execution_quality_service: ExecutionQualityService,
+    logger: logging.Logger | None = None,
+) -> tuple[dict[tuple[str, str, str], ExecutionQualitySummary], str | None]:
+    """Build current execution quality without launching on transient DB uncertainty."""
+
+    loop_logger = logger or logging.getLogger("carryme.worker")
+    last_error: Exception | None = None
+    max_attempts = settings.stable_canary_launch_execution_quality_max_attempts
+    retry_delay_seconds = settings.stable_canary_launch_execution_quality_retry_delay_seconds
+
+    for attempt in range(1, max_attempts + 1):
+        try:
+            return await asyncio.to_thread(execution_quality_service.build_index), None
+        except Exception as exc:
+            last_error = exc
+            if attempt >= max_attempts:
+                break
+            loop_logger.warning(
+                "stable launch current execution quality read failed on attempt %d/%d; "
+                "retrying in %.2fs",
+                attempt,
+                max_attempts,
+                retry_delay_seconds,
+                exc_info=True,
+            )
+            if retry_delay_seconds > 0:
+                await asyncio.sleep(retry_delay_seconds)
+
+    assert last_error is not None
+    loop_logger.warning(
+        "stable launch current execution quality read failed after %d attempts; "
+        "skipping launch cycle",
+        max_attempts,
+        exc_info=(type(last_error), last_error, last_error.__traceback__),
+    )
+    return {}, (
+        "Stable launch current execution quality unavailable after "
+        f"{max_attempts} attempts: {type(last_error).__name__}"
+    )
+
+
 def _with_current_execution_quality(
     *,
     candidate: FundingUniverseCanaryCandidate,
@@ -3571,9 +3615,19 @@ async def launch_latest_stable_canary_once(
             journal_store=execution_store,
             observation_store=observation_store,
         )
-        execution_quality_index = await asyncio.to_thread(
-            execution_quality_service.build_index
+        (
+            execution_quality_index,
+            execution_quality_unavailable_reason,
+        ) = await _build_current_execution_quality_index(
+            settings=settings,
+            execution_quality_service=execution_quality_service,
         )
+        if execution_quality_unavailable_reason is not None:
+            return StableCanaryLaunchSummary(
+                status="skipped",
+                database_path=settings.database_target,
+                detail=execution_quality_unavailable_reason,
+            )
     balance_service = BalanceAccountingService(
         store=BalanceSnapshotStore(runtime_settings.database_path)
     )

--- a/apps/worker/src/carryme_worker/poller.py
+++ b/apps/worker/src/carryme_worker/poller.py
@@ -150,6 +150,7 @@ from carryme_storage import (
     load_watchlist,
 )
 from fastapi import HTTPException
+from sqlalchemy.exc import DBAPIError
 
 from carryme_worker.config import (
     STABLE_CANARY_LAUNCH_BASE_SLIPPAGE_TOLERANCE_BPS,
@@ -980,27 +981,31 @@ async def _build_current_execution_quality_index(
     for attempt in range(1, max_attempts + 1):
         try:
             return await asyncio.to_thread(execution_quality_service.build_index), None
-        except Exception as exc:
+        except asyncio.CancelledError:
+            raise
+        except (DBAPIError, sqlite3.Error, TimeoutError, ConnectionError) as exc:
             last_error = exc
             if attempt >= max_attempts:
                 break
             loop_logger.warning(
                 "stable launch current execution quality read failed on attempt %d/%d; "
-                "retrying in %.2fs",
+                "retrying in %.2fs error_type=%s",
                 attempt,
                 max_attempts,
                 retry_delay_seconds,
-                exc_info=True,
+                type(exc).__name__,
             )
             if retry_delay_seconds > 0:
                 await asyncio.sleep(retry_delay_seconds)
 
-    assert last_error is not None
-    loop_logger.warning(
+    if last_error is None:
+        return {}, "Stable launch current execution quality unavailable: unknown error"
+
+    loop_logger.error(
         "stable launch current execution quality read failed after %d attempts; "
-        "skipping launch cycle",
+        "skipping launch cycle error_type=%s",
         max_attempts,
-        exc_info=(type(last_error), last_error, last_error.__traceback__),
+        type(last_error).__name__,
     )
     return {}, (
         "Stable launch current execution quality unavailable after "

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -8099,7 +8099,7 @@ def test_stable_launch_current_execution_quality_retries_transient_read_failure(
         def build_index(self) -> dict[tuple[str, str, str], ExecutionQualitySummary]:
             self.attempts += 1
             if self.attempts == 1:
-                raise RuntimeError("transient db eof")
+                raise sqlite3.OperationalError("transient db eof")
             return {("ARB-USD-PERP", "extended", "paradex"): quality}
 
     service = TransientQualityService()
@@ -8128,7 +8128,7 @@ def test_launch_latest_stable_canary_once_skips_when_current_execution_quality_u
     )
 
     async def fail_to_thread(func: Any, *args: Any, **kwargs: Any) -> Any:
-        raise RuntimeError("transient db eof")
+        raise sqlite3.OperationalError("transient db eof")
 
     with pytest.MonkeyPatch.context() as monkeypatch:
         monkeypatch.setattr("carryme_worker.poller.asyncio.to_thread", fail_to_thread)
@@ -8142,8 +8142,59 @@ def test_launch_latest_stable_canary_once_skips_when_current_execution_quality_u
 
     assert summary.status == "skipped"
     assert summary.detail == (
-        "Stable launch current execution quality unavailable after 2 attempts: RuntimeError"
+        "Stable launch current execution quality unavailable after 2 attempts: OperationalError"
     )
+
+
+def test_stable_launch_current_execution_quality_propagates_unexpected_errors(
+    tmp_path: Path,
+) -> None:
+    settings = WorkerSettings(
+        database_path=str(tmp_path / "history.sqlite3"),
+        stable_canary_launch_execution_quality_max_attempts=2,
+        stable_canary_launch_execution_quality_retry_delay_seconds=0,
+    )
+
+    class BuggyQualityService:
+        def build_index(self) -> dict[tuple[str, str, str], ExecutionQualitySummary]:
+            raise ValueError("schema regression")
+
+    with pytest.raises(ValueError, match="schema regression"):
+        asyncio.run(
+            _build_current_execution_quality_index(
+                settings=settings,
+                execution_quality_service=cast(Any, BuggyQualityService()),
+                logger=logging.getLogger("test"),
+            )
+        )
+
+
+def test_stable_launch_current_execution_quality_propagates_cancellation(
+    tmp_path: Path,
+) -> None:
+    settings = WorkerSettings(
+        database_path=str(tmp_path / "history.sqlite3"),
+        stable_canary_launch_execution_quality_max_attempts=2,
+        stable_canary_launch_execution_quality_retry_delay_seconds=0,
+    )
+
+    async def cancel_to_thread(func: Any, *args: Any, **kwargs: Any) -> Any:
+        raise asyncio.CancelledError
+
+    class UnusedQualityService:
+        def build_index(self) -> dict[tuple[str, str, str], ExecutionQualitySummary]:
+            raise AssertionError("cancelled to_thread should not call build_index")
+
+    with pytest.MonkeyPatch.context() as monkeypatch:
+        monkeypatch.setattr("carryme_worker.poller.asyncio.to_thread", cancel_to_thread)
+        with pytest.raises(asyncio.CancelledError):
+            asyncio.run(
+                _build_current_execution_quality_index(
+                    settings=settings,
+                    execution_quality_service=cast(Any, UnusedQualityService()),
+                    logger=logging.getLogger("test"),
+                )
+            )
 
 
 def test_launch_latest_stable_canary_once_uses_latest_execution_quality_for_maturity(

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -126,6 +126,7 @@ from carryme_worker.poller import (
     UniverseScanLoopSummary,
     UniverseScanSummary,
     _build_api_settings_from_worker_settings,
+    _build_current_execution_quality_index,
     _build_latest_launch_ready_stability,
     _build_open_hedge_auto_close_reason,
     _build_open_hedge_profit_protection_reason,
@@ -382,6 +383,8 @@ def test_worker_defaults(monkeypatch: pytest.MonkeyPatch) -> None:
     assert settings.stable_canary_launch_min_slippage_adjusted_one_day_round_trip_pnl == 0.0
     assert settings.stable_canary_launch_require_executable_round_trip_cost is True
     assert settings.stable_canary_launch_block_adverse_latest_outcome is False
+    assert settings.stable_canary_launch_execution_quality_max_attempts == 2
+    assert settings.stable_canary_launch_execution_quality_retry_delay_seconds == 0.25
     assert settings.execution_auto_pair_close_enabled is False
     assert settings.execution_auto_pair_close_shadow_mode is False
     assert settings.execution_auto_pair_close_max_snapshot_age_seconds == 300
@@ -8070,6 +8073,77 @@ def test_stable_launch_current_execution_quality_lookup_normalizes_route_key() -
     )
 
     assert updated.opportunity.execution_quality == quality
+
+
+def test_stable_launch_current_execution_quality_retries_transient_read_failure(
+    tmp_path: Path,
+) -> None:
+    settings = WorkerSettings(
+        database_path=str(tmp_path / "history.sqlite3"),
+        stable_canary_launch_execution_quality_max_attempts=2,
+        stable_canary_launch_execution_quality_retry_delay_seconds=0,
+    )
+    quality = ExecutionQualitySummary(
+        canonical_symbol="ARB-USD-PERP",
+        short_venue="extended",
+        long_venue="paradex",
+        sample_size=2,
+        weighted_score=0.72,
+        latest_outcome="closed",
+        closed_count=2,
+    )
+
+    class TransientQualityService:
+        attempts = 0
+
+        def build_index(self) -> dict[tuple[str, str, str], ExecutionQualitySummary]:
+            self.attempts += 1
+            if self.attempts == 1:
+                raise RuntimeError("transient db eof")
+            return {("ARB-USD-PERP", "extended", "paradex"): quality}
+
+    service = TransientQualityService()
+
+    index, reason = asyncio.run(
+        _build_current_execution_quality_index(
+            settings=settings,
+            execution_quality_service=cast(Any, service),
+            logger=logging.getLogger("test"),
+        )
+    )
+
+    assert reason is None
+    assert service.attempts == 2
+    assert index == {("ARB-USD-PERP", "extended", "paradex"): quality}
+
+
+def test_launch_latest_stable_canary_once_skips_when_current_execution_quality_unavailable(
+    tmp_path: Path,
+) -> None:
+    settings = WorkerSettings(
+        database_path=str(tmp_path / "history.sqlite3"),
+        stable_canary_launch_min_execution_quality_score=0.7,
+        stable_canary_launch_execution_quality_max_attempts=2,
+        stable_canary_launch_execution_quality_retry_delay_seconds=0,
+    )
+
+    async def fail_to_thread(func: Any, *args: Any, **kwargs: Any) -> Any:
+        raise RuntimeError("transient db eof")
+
+    with pytest.MonkeyPatch.context() as monkeypatch:
+        monkeypatch.setattr("carryme_worker.poller.asyncio.to_thread", fail_to_thread)
+        summary = asyncio.run(
+            launch_latest_stable_canary_once(
+                settings,
+                api_settings=ApiSettings(database_path=settings.database_path),
+                now=datetime(2026, 4, 4, 10, 2, tzinfo=UTC),
+            )
+        )
+
+    assert summary.status == "skipped"
+    assert summary.detail == (
+        "Stable launch current execution quality unavailable after 2 attempts: RuntimeError"
+    )
 
 
 def test_launch_latest_stable_canary_once_uses_latest_execution_quality_for_maturity(


### PR DESCRIPTION
## Summary
- retry transient stable-launch execution-quality DB reads before giving up
- fail closed by skipping the launch cycle when current execution quality remains unavailable
- add deterministic coverage for retry success and exhausted retry behavior

## Validation
- uv run ruff check .
- uv run mypy src apps packages tests
- uv run pytest -q tests/test_worker.py -k 'current_execution_quality or worker_defaults'
- uv run pytest -q

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added new configuration options for execution-quality operation retry behavior

* **Bug Fixes**
  * Improved resilience against transient database and connection failures with automatic retry logic
  * Stable launches now gracefully skip with clear status when execution-quality data is unavailable

* **Tests**
  * Added comprehensive test coverage for execution-quality retrieval and retry behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->