### PR TITLE
fix: retry API migrations on startup

### DIFF
--- a/apps/api/pyproject.toml
+++ b/apps/api/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
 
 [project.scripts]
 carryme-api = "carryme_api.main:main"
+carryme-api-migrate-and-start = "carryme_api.main:migrate_and_start"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/carryme_api"]

--- a/apps/api/pyproject.toml
+++ b/apps/api/pyproject.toml
@@ -9,6 +9,7 @@ description = "FastAPI application for the carryme operator/control plane."
 readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
+  "alembic>=1.16,<2",
   "carryme-models",
   "carryme-normalizers",
   "carryme-runtime",

--- a/apps/api/src/carryme_api/main.py
+++ b/apps/api/src/carryme_api/main.py
@@ -1,11 +1,21 @@
 """CLI entrypoint for the carryme API service."""
 
+import logging
 import os
+import subprocess
+import time
+from collections.abc import Callable, Sequence
 
 import uvicorn
 
 DEFAULT_HOST = "0.0.0.0"
 DEFAULT_PORT = 8000
+DEFAULT_MIGRATION_MAX_ATTEMPTS = 5
+DEFAULT_MIGRATION_RETRY_DELAY_SECONDS = 2.0
+MIGRATION_MAX_ATTEMPTS_ENV = "CARRYME_API_MIGRATION_MAX_ATTEMPTS"
+MIGRATION_RETRY_DELAY_SECONDS_ENV = "CARRYME_API_MIGRATION_RETRY_DELAY_SECONDS"
+ALEMBIC_UPGRADE_COMMAND = ("alembic", "upgrade", "head")
+logger = logging.getLogger(__name__)
 
 
 def get_server_host() -> str:
@@ -23,6 +33,91 @@ def get_server_port() -> int:
     return int(raw_port)
 
 
+def _read_positive_int_env(name: str, default: int) -> int:
+    raw_value = os.getenv(name)
+    if raw_value is None:
+        return default
+    value = int(raw_value)
+    if value < 1:
+        raise ValueError(f"{name} must be >= 1")
+    return value
+
+
+def _read_non_negative_float_env(name: str, default: float) -> float:
+    raw_value = os.getenv(name)
+    if raw_value is None:
+        return default
+    value = float(raw_value)
+    if value < 0:
+        raise ValueError(f"{name} must be >= 0")
+    return value
+
+
+def get_migration_max_attempts() -> int:
+    """Return how many Alembic startup attempts Render should tolerate."""
+
+    return _read_positive_int_env(
+        MIGRATION_MAX_ATTEMPTS_ENV,
+        DEFAULT_MIGRATION_MAX_ATTEMPTS,
+    )
+
+
+def get_migration_retry_delay_seconds() -> float:
+    """Return the delay between failed Alembic startup attempts."""
+
+    return _read_non_negative_float_env(
+        MIGRATION_RETRY_DELAY_SECONDS_ENV,
+        DEFAULT_MIGRATION_RETRY_DELAY_SECONDS,
+    )
+
+
+def run_alembic_upgrade_with_retries(
+    *,
+    run: Callable[[Sequence[str]], subprocess.CompletedProcess[object]] = subprocess.run,
+    sleep: Callable[[float], None] = time.sleep,
+    max_attempts: int | None = None,
+    retry_delay_seconds: float | None = None,
+) -> None:
+    """Run Alembic with bounded retries for transient Render Postgres recovery."""
+
+    attempt_limit = max_attempts if max_attempts is not None else get_migration_max_attempts()
+    delay_seconds = (
+        retry_delay_seconds
+        if retry_delay_seconds is not None
+        else get_migration_retry_delay_seconds()
+    )
+    if attempt_limit < 1:
+        raise ValueError("max_attempts must be >= 1")
+    if delay_seconds < 0:
+        raise ValueError("retry_delay_seconds must be >= 0")
+
+    last_returncode = 1
+    for attempt in range(1, attempt_limit + 1):
+        completed = run(ALEMBIC_UPGRADE_COMMAND)
+        if completed.returncode == 0:
+            return
+        last_returncode = completed.returncode
+        if attempt >= attempt_limit:
+            break
+        logger.warning(
+            "Alembic upgrade failed during API startup attempt %d/%d; "
+            "retrying in %.1fs returncode=%d",
+            attempt,
+            attempt_limit,
+            delay_seconds,
+            completed.returncode,
+        )
+        if delay_seconds > 0:
+            sleep(delay_seconds)
+
+    logger.error(
+        "Alembic upgrade failed during API startup after %d attempts returncode=%d",
+        attempt_limit,
+        last_returncode,
+    )
+    raise SystemExit(last_returncode)
+
+
 def main() -> None:
     """Run the FastAPI service."""
 
@@ -32,6 +127,13 @@ def main() -> None:
         port=get_server_port(),
         reload=False,
     )
+
+
+def migrate_and_start() -> None:
+    """Run startup migrations with retry, then serve the API."""
+
+    run_alembic_upgrade_with_retries()
+    main()
 
 
 if __name__ == "__main__":

--- a/apps/api/src/carryme_api/main.py
+++ b/apps/api/src/carryme_api/main.py
@@ -3,6 +3,7 @@
 import logging
 import os
 import subprocess
+import sys
 import time
 from collections.abc import Callable, Sequence
 
@@ -14,7 +15,7 @@ DEFAULT_MIGRATION_MAX_ATTEMPTS = 5
 DEFAULT_MIGRATION_RETRY_DELAY_SECONDS = 2.0
 MIGRATION_MAX_ATTEMPTS_ENV = "CARRYME_API_MIGRATION_MAX_ATTEMPTS"
 MIGRATION_RETRY_DELAY_SECONDS_ENV = "CARRYME_API_MIGRATION_RETRY_DELAY_SECONDS"
-ALEMBIC_UPGRADE_COMMAND = ("alembic", "upgrade", "head")
+ALEMBIC_UPGRADE_COMMAND = (sys.executable, "-m", "alembic", "upgrade", "head")
 logger = logging.getLogger(__name__)
 
 

--- a/render.yaml
+++ b/render.yaml
@@ -10,7 +10,7 @@ services:
     rootDir: .
     plan: starter
     buildCommand: pip install uv && uv sync --frozen --all-packages
-    startCommand: sh -c 'uv run alembic upgrade head && uv run carryme-api'
+    startCommand: uv run carryme-api-migrate-and-start
     healthCheckPath: /ready
     envVars:
       - key: DATABASE_URL

--- a/src/carryme_dev/render.py
+++ b/src/carryme_dev/render.py
@@ -29,7 +29,7 @@ REQUIRED_RENDER_DATABASES = ("carryme-postgres",)
 REQUIRED_RENDER_SERVICE_SPECS: dict[str, dict[str, str]] = {
     "carryme-api": {
         "type": "web",
-        "start_command": "uv run carryme-api",
+        "start_command": "uv run carryme-api-migrate-and-start",
     },
     "carryme-universe-scan": {
         "type": "worker",

--- a/tests/test_api_main.py
+++ b/tests/test_api_main.py
@@ -1,0 +1,73 @@
+import subprocess
+from collections.abc import Sequence
+
+import pytest
+from carryme_api import main as main_module
+
+
+def test_run_alembic_upgrade_with_retries_succeeds_after_transient_failure() -> None:
+    attempts: list[tuple[str, ...]] = []
+    sleeps: list[float] = []
+
+    def fake_run(command: Sequence[str]) -> subprocess.CompletedProcess[object]:
+        attempts.append(tuple(command))
+        return subprocess.CompletedProcess(
+            command,
+            returncode=0 if len(attempts) == 3 else 1,
+        )
+
+    main_module.run_alembic_upgrade_with_retries(
+        run=fake_run,
+        sleep=sleeps.append,
+        max_attempts=3,
+        retry_delay_seconds=0.5,
+    )
+
+    assert attempts == [main_module.ALEMBIC_UPGRADE_COMMAND] * 3
+    assert sleeps == [0.5, 0.5]
+
+
+def test_run_alembic_upgrade_with_retries_exits_after_retry_budget() -> None:
+    attempts: list[tuple[str, ...]] = []
+
+    def fake_run(command: Sequence[str]) -> subprocess.CompletedProcess[object]:
+        attempts.append(tuple(command))
+        return subprocess.CompletedProcess(command, returncode=7)
+
+    with pytest.raises(SystemExit) as exc_info:
+        main_module.run_alembic_upgrade_with_retries(
+            run=fake_run,
+            sleep=lambda delay: None,
+            max_attempts=2,
+            retry_delay_seconds=0,
+        )
+
+    assert exc_info.value.code == 7
+    assert attempts == [main_module.ALEMBIC_UPGRADE_COMMAND] * 2
+
+
+def test_migrate_and_start_runs_migrations_before_server(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[str] = []
+
+    monkeypatch.setattr(
+        main_module,
+        "run_alembic_upgrade_with_retries",
+        lambda: calls.append("migrate"),
+    )
+    monkeypatch.setattr(main_module, "main", lambda: calls.append("main"))
+
+    main_module.migrate_and_start()
+
+    assert calls == ["migrate", "main"]
+
+
+def test_migration_retry_settings_read_environment(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(main_module.MIGRATION_MAX_ATTEMPTS_ENV, "9")
+    monkeypatch.setenv(main_module.MIGRATION_RETRY_DELAY_SECONDS_ENV, "1.75")
+
+    assert main_module.get_migration_max_attempts() == 9
+    assert main_module.get_migration_retry_delay_seconds() == 1.75

--- a/tests/test_render_validate.py
+++ b/tests/test_render_validate.py
@@ -46,7 +46,7 @@ databases:
 services:
   - type: web
     name: carryme-api
-    startCommand: uv run carryme-api
+    startCommand: uv run carryme-api-migrate-and-start
   - type: worker
     name: carryme-approved-canary-scan
     startCommand: uv run carryme-worker --scan-approved-canary-supervise
@@ -75,7 +75,7 @@ databases:
 services:
   - type: web
     name: carryme-api
-    startCommand: sh -c 'uv run alembic upgrade head && uv run carryme-api'
+    startCommand: uv run carryme-api-migrate-and-start
   - type: worker
     name: carryme-universe-scan
     startCommand: uv run carryme-worker --scan-universe-supervise
@@ -118,7 +118,7 @@ databases:
 services:
   - type: web
     name: carryme-api
-    startCommand: sh -c 'uv run alembic upgrade head && uv run carryme-api'
+    startCommand: uv run carryme-api-migrate-and-start
   - type: worker
     name: carryme-universe-scan
     startCommand: uv run carryme-worker --scan-universe-supervise

--- a/uv.lock
+++ b/uv.lock
@@ -111,6 +111,7 @@ name = "carryme-api"
 version = "0.1.0"
 source = { editable = "apps/api" }
 dependencies = [
+    { name = "alembic" },
     { name = "carryme-models" },
     { name = "carryme-normalizers" },
     { name = "carryme-runtime" },
@@ -123,6 +124,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
+    { name = "alembic", specifier = ">=1.16,<2" },
     { name = "carryme-models", editable = "packages/models" },
     { name = "carryme-normalizers", editable = "packages/normalizers" },
     { name = "carryme-runtime", editable = "packages/runtime" },


### PR DESCRIPTION
## Summary
- replace Render API start command with a tested migration-and-start entrypoint
- retry Alembic startup migrations so transient Render Postgres recovery does not fail deploys before the API process starts
- keep the API server start after migrations succeed only
- update Render blueprint validation for the new command

## Validation
- uv run ruff check .
- uv run mypy src apps packages tests
- uv run pytest -q tests/test_api_main.py tests/test_render_validate.py
- uv run pytest -q

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added automatic retry logic for database migrations with configurable maximum attempts and retry delay settings.

* **Chores**
  * Updated API startup sequence to use a dedicated migration initialization command for improved deployment consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->